### PR TITLE
Slow poll remote even if local is idle; enable by default at 5 minute…

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Vision
 
-Sync should be invisible -- like air. When the user opens Obsidian, changes since the last session are reflected within hundreds of milliseconds. After editing, background sync runs on a 5-second batch interval. Opening a note always shows the latest version. If the network drops or the app crashes, the worst case is a duplicate file; user data is never lost. Conflicts are resolved transparently via auto-merge, and the user is only prompted when edits truly contradict each other.
+Sync should be invisible -- like air. When the user opens Obsidian, changes since the last session are reflected within hundreds of milliseconds. After editing, background sync fires 5 seconds after the last local change. When slow polling is enabled, the plugin also checks for remote changes at a configurable interval even when the user is idle. Opening a note always shows the latest version. If the network drops or the app crashes, the worst case is a duplicate file; user data is never lost. Conflicts are resolved transparently via auto-merge, and the user is only prompted when edits truly contradict each other.
 
 ## Design principles
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Vision
 
-Sync should be invisible -- like air. When the user opens Obsidian, changes since the last session are reflected within hundreds of milliseconds. After editing, background sync fires 5 seconds after the last local change. When slow polling is enabled, the plugin also checks for remote changes at a configurable interval even when the user is idle. Opening a note always shows the latest version. If the network drops or the app crashes, the worst case is a duplicate file; user data is never lost. Conflicts are resolved transparently via auto-merge, and the user is only prompted when edits truly contradict each other.
+Sync should be invisible -- like air. When the user opens Obsidian, changes since the last session are reflected within hundreds of milliseconds. After editing, background sync fires 5 seconds after the last local change. When slow polling is enabled, the plugin also checks for changes at a configurable interval when the user is idle or has been generating local changes slowly, like every 4 seconds, but persistently. Opening a note always shows the latest version. If the network drops or the app crashes, the worst case is a duplicate file; user data is never lost. Conflicts are resolved transparently via auto-merge, and the user is only prompted when edits truly contradict each other.
 
 ## Design principles
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -137,17 +137,29 @@ Failed actions are not committed; they will be re-detected on the next sync cycl
 
 ## Sync triggers
 
-`SyncScheduler` (`scheduler.ts`) registers five event-driven sync triggers on `start()`:
+`SyncScheduler` (`scheduler.ts`) registers event-driven sync triggers on `start()` and runs a 1-second heartbeat to evaluate scheduled syncs.
 
-| Trigger | Event | Behaviour |
-|---------|-------|-----------|
-| Vault change | `create` / `modify` / `delete` / `rename` | Marks path dirty via `localTracker.markDirty()`, then calls `debouncedSync()` (5 s debounce). Consecutive edits reset the timer so sync fires 5 s after the last change. |
-| Visibility | `document.visibilitychange` → `"visible"` | Immediately calls `runSync()` when the app returns to the foreground (e.g. mobile app switch, desktop minimize restore), unless a sync is already running. |
-| Focus | `window.focus` | Immediately calls `runSync()` when the window gains focus (e.g. switching back from another desktop app), unless a sync is already running. |
+### Heartbeat and scheduled syncs
+
+The scheduler maintains two fields that drive when the next sync fires:
+
+- **`nextSyncAt`** (`number | null`) — set by vault change events to `Date.now() + 5000`. The heartbeat fires `runSync()` when `now >= nextSyncAt`, then clears the field. Consecutive edits keep resetting `nextSyncAt`, so sync fires 5 s after the *last* change in a burst.
+- **`lastSyncCompletedAt`** (`number`) — initialized to `0`. Updated by `notifySyncComplete()`, which the orchestrator calls via its `onSyncComplete` callback at the end of every successful sync cycle. When `slowPollIntervalSec > 0`, the heartbeat fires `runSync()` whenever `now >= lastSyncCompletedAt + slowPollIntervalSec * 1000`. Setting `slowPollIntervalSec` to `0` disables polling for remote changes when local is idle.
+
+The heartbeat checks `isSyncing()` and `remoteFs()` before calling `runSync()` in either path.
+
+### Trigger table
+
+| Trigger | Mechanism | Behaviour |
+| ------- | --------- | --------- |
+| Vault change | `create` / `modify` / `delete` / `rename` | Marks path dirty via `localTracker.markDirty()` and sets `nextSyncAt = now + 5 s`. The heartbeat fires the sync once the debounce window elapses. |
+| Slow poll | Heartbeat (`setInterval`, 1 s) | When `slowPollIntervalSec > 0`, fires `runSync()` if the configured interval has elapsed since `lastSyncCompletedAt`. Detects remote changes while the user is idle. Disabled when `slowPollIntervalSec = 0`. Default is 300 s (5 minutes). |
+| Visibility | `document.visibilitychange` → `"visible"` | Immediately calls `runSync()` when the app returns to the foreground, unless a sync is already running. |
+| Focus | `window.focus` | Immediately calls `runSync()` when the window gains focus, unless a sync is already running. |
 | Online | `window.online` | Immediately calls `runSync()` when the network connection is restored. |
 | File open | `workspace.on("file-open")` | Priority pull for the opened file (see below). |
 
-All triggers are event-driven — there is no periodic timer. All triggers except file-open run a full sync cycle through the pipeline. Ignored paths (from `ignorePatterns`) are excluded at the vault-event level — dirty marks and debounce are skipped entirely.
+All triggers except slow poll are event-driven. All triggers except file-open run a full sync cycle through the pipeline. Ignored paths (from `ignorePatterns`) are excluded at the vault-event level — dirty marks and `nextSyncAt` updates are skipped entirely.
 
 ## Active file priority sync
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -153,7 +153,7 @@ The heartbeat checks `isSyncing()` and `remoteFs()` before calling `runSync()` i
 | Trigger | Mechanism | Behaviour |
 | ------- | --------- | --------- |
 | Vault change | `create` / `modify` / `delete` / `rename` | Marks path dirty via `localTracker.markDirty()` and sets `nextSyncAt = now + 5 s`. The heartbeat fires the sync once the debounce window elapses. |
-| Slow poll | Heartbeat (`setInterval`, 1 s) | When `slowPollIntervalSec > 0`, fires `runSync()` if the configured interval has elapsed since `lastSyncCompletedAt`. Detects remote changes while the user is idle. Disabled when `slowPollIntervalSec = 0`. Default is 300 s (5 minutes). |
+| Slow poll | Heartbeat (`setInterval`, 1 s) | When `slowPollIntervalSec > 0`, fires `runSync()` if the configured interval has elapsed since `lastSyncCompletedAt`. Detects remote changes while the user is idle, but also a long string of local changes happening within the debounce window. Disabled when `slowPollIntervalSec = 0`. Default is 300 s (5 minutes). |
 | Visibility | `document.visibilitychange` → `"visible"` | Immediately calls `runSync()` when the app returns to the foreground, unless a sync is already running. |
 | Focus | `window.focus` | Immediately calls `runSync()` when the window gains focus, unless a sync is already running. |
 | Online | `window.online` | Immediately calls `runSync()` when the network connection is restored. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-	"name": "obsidian-smart-sync",
-	"version": "0.1.1",
+	"name": "obsidian-air-sync",
+	"version": "0.1.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "obsidian-smart-sync",
-			"version": "0.1.1",
+			"name": "obsidian-air-sync",
+			"version": "0.1.14",
 			"license": "MIT",
 			"dependencies": {
 				"ignore": "^7.0.5",

--- a/src/fs/backend-manager.test.ts
+++ b/src/fs/backend-manager.test.ts
@@ -26,6 +26,7 @@ function mockSettings(overrides: Partial<AirSyncSettings> = {}): AirSyncSettings
 		conflictStrategy: "auto_merge",
 		enableThreeWayMerge: false,
 		mobileMaxFileSizeMB: 10,
+		slowPollIntervalSec: 0,
 		enableLogging: false,
 		logLevel: "info",
 		backendData: {},

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,7 @@ export default class AirSyncPlugin extends Plugin {
 			localTracker: this.localTracker,
 			logger: this.logger,
 			isBackendConnecting: () => this.backendManager.isConnecting(),
+			onSyncComplete: () => this.scheduler.notifySyncComplete(),
 		});
 
 		this.scheduler = new SyncScheduler({
@@ -103,6 +104,7 @@ export default class AirSyncPlugin extends Plugin {
 			isExcluded: (path) => this.orchestrator.isExcluded(path),
 			registerEvent: (ref) => this.registerEvent(ref),
 			register: (cb) => this.register(cb),
+			getSlowPollIntervalSec: () => this.settings.slowPollIntervalSec,
 		});
 
 		this.settingTab = new AirSyncSettingTab(this.app, this);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,9 @@ export interface AirSyncSettings {
 	/** Maximum file size in MB to sync on mobile */
 	mobileMaxFileSizeMB: number;
 
+	/** Seconds between automatic background sync checks (0 = disabled) */
+	slowPollIntervalSec: number;
+
 	/** Write sync logs to .airsync/logs/{device}/{date}.log */
 	enableLogging: boolean;
 	/** Minimum log level to write */
@@ -33,6 +36,7 @@ export const DEFAULT_SETTINGS: AirSyncSettings = {
 	syncDotPaths: [],
 	enableThreeWayMerge: true,
 	mobileMaxFileSizeMB: 10,
+	slowPollIntervalSec: 300,
 	enableLogging: false,
 	logLevel: "info",
 	backendData: {},

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -15,6 +15,7 @@ function mockSettings() {
 		conflictStrategy: "auto_merge" as const,
 		enableThreeWayMerge: false,
 		mobileMaxFileSizeMB: 10,
+		slowPollIntervalSec: 0,
 		enableLogging: false,
 		logLevel: "info" as const,
 		backendData: {} as Record<string, Record<string, unknown>>,

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -55,6 +55,8 @@ export interface SyncOrchestratorDeps {
 	isMobile: () => boolean;
 	/** Returns true when the backend is in the process of connecting */
 	isBackendConnecting?: () => boolean;
+	/** Called after a full sync cycle completes (success or partial error) */
+	onSyncComplete?: () => void;
 	localTracker: LocalChangeTracker;
 	logger?: Logger;
 }
@@ -153,6 +155,7 @@ export class SyncOrchestrator {
 				this.deps.localTracker.acknowledge(allPaths);
 			} while (this.syncPending);
 		});
+		this.deps.onSyncComplete?.();
 	}
 
 	/**

--- a/src/sync/scheduler.test.ts
+++ b/src/sync/scheduler.test.ts
@@ -142,6 +142,21 @@ describe("SyncScheduler", () => {
 			expect(deps.runSync).toHaveBeenCalledTimes(1);
 		});
 
+		it("does not sync while local changes arrive every 4s; fires only after final debounce window", () => {
+			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
+			handler(makeFile("a.md")); // T=0s, nextSyncAt=5s
+			vi.advanceTimersByTime(4_000); // T=4s — debounce not yet due
+			handler(makeFile("b.md")); // T=4s, nextSyncAt=9s
+			vi.advanceTimersByTime(4_000); // T=8s — debounce not yet due
+			handler(makeFile("c.md")); // T=8s, nextSyncAt=13s
+
+			vi.advanceTimersByTime(4_999); // T=12.999s — still inside window
+			expect(deps.runSync).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(1); // T=13s — debounce fires
+			expect(deps.runSync).toHaveBeenCalledTimes(1);
+		});
+
 		it("does not trigger sync for excluded paths", () => {
 			scheduler.destroy();
 			deps = createDeps({ isExcluded: () => true });
@@ -360,6 +375,37 @@ describe("SyncScheduler", () => {
 			scheduler.notifySyncComplete();
 			vi.advanceTimersByTime(120_000);
 			expect(runSync).not.toHaveBeenCalled();
+		});
+
+		it("fires at poll interval despite a steady stream of local changes every 4s", () => {
+			// runSync mock calls notifySyncComplete so the poll clock resets after each sync.
+			const runSync = vi.fn<() => Promise<void>>();
+			scheduler.destroy();
+			deps = createDeps({
+				getSlowPollIntervalSec: () => 300,
+				orchestrator: { runSync, pullSingle: vi.fn().mockResolvedValue(undefined), isSyncing: () => false },
+			});
+			scheduler = new SyncScheduler(deps);
+			runSync.mockImplementation(() => {
+				scheduler.notifySyncComplete();
+				return Promise.resolve();
+			});
+			scheduler.start();
+
+			scheduler.notifySyncComplete(); // T=0: reset poll clock
+
+			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
+
+			// Simulate a vault change every 4s for 7 minutes (105 steps).
+			// The debounce window (5s) is continuously pushed forward, so it never fires.
+			// The slow poll fires once at T=300s; notifySyncComplete resets lastSyncCompletedAt
+			// to T=300s, so the next poll would be at T=600s which is beyond our 7-min window.
+			for (let i = 0; i < 105; i++) {
+				vi.advanceTimersByTime(4_000);
+				handler(makeFile("note.md"));
+			}
+
+			expect(runSync).toHaveBeenCalledTimes(1);
 		});
 
 		it("debounce-triggered sync takes priority over slow poll in same tick", () => {

--- a/src/sync/scheduler.test.ts
+++ b/src/sync/scheduler.test.ts
@@ -61,6 +61,7 @@ function createDeps(overrides: Partial<SyncSchedulerDeps> = {}) {
 		isExcluded: () => false,
 		registerEvent: vi.fn(),
 		register: vi.fn((cb: () => void) => { cleanups.push(cb); }),
+		getSlowPollIntervalSec: () => 0,
 		vaultHandlers,
 		workspaceHandlers,
 		cleanups,
@@ -123,7 +124,7 @@ describe("SyncScheduler", () => {
 			expect(deps.localTracker.getDirtyPaths().has("excluded/note.md")).toBe(false);
 		});
 
-		it("triggers debounced sync on vault change", () => {
+		it("triggers sync via heartbeat after debounce window", () => {
 			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
 			handler(makeFile("note.md"));
 			vi.advanceTimersByTime(5000);
@@ -153,9 +154,21 @@ describe("SyncScheduler", () => {
 			expect(deps.runSync).not.toHaveBeenCalled();
 		});
 
-		it("skips debounced sync on vault change when remoteFs is null", () => {
+		it("skips sync via heartbeat when remoteFs is null", () => {
 			scheduler.destroy();
 			deps = createDeps({ remoteFs: () => null });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
+			handler(makeFile("note.md"));
+			vi.advanceTimersByTime(5000);
+			expect(deps.runSync).not.toHaveBeenCalled();
+		});
+
+		it("skips sync via heartbeat when already syncing", () => {
+			scheduler.destroy();
+			deps = createDeps({ orchestrator: { runSync: vi.fn().mockResolvedValue(undefined), pullSingle: vi.fn().mockResolvedValue(undefined), isSyncing: () => true } });
 			scheduler = new SyncScheduler(deps);
 			scheduler.start();
 
@@ -273,12 +286,116 @@ describe("SyncScheduler", () => {
 		});
 	});
 
+	describe("slow poll", () => {
+		it("does not poll when slowPollIntervalSec is 0", () => {
+			// interval is 0 (default in createDeps), so slow poll is disabled
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(300_000); // 5 minutes
+			expect(deps.runSync).not.toHaveBeenCalled();
+		});
+
+		it("triggers sync after slow poll interval elapses since last sync", () => {
+			scheduler.destroy();
+			deps = createDeps({ getSlowPollIntervalSec: () => 60 });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(59_000);
+			expect(deps.runSync).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(1_000); // now at 60s
+			expect(deps.runSync).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not fire before interval elapses", () => {
+			scheduler.destroy();
+			deps = createDeps({ getSlowPollIntervalSec: () => 60 });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(59_999);
+			expect(deps.runSync).not.toHaveBeenCalled();
+		});
+
+		it("resets interval when notifySyncComplete is called again", () => {
+			scheduler.destroy();
+			deps = createDeps({ getSlowPollIntervalSec: () => 60 });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(30_000);
+			// A local-change sync finishes partway through the interval
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(30_000); // only 30s since last completion
+			expect(deps.runSync).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(30_000); // now 60s since last completion
+			expect(deps.runSync).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not poll when remoteFs is null", () => {
+			scheduler.destroy();
+			deps = createDeps({ getSlowPollIntervalSec: () => 60, remoteFs: () => null });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(120_000);
+			expect(deps.runSync).not.toHaveBeenCalled();
+		});
+
+		it("does not poll when already syncing", () => {
+			const runSync = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+			scheduler.destroy();
+			deps = createDeps({
+				getSlowPollIntervalSec: () => 60,
+				orchestrator: { runSync, pullSingle: vi.fn().mockResolvedValue(undefined), isSyncing: () => true },
+			});
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			scheduler.notifySyncComplete();
+			vi.advanceTimersByTime(120_000);
+			expect(runSync).not.toHaveBeenCalled();
+		});
+
+		it("debounce-triggered sync takes priority over slow poll in same tick", () => {
+			scheduler.destroy();
+			deps = createDeps({ getSlowPollIntervalSec: () => 5 });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			// Vault change schedules debounce sync at now+5s; slow poll also due at now+5s
+			scheduler.notifySyncComplete();
+			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
+			handler(makeFile("note.md"));
+			vi.advanceTimersByTime(5000);
+			// Both conditions met but heartbeat should fire runSync exactly once per tick
+			expect(deps.runSync).toHaveBeenCalledTimes(1);
+		});
+	});
+
 	describe("destroy", () => {
-		it("cancels debounced sync", () => {
+		it("stops heartbeat and prevents further syncs", () => {
 			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
 			handler(makeFile("note.md"));
 			scheduler.destroy();
 			vi.advanceTimersByTime(5000);
+			expect(deps.runSync).not.toHaveBeenCalled();
+		});
+
+		it("stops slow poll after destroy", () => {
+			scheduler.destroy();
+			deps = createDeps({ getSlowPollIntervalSec: () => 60 });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+			scheduler.notifySyncComplete();
+
+			scheduler.destroy();
+			vi.advanceTimersByTime(120_000);
 			expect(deps.runSync).not.toHaveBeenCalled();
 		});
 	});

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -1,4 +1,3 @@
-import { debounce } from "obsidian";
 import type { EventRef, Workspace, Vault, TAbstractFile, TFile } from "obsidian";
 import type { IFileSystem } from "../fs/interface";
 import type { SyncStateStore } from "./state";
@@ -6,6 +5,7 @@ import type { LocalChangeTracker } from "./local-tracker";
 import { hasChanged, hasRemoteChanged } from "./change-compare";
 
 const DEBOUNCE_MS = 5000;
+const HEARTBEAT_MS = 1000;
 
 export interface SyncOrchestrator {
 	runSync(): Promise<void>;
@@ -24,22 +24,18 @@ export interface SyncSchedulerDeps {
 	isExcluded: (path: string) => boolean;
 	registerEvent: (ref: EventRef) => void;
 	register: (cb: () => void) => void;
+	getSlowPollIntervalSec: () => number;
 }
 
 export class SyncScheduler {
 	private deps: SyncSchedulerDeps;
-	private debouncedSync: ReturnType<typeof debounce>;
+	private nextSyncAt: number | null = null;
+	private lastSyncCompletedAt: number;
+	private heartbeatHandle: ReturnType<typeof setInterval> | null = null;
 
 	constructor(deps: SyncSchedulerDeps) {
 		this.deps = deps;
-		this.debouncedSync = debounce(
-			() => {
-				if (!this.deps.remoteFs()) return;
-				void deps.orchestrator.runSync();
-			},
-			DEBOUNCE_MS,
-			true,
-		);
+		this.lastSyncCompletedAt = 0;
 	}
 
 	start(): void {
@@ -48,10 +44,40 @@ export class SyncScheduler {
 		this.wireVisibilityEvent();
 		this.wireFocusEvent();
 		this.wireFileOpenEvent();
+		this.heartbeatHandle = setInterval(() => { this.onHeartbeat(); }, HEARTBEAT_MS);
 	}
 
 	destroy(): void {
-		this.debouncedSync.cancel();
+		if (this.heartbeatHandle !== null) {
+			clearInterval(this.heartbeatHandle);
+			this.heartbeatHandle = null;
+		}
+		this.nextSyncAt = null;
+	}
+
+	/** Called by the orchestrator when a sync cycle completes. */
+	notifySyncComplete(): void {
+		this.lastSyncCompletedAt = Date.now();
+	}
+
+	private onHeartbeat(): void {
+		const now = Date.now();
+		const remoteFs = this.deps.remoteFs();
+		if (!remoteFs) return;
+		if (this.deps.orchestrator.isSyncing()) return;
+
+		// Debounce path: a vault change scheduled a sync
+		if (this.nextSyncAt !== null && now >= this.nextSyncAt) {
+			this.nextSyncAt = null;
+			void this.deps.orchestrator.runSync();
+			return;
+		}
+
+		// Slow poll path: time since last sync exceeds the configured interval
+		const slowPollMs = this.deps.getSlowPollIntervalSec() * 1000;
+		if (slowPollMs > 0 && now >= this.lastSyncCompletedAt + slowPollMs) {
+			void this.deps.orchestrator.runSync();
+		}
 	}
 
 	private wireFocusEvent(): void {
@@ -70,7 +96,7 @@ export class SyncScheduler {
 		const onVaultChange = (file: TAbstractFile) => {
 			if (!isExcluded(file.path)) {
 				localTracker.markDirty(file.path);
-				this.debouncedSync();
+				this.nextSyncAt = Date.now() + DEBOUNCE_MS;
 			}
 		};
 
@@ -82,7 +108,7 @@ export class SyncScheduler {
 				localTracker.markDirty(oldPath);
 			}
 			if (!isExcluded(file.path) || !isExcluded(oldPath)) {
-				this.debouncedSync();
+				this.nextSyncAt = Date.now() + DEBOUNCE_MS;
 			}
 		};
 

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -60,20 +60,21 @@ export class SyncScheduler {
 		this.lastSyncCompletedAt = Date.now();
 	}
 
+	/** Called by setInterval() every HEARTBEAT_MS, schedules a sync pass if the time is ripe. **/
 	private onHeartbeat(): void {
 		const now = Date.now();
 		const remoteFs = this.deps.remoteFs();
 		if (!remoteFs) return;
 		if (this.deps.orchestrator.isSyncing()) return;
 
-		// Debounce path: a vault change scheduled a sync
+		// deadline 1: debounce interval after last vault change has passed
 		if (this.nextSyncAt !== null && now >= this.nextSyncAt) {
 			this.nextSyncAt = null;
 			void this.deps.orchestrator.runSync();
 			return;
 		}
 
-		// Slow poll path: time since last sync exceeds the configured interval
+		// deadline 2: do slow interval poll once in a while if no vault change or even if there's a steady stream of them.
 		const slowPollMs = this.deps.getSlowPollIntervalSec() * 1000;
 		if (slowPollMs > 0 && now >= this.lastSyncCompletedAt + slowPollMs) {
 			void this.deps.orchestrator.runSync();

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -19,6 +19,24 @@ export class AirSyncSettingTab extends PluginSettingTab {
 		new Setting(containerEl).setName("Sync").setHeading();
 
 		new Setting(containerEl)
+			.setName("Slow poll interval (seconds)")
+			.setDesc(
+				"How often to check for remote changes while local is idle. Set to 0 to disable background polling."
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("300")
+					.setValue(String(this.plugin.settings.slowPollIntervalSec))
+					.onChange(async (value) => {
+						const num = parseInt(value, 10);
+						if (!isNaN(num) && num >= 0) {
+							this.plugin.settings.slowPollIntervalSec = num;
+							await this.plugin.saveSettings();
+						}
+					})
+			);
+
+		new Setting(containerEl)
 			.setName("Conflict strategy")
 			.setDesc(
 				"How to resolve conflicts when both local and remote files have changed."


### PR DESCRIPTION
Proposed fix for #9 

Arrange to do a sync operation periodically to pull down remote changes even if there are no local changes.

This handles the scenario that user opens local vault and leaves it open while changes are being made on another device.
Also ensures that local vault reflects accumulated remote changes immediately on being opened.

New configuration item: `slowPollIntervalSec` which defaults to 300 sec, 5 minutes.
Although this breaks backward compatibility,  it fixes a problem that I think users would rightly call a bug.

