### PR TITLE
DEV-127: Suppress sync completion popups unless logging is enabled

### DIFF
--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -85,8 +85,18 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
-		it("notifies 'Everything up to date' when both sides are empty", async () => {
+		it("does not show sync completion notice when logging is disabled", async () => {
 			const deps = createDeps();
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.runSync();
+			expect(deps.notify).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenCalledWith("idle");
+			await orchestrator.close();
+		});
+
+		it("shows sync completion notice when logging is enabled", async () => {
+			const settings = { ...mockSettings(), enableLogging: true };
+			const deps = createDeps({ getSettings: () => settings });
 			const orchestrator = new SyncOrchestrator(deps);
 			await orchestrator.runSync();
 			expect(deps.notify).toHaveBeenCalledWith("Everything up to date");

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -136,7 +136,9 @@ export class SyncOrchestrator {
 					this.deps.logger?.info("Sync completed", { succeeded, conflicts, failed });
 				}
 
-				this.deps.notify(buildNotificationMessage(result));
+				if (this.deps.getSettings().enableLogging) {
+					this.deps.notify(buildNotificationMessage(result));
+				}
 				await this.deps.logger?.flush();
 
 				const allPaths = this.deps.localTracker.getDirtyPaths();


### PR DESCRIPTION
## Summary

- 同期完了の通知をモーダルポップアップで表示しないように変更
- `enableLogging` が有効な場合のみ、同期完了通知を表示
- エラーや認証エラーなどの重要な通知は常に表示
- ユーザーに本当に必要な通知のみ表示する

## Changes

**DEV-128**: `orchestrator.ts` で同期完了通知を `enableLogging` でゲート
- `SyncOrchestrator.runSync()` の 139行目で、`buildNotificationMessage(result)` の呼び出しを `enableLogging` 設定でゲート

**DEV-129**: `orchestrator.test.ts` でテストを更新
- 既存テスト「Everything up to date」を修正（デフォルトではログが無効なため通知されない）
- 新規テスト追加：ログが有効な場合に同期完了通知が表示される
- 新規テスト追加：ログが無効な場合に同期完了通知が表示されない

## Related Issue

[DEV-127](https://linear.app/issue/DEV-127)