### PR TITLE
Fix duplicate 'Everything up to date' notice on mobile resume

### DIFF
--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -160,6 +160,42 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
+		it("notifies once for a coalesced burst (no duplicate up-to-date notice)", async () => {
+			// A second trigger arriving mid-sync (e.g. mobile resume firing both
+			// focus and visibilitychange) sets syncPending and runs another cycle.
+			// The burst must emit a single notice, not one per cycle.
+			const settings = { ...mockSettings(), showSyncNotifications: true };
+			const deps = createDeps({ getSettings: () => settings });
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			deps.localFs = () => localFs;
+			deps.remoteFs = () => remoteFs;
+
+			let callCount = 0;
+			let unblockFirst!: () => void;
+			const blocker = new Promise<void>((res) => {
+				unblockFirst = res;
+			});
+			vi.spyOn(localFs, "list").mockImplementation(async () => {
+				callCount++;
+				if (callCount === 1) await blocker;
+				return [];
+			});
+
+			const orchestrator = new SyncOrchestrator(deps);
+			const first = orchestrator.runSync();
+			await new Promise((res) => setTimeout(res, 10));
+			const second = orchestrator.runSync(); // sets syncPending while locked
+			unblockFirst();
+			await first;
+			await second;
+
+			expect(callCount).toBeGreaterThanOrEqual(2);
+			expect(deps.notify).toHaveBeenCalledTimes(1);
+			expect(deps.notify).toHaveBeenCalledWith("Everything up to date");
+			await orchestrator.close();
+		});
+
 		it("sets status to error and notifies on AuthError", async () => {
 			const deps = createDeps();
 			const localFs = createMockFs("local");

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -17,7 +17,7 @@ import { classifyHttpError } from "../fs/errors";
 import { decideRetry, sleep } from "./error";
 import type { ConflictRecord, SyncStatus } from "./types";
 import { buildSyncRecord } from "./state-committer";
-import { buildNotificationMessage } from "./sync-notification";
+import { CycleSummary } from "./sync-notification";
 import type { SyncCycleResult } from "./sync-notification";
 
 export type { SyncStatus };
@@ -152,6 +152,10 @@ export class SyncOrchestrator {
 		}
 
 		await this.syncMutex.run(async () => {
+			// Coalesce every cycle in this burst into ONE end-of-run notice (see
+			// CycleSummary): a mobile resume firing focus + visibilitychange
+			// back-to-back must not show "Everything up to date" twice.
+			const summary = new CycleSummary();
 			do {
 				this.syncPending = false;
 				this.deps.onStatusChange("syncing");
@@ -183,11 +187,7 @@ export class SyncOrchestrator {
 					this.deps.logger?.info("Sync completed", { succeeded, conflicts, failed });
 				}
 
-				// The per-cycle notice is gated on its OWN setting now — `enableLogging`
-				// controls only whether logs are written (it used to double as this gate).
-				if (this.deps.getSettings().showSyncNotifications) {
-					this.deps.notify(buildNotificationMessage(result));
-				}
+				summary.add(result.result);
 
 				// Record this cycle's resolved conflicts to the audit history — once per
 				// cycle, and only when there were any. Writing stays separate from
@@ -203,9 +203,14 @@ export class SyncOrchestrator {
 				}
 				await this.deps.logger?.flush();
 
-				const allPaths = this.deps.localTracker.getDirtyPaths();
-				this.deps.localTracker.acknowledge(allPaths);
+				this.deps.localTracker.acknowledge(this.deps.localTracker.getDirtyPaths());
 			} while (this.syncPending);
+
+			// One notice per burst, gated on its OWN setting (`enableLogging` controls
+			// only whether logs are written — it used to double as this gate).
+			if (this.deps.getSettings().showSyncNotifications) {
+				this.deps.notify(summary.message);
+			}
 		});
 	}
 

--- a/src/sync/sync-notification.ts
+++ b/src/sync/sync-notification.ts
@@ -9,9 +9,9 @@ export interface SyncCycleResult {
 }
 
 /** Build the human-readable summary shown after a sync cycle completes. */
-export function buildNotificationMessage(cycle: SyncCycleResult): string {
+export function buildNotificationMessage(result: ExecutionResult): string {
 	const counts = { pushed: 0, pulled: 0, matched: 0, deleted: 0, renamed: 0 };
-	for (const a of cycle.result.succeeded) {
+	for (const a of result.succeeded) {
 		if (a.action.action === "push") counts.pushed++;
 		else if (a.action.action === "pull") counts.pulled++;
 		else if (a.action.action === "match") counts.matched++;
@@ -24,7 +24,31 @@ export function buildNotificationMessage(cycle: SyncCycleResult): string {
 	if (counts.matched > 0) parts.push(`${counts.matched} matched`);
 	if (counts.deleted > 0) parts.push(`${counts.deleted} deleted`);
 	if (counts.renamed > 0) parts.push(`${counts.renamed} renamed`);
-	if (cycle.conflicts > 0) parts.push(`${cycle.conflicts} conflicts`);
-	if (cycle.failed > 0) parts.push(`${cycle.failed} errors`);
+	if (result.conflicts.length > 0) parts.push(`${result.conflicts.length} conflicts`);
+	if (result.failed.length > 0) parts.push(`${result.failed.length} errors`);
 	return parts.length === 0 ? "Everything up to date" : `Sync: ${parts.join(", ")}`;
+}
+
+/**
+ * Coalesces the outcomes of one or more sync cycles into a single notice. When a
+ * trigger arrives mid-sync (e.g. a mobile resume firing focus + visibilitychange
+ * back-to-back), the orchestrator runs another cycle in the same burst; merging —
+ * rather than notifying per cycle — keeps an earlier cycle's real work visible
+ * while collapsing repeated "Everything up to date" cycles into one message.
+ */
+export class CycleSummary {
+	private readonly merged: ExecutionResult = { succeeded: [], failed: [], conflicts: [] };
+
+	add(cycle: ExecutionResult): void {
+		// Append element-by-element, not `push(...arr)`: a cold full-scan cycle can
+		// carry tens of thousands of actions, and spreading that many arguments can
+		// overflow the engine's argument limit (RangeError) on mobile.
+		for (const a of cycle.succeeded) this.merged.succeeded.push(a);
+		for (const f of cycle.failed) this.merged.failed.push(f);
+		for (const c of cycle.conflicts) this.merged.conflicts.push(c);
+	}
+
+	get message(): string {
+		return buildNotificationMessage(this.merged);
+	}
 }


### PR DESCRIPTION
When the app becomes active on mobile, multiple triggers (focus +
visibilitychange) can fire back-to-back. A second trigger arriving while a
sync is in flight sets syncPending, so runSync coalesces another cycle in the
same burst. The notice was emitted per cycle, so a no-op trailing cycle showed
'Everything up to date' a second time.

Accumulate each cycle's outcome in a CycleSummary and emit a single notice
after the burst. Merging (not last-wins) keeps an earlier cycle's real work
visible even when the trailing cycle is a no-op.

https://claude.ai/code/session_0113bfMqygHhrTQrfPeUUDXV