### PR TITLE
Recover from iOS "database connection is closing" IDB errors

### DIFF
--- a/src/store/idb-helper.test.ts
+++ b/src/store/idb-helper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import "fake-indexeddb/auto";
-import { IDBHelper, sanitizeDbName } from "./idb-helper";
+import { IDBHelper, isConnectionClosingError, sanitizeDbName } from "./idb-helper";
 
 describe("IDBHelper", () => {
 	let helper: IDBHelper;
@@ -61,6 +61,65 @@ describe("IDBHelper", () => {
 		// getDb() should re-open
 		const db = await h.getDb();
 		expect(db).toBeTruthy();
+	});
+
+	it("recovers when transaction() throws 'connection is closing'", async () => {
+		const h = createHelper();
+		await h.runTransaction("items", "readwrite", (tx) => {
+			tx.objectStore("items").put({ id: "a", value: 42 });
+			return () => {};
+		});
+
+		// Simulate iOS closing the connection under us: the cached db handle throws
+		// on the first transaction() call, then the helper must drop it and reopen.
+		const internal = h as unknown as { db: IDBDatabase | null };
+		const realDb = internal.db!;
+		let threw = false;
+		internal.db = new Proxy(realDb, {
+			get(target, prop, receiver) {
+				if (prop === "transaction" && !threw) {
+					return () => {
+						threw = true;
+						const err = new Error(
+							"Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.",
+						);
+						err.name = "InvalidStateError";
+						throw err;
+					};
+				}
+				const value: unknown = Reflect.get(target, prop, receiver);
+				return typeof value === "function"
+					? (value as (...args: unknown[]) => unknown).bind(target)
+					: value;
+			},
+		});
+
+		const result = await h.runTransaction("items", "readonly", (tx) => {
+			const req = tx.objectStore("items").get("a");
+			return () => req.result as { id: string; value: number };
+		});
+
+		expect(threw).toBe(true);
+		expect(result).toEqual({ id: "a", value: 42 });
+	});
+});
+
+describe("isConnectionClosingError", () => {
+	it("matches InvalidStateError by name", () => {
+		const err = new Error("boom");
+		err.name = "InvalidStateError";
+		expect(isConnectionClosingError(err)).toBe(true);
+	});
+
+	it("matches wrapped errors by message", () => {
+		expect(
+			isConnectionClosingError(new Error("Transaction aborted: The database connection is closing.")),
+		).toBe(true);
+	});
+
+	it("ignores unrelated errors and non-errors", () => {
+		expect(isConnectionClosingError(new Error("network down"))).toBe(false);
+		expect(isConnectionClosingError("connection is closing")).toBe(false);
 	});
 });
 

--- a/src/store/idb-helper.ts
+++ b/src/store/idb-helper.ts
@@ -63,6 +63,23 @@ export class IDBHelper {
 		return this.db;
 	}
 
+	/**
+	 * Discard the cached connection so the next `getDb()` opens a fresh one.
+	 * iOS Safari closes IndexedDB connections out from under us when the app is
+	 * backgrounded or under memory pressure; the stale handle then throws
+	 * "The database connection is closing" on every transaction until it is
+	 * dropped — which is why the plugin previously needed a task-kill to recover.
+	 */
+	private resetConnection(): void {
+		try {
+			this.db?.close();
+		} catch {
+			// already closing/closed — nothing to do
+		}
+		this.db = null;
+		this.openPromise = null;
+	}
+
 	async close(): Promise<void> {
 		if (this.openPromise) {
 			try {
@@ -88,9 +105,34 @@ export class IDBHelper {
 		mode: IDBTransactionMode,
 		fn: (tx: IDBTransaction) => () => T,
 	): Promise<T> {
+		try {
+			return await this.attemptTransaction(storeNames, mode, fn);
+		} catch (err) {
+			if (!isConnectionClosingError(err)) throw err;
+			// The cached connection was closed under us (typically iOS backgrounding
+			// the app). Drop it and retry once with a freshly opened connection so the
+			// next sync recovers without a task-kill.
+			this.resetConnection();
+			return this.attemptTransaction(storeNames, mode, fn);
+		}
+	}
+
+	private async attemptTransaction<T>(
+		storeNames: string | string[],
+		mode: IDBTransactionMode,
+		fn: (tx: IDBTransaction) => () => T,
+	): Promise<T> {
 		const db = await this.getDb();
 		return new Promise<T>((resolve, reject) => {
-			const tx = db.transaction(storeNames, mode);
+			let tx: IDBTransaction;
+			try {
+				tx = db.transaction(storeNames, mode);
+			} catch (err) {
+				// `transaction()` throws synchronously when the connection is closing;
+				// surface it as a rejection so runTransaction can decide to recover.
+				reject(err instanceof Error ? err : new Error(String(err)));
+				return;
+			}
 			const getResult = fn(tx);
 			tx.oncomplete = () => resolve(getResult());
 			tx.onerror = () =>
@@ -99,6 +141,17 @@ export class IDBHelper {
 				reject(new Error(`Transaction aborted: ${tx.error?.message ?? "unknown"}`));
 		});
 	}
+}
+
+/**
+ * Detect the "database connection is closing" failure that iOS Safari raises
+ * when it closes an IndexedDB connection out from under us. Matches both the
+ * raw `InvalidStateError` thrown by `transaction()` and the wrapped error
+ * surfaced via `tx.onerror`/`tx.onabort` when the connection dies mid-flight.
+ */
+export function isConnectionClosingError(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+	return err.name === "InvalidStateError" || /connection is closing/i.test(err.message);
 }
 
 export function sanitizeDbName(name: string): string {

--- a/src/store/idb-helper.ts
+++ b/src/store/idb-helper.ts
@@ -99,6 +99,11 @@ export class IDBHelper {
 	 * Run an IndexedDB transaction with automatic promise wrapping.
 	 * `fn` receives the transaction, performs IDB operations, and returns
 	 * a thunk `() => T` that is called on `tx.oncomplete` to safely read results.
+	 *
+	 * `fn` must be idempotent: on a "connection is closing" failure the
+	 * transaction is retried once on a fresh connection, so it may run twice.
+	 * Every caller here issues only keyed put/get/delete/clear/getAll ops, which
+	 * are safe to repeat; read-modify-write counters would not be.
 	 */
 	async runTransaction<T>(
 		storeNames: string | string[],


### PR DESCRIPTION
iOS Safari closes IndexedDB connections when the app is backgrounded or
under memory pressure. The cached connection handle then throws
"The database connection is closing" on every transaction, and because
runTransaction never dropped the dead handle, sync stayed broken until
the app was force-quit.

Wrap the synchronous transaction() call, and on a connection-closing
error discard the stale connection and retry once with a freshly opened
one. This lets sync self-heal on the next cycle without a task-kill.

https://claude.ai/code/session_011BY5886gNAYWoSnKq52WZt