### PR TITLE
Consolidate backend auth identity config into one file

### DIFF
--- a/e2e/bootstrap.ts
+++ b/e2e/bootstrap.ts
@@ -1,10 +1,7 @@
 import { stdout } from "node:process";
 import { GoogleAuthDirect } from "../src/fs/googledrive/auth";
-import {
-	buildDropboxAuthorizeUrl,
-	DROPBOX_CLIENT_ID,
-	DropboxAuth,
-} from "../src/fs/dropbox/auth";
+import { buildDropboxAuthorizeUrl, DropboxAuth } from "../src/fs/dropbox/auth";
+import { DROPBOX_AUTH } from "../src/fs/auth-config";
 import { buildOneDriveAuthorizeUrl, OneDriveAuth } from "../src/fs/onedrive/auth";
 import { buildOAuthState, computeS256Challenge, generateRandomString } from "../src/fs/oauth-pkce";
 import { loadDotEnvE2e } from "./helpers/env";
@@ -60,7 +57,7 @@ async function bootstrapDropbox(): Promise<void> {
 		const codeChallenge = await computeS256Challenge(codeVerifier);
 		const state = buildOAuthState();
 		const url = buildDropboxAuthorizeUrl({
-			clientId: DROPBOX_CLIENT_ID,
+			clientId: DROPBOX_AUTH.clientId,
 			codeChallenge,
 			state,
 			redirectUri: loopback.redirectUri,
@@ -69,7 +66,7 @@ async function bootstrapDropbox(): Promise<void> {
 		const params = await loopback.waitForCallback();
 		if (params.state !== state) throw new Error("State mismatch — possible CSRF; aborting.");
 		if (!params.code) throw new Error("No authorization code in the callback.");
-		const auth = new DropboxAuth(DROPBOX_CLIENT_ID);
+		const auth = new DropboxAuth(DROPBOX_AUTH.clientId);
 		await auth.exchangeCode(params.code, codeVerifier, loopback.redirectUri);
 		const path = writeEnvE2e("AIRSYNC_E2E_DROPBOX_REFRESH_TOKEN", auth.getTokenState().refreshToken);
 		stdout.write(`\n✓ Dropbox refresh token written to ${path}\n`);

--- a/e2e/dropbox.e2e.ts
+++ b/e2e/dropbox.e2e.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe } from "vitest";
-import { DROPBOX_CLIENT_ID, DropboxAuth } from "../src/fs/dropbox/auth";
+import { DropboxAuth } from "../src/fs/dropbox/auth";
+import { DROPBOX_AUTH } from "../src/fs/auth-config";
 import { DropboxFs } from "../src/fs/dropbox/index";
 import { runIFileSystemContract } from "../src/fs/ifilesystem-contract";
 import { RetryingDropboxClient } from "./helpers/dropbox-retry-client";
@@ -31,7 +32,7 @@ if (!creds) {
 } else {
 	// PKCE refresh needs only the public client id. Empty access token + expiry 0
 	// forces a refresh on the first getAccessToken().
-	const auth = new DropboxAuth(DROPBOX_CLIENT_ID);
+	const auth = new DropboxAuth(DROPBOX_AUTH.clientId);
 	auth.setTokens(creds.refreshToken, "", 0);
 	// Inject a node-safe sleep: the client's default sleep uses window.setTimeout,
 	// which is undefined under vitest's node environment — a 429 backoff (the very

--- a/src/fs/auth-config.ts
+++ b/src/fs/auth-config.ts
@@ -1,0 +1,57 @@
+/**
+ * Centralized auth identity config for every cloud backend: auth-relay server,
+ * public OAuth client ids, and redirect URIs. Kept in one place — rather than
+ * scattered across each backend's auth.ts — so the auth surface is auditable at
+ * a glance and the cross-backend duplicate (the shared obsidian:// redirect)
+ * cannot drift. OAuth endpoint URLs and scopes stay in each backend's auth.ts.
+ */
+
+/**
+ * Direct deep link back to the in-plugin protocol handler — no relay page.
+ * Shared by Dropbox and OneDrive: both register `obsidian://air-sync-auth` as a
+ * redirect URI. Custom-scheme redirects are permitted for PKCE apps (the
+ * authorization-code flow otherwise requires https/localhost), so the code can
+ * return straight to Obsidian.
+ */
+export const PLUGIN_REDIRECT_URI = "obsidian://air-sync-auth";
+
+/** Air Sync auth relay server (confidential client; server-side token exchange). */
+const GOOGLE_AUTH_SERVER_URL = "https://auth-airsync.takezo.dev";
+
+export const GOOGLE_DRIVE_AUTH = {
+	authServerUrl: GOOGLE_AUTH_SERVER_URL,
+	clientId: "135801498656-lfjor2ml3v26t9l63mkoka0bndgl9eue.apps.googleusercontent.com",
+	redirectUri: `${GOOGLE_AUTH_SERVER_URL}/google/callback`,
+	tokenRefreshUrl: `${GOOGLE_AUTH_SERVER_URL}/google/token/refresh`,
+} as const;
+
+/** Default redirect URI for user-supplied (direct) Google credentials. */
+export const DEFAULT_CUSTOM_REDIRECT_URI = "https://airsync.takezo.dev/callback";
+
+/**
+ * Public OAuth app for the Air Sync Dropbox app (App folder permission).
+ *
+ * PKCE means there is NO client secret anywhere — the `code_verifier` is the
+ * ephemeral proof. Registered at https://www.dropbox.com/developers/apps with
+ * `obsidian://air-sync-auth` as a redirect URI (Dropbox allows custom schemes for
+ * PKCE apps). The Dropbox backend is still labelled "Preview" in the UI, but the
+ * key is embedded so it connects with no per-user setup.
+ */
+export const DROPBOX_AUTH = {
+	clientId: "icsyogaens93hde",
+	redirectUri: PLUGIN_REDIRECT_URI,
+} as const;
+
+/**
+ * Public OAuth app for the Air Sync OneDrive app (Files.ReadWrite.AppFolder).
+ *
+ * The real Entra (Azure AD) application (client) id, registered at
+ * https://entra.microsoft.com with `obsidian://air-sync-auth` as a redirect URI and
+ * "Personal Microsoft accounts only" as the supported account type. PKCE means there
+ * is NO client secret anywhere — the `code_verifier` is the ephemeral proof. The
+ * contract tests pass a fake client id, so they are green regardless of this value.
+ */
+export const ONEDRIVE_AUTH = {
+	clientId: "71cd9a2a-a701-4ec2-b7d0-2352e0e84e9f",
+	redirectUri: PLUGIN_REDIRECT_URI,
+} as const;

--- a/src/fs/dropbox/auth.ts
+++ b/src/fs/dropbox/auth.ts
@@ -5,31 +5,14 @@ import type { Logger } from "../../logging/logger";
 import { AuthError } from "../errors";
 import { setBackendSecret, hasBackendSecret } from "../token-store";
 import { BaseOAuthTokenManager, buildOAuthState, computeS256Challenge, generateRandomString } from "../oauth-pkce";
+import { DROPBOX_AUTH } from "../auth-config";
 import { assertDropboxTokenResponse } from "./types";
 
 const AUTHORIZE_URL = "https://www.dropbox.com/oauth2/authorize";
 const TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
 const REVOKE_URL = "https://api.dropboxapi.com/2/auth/token/revoke";
-/**
- * Direct deep link back to the in-plugin protocol handler — no relay page.
- * Dropbox permits a custom-scheme redirect URI specifically for PKCE apps (the
- * authorization-code flow otherwise requires https/localhost), so the code can
- * return straight to Obsidian, matching the OneDrive backend.
- */
-const REDIRECT_URI = "obsidian://air-sync-auth";
 const SCOPES = "files.metadata.read files.content.read files.content.write";
 const BACKEND_TYPE = "dropbox";
-
-/**
- * Public OAuth app key for the Air Sync Dropbox app (App folder permission).
- *
- * PKCE means there is NO client secret anywhere — the `code_verifier` is the
- * ephemeral proof. Registered at https://www.dropbox.com/developers/apps with
- * `obsidian://air-sync-auth` as a redirect URI (Dropbox allows custom schemes for
- * PKCE apps). The Dropbox backend is still labelled "Preview" in the UI, but the
- * key is embedded so it connects with no per-user setup.
- */
-export const DROPBOX_CLIENT_ID = "icsyogaens93hde";
 
 /**
  * Build the Dropbox authorization-code + PKCE authorize URL. The single source of
@@ -50,7 +33,7 @@ export function buildDropboxAuthorizeUrl(opts: {
 		code_challenge: opts.codeChallenge,
 		code_challenge_method: "S256",
 		scope: SCOPES,
-		redirect_uri: opts.redirectUri ?? REDIRECT_URI,
+		redirect_uri: opts.redirectUri ?? DROPBOX_AUTH.redirectUri,
 		state: opts.state,
 	});
 	return `${AUTHORIZE_URL}?${params.toString()}`;
@@ -101,11 +84,11 @@ export class DropboxAuth extends BaseOAuthTokenManager {
 	 * Exchange an authorization code for tokens (PKCE — no client secret).
 	 *
 	 * `redirectUri` must match the one used in the authorize request and defaults
-	 * to the shipped relay ({@link REDIRECT_URI}). The opt-in e2e bootstrap (ADR
-	 * 0003) overrides it with a `http://localhost:<port>` loopback so a headless
-	 * CLI can capture the redirect directly.
+	 * to the shipped in-plugin redirect ({@link DROPBOX_AUTH}.redirectUri). The
+	 * opt-in e2e bootstrap (ADR 0003) overrides it with a `http://localhost:<port>`
+	 * loopback so a headless CLI can capture the redirect directly.
 	 */
-	async exchangeCode(code: string, codeVerifier: string, redirectUri: string = REDIRECT_URI): Promise<void> {
+	async exchangeCode(code: string, codeVerifier: string, redirectUri: string = DROPBOX_AUTH.redirectUri): Promise<void> {
 		const res = await requestUrl({
 			url: TOKEN_URL,
 			method: "POST",
@@ -196,7 +179,7 @@ export class DropboxAuthProvider implements IAuthProvider {
 
 	constructor(
 		private secretStore: ISecretStore,
-		private clientId: string = DROPBOX_CLIENT_ID,
+		private clientId: string = DROPBOX_AUTH.clientId,
 		private logger?: Logger,
 	) {}
 

--- a/src/fs/googledrive/auth.ts
+++ b/src/fs/googledrive/auth.ts
@@ -2,16 +2,12 @@ import { requestUrl } from "obsidian";
 import type { Logger } from "../../logging/logger";
 import { assertTokenResponse } from "./types";
 import { BaseOAuthTokenManager, buildOAuthState, computeS256Challenge, generateRandomString } from "../oauth-pkce";
+import { GOOGLE_DRIVE_AUTH, DEFAULT_CUSTOM_REDIRECT_URI } from "../auth-config";
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
-const AUTH_SERVER_URL = "https://auth-airsync.takezo.dev";
 const SCOPES = "https://www.googleapis.com/auth/drive.file";
 export const DEFAULT_CUSTOM_SCOPE = SCOPES;
-export const DEFAULT_CUSTOM_REDIRECT_URI = "https://airsync.takezo.dev/callback";
-const REDIRECT_URI = `${AUTH_SERVER_URL}/google/callback`;
-
-const GOOGLE_CLIENT_ID = "135801498656-lfjor2ml3v26t9l63mkoka0bndgl9eue.apps.googleusercontent.com";
 
 /** Shared interface for GoogleAuth and GoogleAuthDirect */
 export interface IGoogleAuth {
@@ -121,8 +117,8 @@ export class GoogleAuth extends GoogleAuthBase {
 		const state = this.generateState();
 
 		const params = new URLSearchParams({
-			client_id: GOOGLE_CLIENT_ID,
-			redirect_uri: REDIRECT_URI,
+			client_id: GOOGLE_DRIVE_AUTH.clientId,
+			redirect_uri: GOOGLE_DRIVE_AUTH.redirectUri,
 			response_type: "code",
 			scope: SCOPES,
 			access_type: "offline",
@@ -166,7 +162,7 @@ export class GoogleAuth extends GoogleAuthBase {
 		this.logger?.info("Refreshing access token");
 		try {
 			const response = await requestUrl({
-				url: `${AUTH_SERVER_URL}/google/token/refresh`,
+				url: GOOGLE_DRIVE_AUTH.tokenRefreshUrl,
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ refresh_token: this.refreshToken }),

--- a/src/fs/onedrive/auth.ts
+++ b/src/fs/onedrive/auth.ts
@@ -5,27 +5,15 @@ import type { Logger } from "../../logging/logger";
 import { AuthError } from "../errors";
 import { setBackendSecret, hasBackendSecret } from "../token-store";
 import { BaseOAuthTokenManager, buildOAuthState, computeS256Challenge, generateRandomString } from "../oauth-pkce";
+import { ONEDRIVE_AUTH } from "../auth-config";
 import { assertMicrosoftTokenResponse } from "./types";
 
 /** Personal Microsoft accounts only — the `consumers` authority host. */
 const AUTHORIZE_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize";
 const TOKEN_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token";
-/** Reuse the existing in-plugin protocol handler — NO new scheme, no relay page. */
-export const REDIRECT_URI = "obsidian://air-sync-auth";
 /** App Folder scope: the vault lives under /me/drive/special/approot; offline_access enables refresh. */
 const SCOPES = "Files.ReadWrite.AppFolder offline_access";
 const BACKEND_TYPE = "onedrive";
-
-/**
- * Public OAuth client id for the Air Sync OneDrive app (Files.ReadWrite.AppFolder).
- *
- * The real Entra (Azure AD) application (client) id, registered at
- * https://entra.microsoft.com with `obsidian://air-sync-auth` as a redirect URI and
- * "Personal Microsoft accounts only" as the supported account type. PKCE means there
- * is NO client secret anywhere — the `code_verifier` is the ephemeral proof. The
- * contract tests pass a fake client id, so they are green regardless of this value.
- */
-export const ONEDRIVE_CLIENT_ID = "71cd9a2a-a701-4ec2-b7d0-2352e0e84e9f";
 
 /**
  * Build the OneDrive authorization-code + PKCE authorize URL. The single source of
@@ -45,7 +33,7 @@ export function buildOneDriveAuthorizeUrl(opts: {
 		code_challenge: opts.codeChallenge,
 		code_challenge_method: "S256",
 		scope: SCOPES,
-		redirect_uri: opts.redirectUri ?? REDIRECT_URI,
+		redirect_uri: opts.redirectUri ?? ONEDRIVE_AUTH.redirectUri,
 		state: opts.state,
 	});
 	return `${AUTHORIZE_URL}?${params.toString()}`;
@@ -108,11 +96,11 @@ export class OneDriveAuth extends BaseOAuthTokenManager {
 	 * Exchange an authorization code for tokens (PKCE — no client secret).
 	 *
 	 * `redirectUri` must match the one used in the authorize request and defaults to
-	 * the in-plugin {@link REDIRECT_URI}. The opt-in e2e bootstrap (ADR 0003) overrides
-	 * it with a `http://localhost:<port>` loopback so a headless CLI can capture the
-	 * redirect directly.
+	 * the in-plugin {@link ONEDRIVE_AUTH}.redirectUri. The opt-in e2e bootstrap (ADR
+	 * 0003) overrides it with a `http://localhost:<port>` loopback so a headless CLI
+	 * can capture the redirect directly.
 	 */
-	async exchangeCode(code: string, codeVerifier: string, redirectUri: string = REDIRECT_URI): Promise<void> {
+	async exchangeCode(code: string, codeVerifier: string, redirectUri: string = ONEDRIVE_AUTH.redirectUri): Promise<void> {
 		const res = await requestUrl({
 			url: TOKEN_URL,
 			method: "POST",
@@ -179,7 +167,7 @@ export class OneDriveAuthProvider implements IAuthProvider {
 
 	constructor(
 		private secretStore: ISecretStore,
-		private clientId: string = ONEDRIVE_CLIENT_ID,
+		private clientId: string = ONEDRIVE_AUTH.clientId,
 		private logger?: Logger,
 	) {}
 

--- a/src/ui/googledrive-settings.ts
+++ b/src/ui/googledrive-settings.ts
@@ -7,7 +7,8 @@ import type {
 } from "../fs/settings-renderer";
 import type { GoogleDriveBackendData } from "../fs/googledrive/provider";
 import type { GoogleDriveCustomBackendData } from "../fs/googledrive/provider-custom";
-import { DEFAULT_CUSTOM_SCOPE, DEFAULT_CUSTOM_REDIRECT_URI } from "../fs/googledrive/auth";
+import { DEFAULT_CUSTOM_SCOPE } from "../fs/googledrive/auth";
+import { DEFAULT_CUSTOM_REDIRECT_URI } from "../fs/auth-config";
 import { getBackendProvider } from "../fs/registry";
 import { REMOTE_VAULT_ROOT } from "../fs/remote-vault-contract";
 


### PR DESCRIPTION
Move each backend's auth-server URL, public OAuth client id, and redirect
URI out of the per-backend auth.ts files into a single src/fs/auth-config.ts,
grouped as per-backend `as const` objects (GOOGLE_DRIVE_AUTH, DROPBOX_AUTH,
ONEDRIVE_AUTH) plus a shared PLUGIN_REDIRECT_URI. The shared
"obsidian://air-sync-auth" redirect (previously duplicated across Dropbox and
OneDrive) now lives in exactly one place, so it can't drift.

OAuth endpoint URLs, scopes, and BACKEND_TYPE stay in each backend's auth.ts
— they're tied to backend-specific behavior. Values are unchanged.

https://claude.ai/code/session_012jU3NKgpfYqETe6bKe6cgn