### PR TITLE
Type IDB transaction errors instead of string matching

### DIFF
--- a/src/store/idb-helper.test.ts
+++ b/src/store/idb-helper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import "fake-indexeddb/auto";
-import { IDBHelper, isConnectionClosingError, sanitizeDbName } from "./idb-helper";
+import { IDBHelper, IDBTransactionError, isConnectionClosingError, sanitizeDbName } from "./idb-helper";
 
 describe("IDBHelper", () => {
 	let helper: IDBHelper;
@@ -104,11 +104,44 @@ describe("IDBHelper", () => {
 	});
 });
 
+describe("IDBTransactionError", () => {
+	it("preserves the DOMException name and message", () => {
+		const dom = new DOMException("The database connection is closing.", "InvalidStateError");
+		const err = new IDBTransactionError("abort", dom);
+		expect(err.name).toBe("IDBTransactionError");
+		expect(err.phase).toBe("abort");
+		expect(err.domName).toBe("InvalidStateError");
+		expect(err.cause).toBe(dom);
+		expect(err.message).toContain("The database connection is closing.");
+	});
+
+	it("tolerates a missing DOMException", () => {
+		const err = new IDBTransactionError("error", null);
+		expect(err.domName).toBeNull();
+		expect(err.message).toContain("unknown");
+	});
+});
+
 describe("isConnectionClosingError", () => {
 	it("matches InvalidStateError by name", () => {
 		const err = new Error("boom");
 		err.name = "InvalidStateError";
 		expect(isConnectionClosingError(err)).toBe(true);
+	});
+
+	it("matches a typed transaction error by its DOMException name", () => {
+		const dom = new DOMException("anything", "InvalidStateError");
+		expect(isConnectionClosingError(new IDBTransactionError("abort", dom))).toBe(true);
+	});
+
+	it("matches a typed transaction error by message fallback when name is unusable", () => {
+		const dom = new DOMException("The database connection is closing.", "AbortError");
+		expect(isConnectionClosingError(new IDBTransactionError("abort", dom))).toBe(true);
+	});
+
+	it("ignores a typed transaction error that is neither", () => {
+		const dom = new DOMException("Quota exceeded", "QuotaExceededError");
+		expect(isConnectionClosingError(new IDBTransactionError("abort", dom))).toBe(false);
 	});
 
 	it("matches wrapped errors by message", () => {

--- a/src/store/idb-helper.ts
+++ b/src/store/idb-helper.ts
@@ -140,23 +140,58 @@ export class IDBHelper {
 			}
 			const getResult = fn(tx);
 			tx.oncomplete = () => resolve(getResult());
-			tx.onerror = () =>
-				reject(new Error(`Transaction failed: ${tx.error?.message ?? "unknown"}`));
-			tx.onabort = () =>
-				reject(new Error(`Transaction aborted: ${tx.error?.message ?? "unknown"}`));
+			tx.onerror = () => reject(new IDBTransactionError("error", tx.error));
+			tx.onabort = () => reject(new IDBTransactionError("abort", tx.error));
 		});
 	}
 }
 
 /**
+ * A failed IndexedDB transaction, surfaced from `tx.onerror`/`tx.onabort`.
+ *
+ * The browser hands us a {@link DOMException} on `tx.error` whose `name`
+ * (`"InvalidStateError"`, `"AbortError"`, `"QuotaExceededError"`, …) is the
+ * structured signal callers should classify on — so we preserve it as
+ * {@link domName} (and the original exception as `cause`) instead of flattening
+ * to a string message that downstream code then has to re-parse.
+ */
+export class IDBTransactionError extends Error {
+	/** Which lifecycle hook fired: `tx.onerror` vs `tx.onabort`. */
+	readonly phase: "error" | "abort";
+	/** The underlying `DOMException.name`, or `null` when the browser gave us none. */
+	readonly domName: string | null;
+	/** The original `DOMException`, preserved for callers that want the raw cause. */
+	readonly cause?: DOMException;
+	constructor(phase: "error" | "abort", domError: DOMException | null) {
+		const verb = phase === "error" ? "failed" : "aborted";
+		super(`Transaction ${verb}: ${domError?.message ?? "unknown"}`);
+		this.name = "IDBTransactionError";
+		this.phase = phase;
+		this.domName = domError?.name ?? null;
+		if (domError) this.cause = domError;
+	}
+}
+
+/** The `DOMException.name` raised when an IndexedDB connection is closing. */
+const CONNECTION_CLOSING_DOM_NAME = "InvalidStateError";
+
+/**
  * Detect the "database connection is closing" failure that iOS Safari raises
- * when it closes an IndexedDB connection out from under us. Matches both the
- * raw `InvalidStateError` thrown by `transaction()` and the wrapped error
- * surfaced via `tx.onerror`/`tx.onabort` when the connection dies mid-flight.
+ * when it closes an IndexedDB connection out from under us. Covers both the
+ * raw `InvalidStateError` thrown synchronously by `transaction()` and the
+ * {@link IDBTransactionError} surfaced via `tx.onerror`/`tx.onabort` when the
+ * connection dies mid-flight.
+ *
+ * Classification is by DOMException `name` (`domName` for the wrapped case,
+ * `err.name` for the raw throw); the message regex is retained only as a
+ * cross-browser fallback for engines that report no usable `name`.
  */
 export function isConnectionClosingError(err: unknown): boolean {
+	if (err instanceof IDBTransactionError) {
+		return err.domName === CONNECTION_CLOSING_DOM_NAME || /connection is closing/i.test(err.message);
+	}
 	if (!(err instanceof Error)) return false;
-	return err.name === "InvalidStateError" || /connection is closing/i.test(err.message);
+	return err.name === CONNECTION_CLOSING_DOM_NAME || /connection is closing/i.test(err.message);
 }
 
 export function sanitizeDbName(name: string): string {


### PR DESCRIPTION
Wrap tx.onerror/tx.onabort failures in a typed IDBTransactionError that
preserves the underlying DOMException name (domName) and cause, instead
of flattening to a generic Error whose message had to be re-parsed.

isConnectionClosingError now classifies on the structured DOMException
name, keeping the message regex only as a cross-browser fallback for
engines that report no usable name.

https://claude.ai/code/session_01W8MFaCFdhzwnAAvqPAMhL8