### PR TITLE
DEV-125: 同期完了通知を削除し buildNotificationMessage を除去

### DIFF
--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -85,11 +85,11 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
-		it("notifies 'Everything up to date' when both sides are empty", async () => {
+		it("does not notify on successful sync", async () => {
 			const deps = createDeps();
 			const orchestrator = new SyncOrchestrator(deps);
 			await orchestrator.runSync();
-			expect(deps.notify).toHaveBeenCalledWith("Everything up to date");
+			expect(deps.notify).not.toHaveBeenCalled();
 			expect(deps.onStatusChange).toHaveBeenCalledWith("idle");
 			await orchestrator.close();
 		});

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -24,24 +24,6 @@ interface SyncCycleResult {
 	conflicts: number;
 }
 
-function buildNotificationMessage(cycle: SyncCycleResult): string {
-	const counts = { pushed: 0, pulled: 0, matched: 0, deleted: 0 };
-	for (const a of cycle.result.succeeded) {
-		if (a.action.action === "push") counts.pushed++;
-		else if (a.action.action === "pull") counts.pulled++;
-		else if (a.action.action === "match") counts.matched++;
-		else if (a.action.action === "delete_local" || a.action.action === "delete_remote") counts.deleted++;
-	}
-	const parts: string[] = [];
-	if (counts.pushed > 0) parts.push(`${counts.pushed} pushed`);
-	if (counts.pulled > 0) parts.push(`${counts.pulled} pulled`);
-	if (counts.matched > 0) parts.push(`${counts.matched} matched`);
-	if (counts.deleted > 0) parts.push(`${counts.deleted} deleted`);
-	if (cycle.conflicts > 0) parts.push(`${cycle.conflicts} conflicts`);
-	if (cycle.failed > 0) parts.push(`${cycle.failed} errors`);
-	return parts.length === 0 ? "Everything up to date" : `Sync: ${parts.join(", ")}`;
-}
-
 export interface SyncOrchestratorDeps {
 	getSettings: () => AirSyncSettings;
 	saveSettings: () => Promise<void>;
@@ -136,7 +118,6 @@ export class SyncOrchestrator {
 					this.deps.logger?.info("Sync completed", { succeeded, conflicts, failed });
 				}
 
-				this.deps.notify(buildNotificationMessage(result));
 				await this.deps.logger?.flush();
 
 				const allPaths = this.deps.localTracker.getDirtyPaths();


### PR DESCRIPTION
## Summary
- ステータスバーで既に同期状態が表示されているため、同期完了時のポップアップ通知は削除
- ユーザーへの通知はエラーや再認証リクエストなど本当に必要な場合のみに限定
- デッドコード化する `buildNotificationMessage` 関数を削除
- テストを更新して同期成功時に通知が呼ばれないことを確認

## Changes
- **DEV-126**: orchestrator から同期完了通知と `buildNotificationMessage` 関数を削除、テストを更新

## Related
Resolves DEV-125