### PR TITLE
Remove dead code left over from removed features

### DIFF
--- a/docs/conflict-resolution.md
+++ b/docs/conflict-resolution.md
@@ -2,17 +2,16 @@
 
 ## Conflict strategies
 
-`conflict-resolver.ts` exposes 3 user-facing strategies via `ConflictStrategy`:
+`conflict-resolver.ts` exposes 2 user-facing strategies via `ConflictStrategy`:
 
 | Strategy | Behavior |
 |----------|----------|
 | `auto_merge` | Try a 3-way merge; if the file is ineligible, the base content is missing, or the merge throws, fall back to newer-wins. Two narrower cases produce a duplicate: within newer-wins, equal or unknown mtimes with differing content; and for `.json`/`.canvas`, a merge that produced conflict markers or invalid JSON. |
 | `duplicate` | Delete-aware (see below). When both sides exist, save remote as a `.conflict` file and keep local at the original path. |
-| `ask` | Show a modal for the user to choose `keep_local` / `keep_remote` / `duplicate`. |
 
-The setting is stored as `conflictStrategy` in `AirSyncSettings` (values `auto_merge` \| `duplicate` \| `ask`).
+The setting is stored as `conflictStrategy` in `AirSyncSettings` (values `auto_merge` \| `duplicate`).
 
-The ask modal defaults to `duplicate` if the user closes it without choosing (`AskConflictModal.onClose`), and `resolveAsk` falls back to `duplicate` (logging a warning) when no `App` instance is available in the resolver context. The modal's third option is labelled "Keep both" (its button, like the others, reads "Choose").
+> NOTE: an interactive `ask` strategy existed in an earlier version. It was removed (it always fell back to `duplicate` anyway). A vault saved while it was selected is normalized to `duplicate` on load (`normalizeConflictStrategy` in `settings-normalize.ts`).
 
 ## auto_merge fallback chain
 
@@ -87,16 +86,14 @@ remote version
 | Strategy | Behavior |
 |----------|----------|
 | `keep_newer` | Compare mtime; newer side overwrites the other |
-| `keep_local` | Push local to remote (or delete remote if local deleted) |
-| `keep_remote` | Pull remote to local (or delete local if remote deleted) |
 | `duplicate` | Delete-aware (see below); when both sides exist, save remote copy with `.conflict` suffix and keep local |
 | `auto_merge` | Attempt 3-way merge, fall back to `keep_newer` |
 
-These are not exposed in the settings UI.
+These are not exposed in the settings UI. Internally, `keep_newer` delegates the actual write to two helpers — push-local-to-remote (or delete remote when local is gone) and pull-remote-to-local (or delete local when remote is gone) — which surface as the `kept_local` / `kept_remote` actions.
 
 `duplicate` is delete-aware. If exactly one side is deleted, the surviving version is restored to the deleted side (action `duplicated`, no `.conflict` file). If both sides are deleted, nothing happens (action `kept_local`). Only when both sides exist is the remote saved as a `.conflict` duplicate on BOTH local and remote, the local file kept at its original path, and that local version also pushed to remote at the original path (action `duplicated`).
 
-`keep_local` / `keep_remote` preserve the surviving side's mtime on the written copy (`remoteFs.write(..., local.mtime)` / `localFs.write(..., remote.mtime)`); `keep_newer` and `duplicate` likewise preserve source mtimes. A successful 3-way merge is the only resolver path that instead stamps both sides with the current time (`Date.now()`), which affects subsequent newer-wins comparisons.
+`keep_newer` and `duplicate` preserve source mtimes on the written copies. A successful 3-way merge is the only resolver path that instead stamps both sides with the current time (`Date.now()`), which affects subsequent newer-wins comparisons.
 
 ## Conflict history
 

--- a/src/fs/dropbox/types.ts
+++ b/src/fs/dropbox/types.ts
@@ -1,9 +1,5 @@
 import type { FileEntity } from "../types";
-import type { FileRecord } from "../../store/metadata-store";
 import { AuthError } from "../errors";
-
-/** Dropbox-specific file record type alias (persisted in IndexedDB). */
-export type DropboxFileRecord = FileRecord<DropboxEntry>;
 
 /**
  * A Dropbox file/folder metadata entry (the subset Air Sync uses).

--- a/src/fs/googledrive/test-helpers.ts
+++ b/src/fs/googledrive/test-helpers.ts
@@ -47,18 +47,6 @@ export function createMockSecretStore(secrets: Record<string, string> = {}): ISe
 	};
 }
 
-/** Create a mock App with SecretStorage for tests (for UI components that need App) */
-export function mockApp(secrets: Record<string, string> = {}): import("obsidian").App {
-	const store = new Map(Object.entries(secrets));
-	return {
-		secretStorage: {
-			getSecret: (id: string) => store.get(id) ?? null,
-			setSecret: (id: string, secret: string) => { store.set(id, secret); },
-			listSecrets: () => [...store.keys()],
-		},
-	} as unknown as import("obsidian").App;
-}
-
 /** Type for accessing the cache on GoogleDriveFs in tests */
 export interface GoogleDriveFsCacheInternal {
 	cache: { getChildren(path: string): ReadonlySet<string> | undefined };

--- a/src/fs/googledrive/types.ts
+++ b/src/fs/googledrive/types.ts
@@ -1,4 +1,3 @@
-import type { FileRecord } from "../../store/metadata-store";
 import type { RemoteChecksum } from "../types";
 
 /** Google Drive folder MIME type */
@@ -11,9 +10,6 @@ export const FOLDER_MIME = "application/vnd.google-apps.folder";
 export function toRemoteChecksum(file: GoogleDriveFile): RemoteChecksum | undefined {
 	return file.md5Checksum ? { algo: "md5", value: file.md5Checksum } : undefined;
 }
-
-/** Google Drive-specific file record type alias */
-export type GoogleDriveFileRecord = FileRecord<GoogleDriveFile>;
 
 /** Google Drive file metadata from API response */
 export interface GoogleDriveFile {

--- a/src/fs/oauth-pkce.ts
+++ b/src/fs/oauth-pkce.ts
@@ -66,7 +66,7 @@ export function buildOAuthState(extra: Record<string, unknown> = {}): string {
 	return base64ToBase64Url(btoa(json));
 }
 
-export interface OAuthTokenState {
+interface OAuthTokenState {
 	refreshToken: string;
 	accessToken: string;
 	accessTokenExpiry: number;

--- a/src/fs/onedrive/metadata-cache.ts
+++ b/src/fs/onedrive/metadata-cache.ts
@@ -3,8 +3,6 @@ import type { OneDriveItem } from "./types";
 import { isFolderEntry, oneDriveItemToEntity } from "./types";
 import { AbstractMetadataCache } from "../caching/metadata-cache";
 
-export type { FileChangeResult } from "../caching/metadata-cache";
-
 /**
  * OneDrive's metadata cache. All the data structures and path/tree logic live in
  * {@link AbstractMetadataCache}; this subclass only reads Graph's driveItem shape

--- a/src/fs/onedrive/types.ts
+++ b/src/fs/onedrive/types.ts
@@ -1,9 +1,5 @@
 import type { FileEntity, RemoteChecksum } from "../types";
-import type { FileRecord } from "../../store/metadata-store";
 import { AuthError } from "../errors";
-
-/** OneDrive-specific file record type alias (persisted in IndexedDB). */
-export type OneDriveFileRecord = FileRecord<OneDriveItem>;
 
 /**
  * A Microsoft Graph `driveItem` (the subset Air Sync uses).

--- a/src/sync/conflict.test.ts
+++ b/src/sync/conflict.test.ts
@@ -21,60 +21,6 @@ describe("resolveWithStrategy", () => {
 		remoteFs = createMockFs("remote");
 	});
 
-	describe("keep_local", () => {
-		it("overwrites remote with the local version", async () => {
-			const local = addFile(localFs, "f.md", "local wins", 1000);
-			addFile(remoteFs, "f.md", "remote old", 1000);
-
-			const r = await resolveWithStrategy(
-				{ path: "f.md", localFs, remoteFs, local },
-				"keep_local",
-			);
-
-			expect(r.action).toBe("kept_local");
-			expect(readText(remoteFs, "f.md")).toBe("local wins");
-		});
-
-		it("deletes the remote when local is absent (the local deletion wins)", async () => {
-			addFile(remoteFs, "f.md", "remote", 1000);
-
-			const r = await resolveWithStrategy(
-				{ path: "f.md", localFs, remoteFs },
-				"keep_local",
-			);
-
-			expect(r.action).toBe("kept_local");
-			expect(remoteFs.files.has("f.md")).toBe(false);
-		});
-	});
-
-	describe("keep_remote", () => {
-		it("overwrites local with the remote version", async () => {
-			const remote = addFile(remoteFs, "f.md", "remote wins", 1000);
-			addFile(localFs, "f.md", "local old", 1000);
-
-			const r = await resolveWithStrategy(
-				{ path: "f.md", localFs, remoteFs, remote },
-				"keep_remote",
-			);
-
-			expect(r.action).toBe("kept_remote");
-			expect(readText(localFs, "f.md")).toBe("remote wins");
-		});
-
-		it("deletes the local when remote is absent (the remote deletion wins)", async () => {
-			addFile(localFs, "f.md", "local", 1000);
-
-			const r = await resolveWithStrategy(
-				{ path: "f.md", localFs, remoteFs },
-				"keep_remote",
-			);
-
-			expect(r.action).toBe("kept_remote");
-			expect(localFs.files.has("f.md")).toBe(false);
-		});
-	});
-
 	describe("keep_newer", () => {
 		it("keeps the remote version when its mtime is newer", async () => {
 			const local = addFile(localFs, "f.md", "older local", 1000);

--- a/src/sync/conflict.ts
+++ b/src/sync/conflict.ts
@@ -8,7 +8,7 @@ import { isMergeEligible, threeWayMerge } from "./merge";
 import { sameContent } from "./content-identity";
 
 /** Internal strategy used by the low-level conflict resolver */
-export type ResolverStrategy = "keep_newer" | "keep_local" | "keep_remote" | "duplicate" | "auto_merge";
+export type ResolverStrategy = "keep_newer" | "duplicate" | "auto_merge";
 
 export interface ConflictResolutionResult {
 	/** The action that was taken */
@@ -30,22 +30,14 @@ export interface ConflictContext {
 	logger?: Logger;
 }
 
-export type FallbackResolver = ResolverStrategy | (() => Promise<ResolverStrategy>);
-
 export async function resolveWithStrategy(
 	ctx: ConflictContext,
 	strategy: ResolverStrategy,
-	fallback?: FallbackResolver,
+	fallback?: ResolverStrategy,
 ): Promise<ConflictResolutionResult> {
 	const { path, localFs, remoteFs, local, remote } = ctx;
 
 	switch (strategy) {
-		case "keep_local":
-			return keepLocal(path, localFs, remoteFs, local);
-
-		case "keep_remote":
-			return keepRemote(path, localFs, remoteFs, remote);
-
 		case "keep_newer":
 			return keepNewer(path, localFs, remoteFs, local, remote);
 
@@ -200,51 +192,44 @@ function insertConflictSuffix(path: string, seq: number | string): string {
 
 async function attemptThreeWayMerge(
 	ctx: ConflictContext,
-	fallback: FallbackResolver = "keep_newer",
+	fallback: ResolverStrategy = "keep_newer",
 ): Promise<ConflictResolutionResult> {
 	const { path, localFs, remoteFs, local, remote, prevSync, stateStore, logger } = ctx;
 	const tag = "auto_merge";
 
 	logger?.debug(`${tag}: attempting 3-way merge`, { path });
 
-	const resolveFallback = async (): Promise<ResolverStrategy> => {
-		return typeof fallback === "function" ? await fallback() : fallback;
-	};
-
 	// Must have both sides present and a previous sync record
 	if (!local || !remote || !prevSync) {
-		const fb = await resolveFallback();
 		logger?.warn(`${tag}: falling back — missing prerequisites`, {
 			path,
 			strategy: tag,
 			reason: `missing: ${[!local && "local", !remote && "remote", !prevSync && "prevSync"].filter(Boolean).join(", ")}`,
-			outcome: fb,
+			outcome: fallback,
 		});
-		return resolveWithStrategy(ctx, fb);
+		return resolveWithStrategy(ctx, fallback);
 	}
 
 	// Retrieve the stored base content
 	const prevSyncContent = stateStore ? await stateStore.getContent(path) : undefined;
 	if (!prevSyncContent) {
-		const fb = await resolveFallback();
 		logger?.warn(`${tag}: falling back — no base content in state store`, {
 			path,
 			strategy: tag,
 			reason: stateStore ? "base content not found in store" : "no state store provided",
-			outcome: fb,
+			outcome: fallback,
 		});
-		return resolveWithStrategy(ctx, fb);
+		return resolveWithStrategy(ctx, fallback);
 	}
 
 	if (!isMergeEligible(path, Math.max(local.size, remote.size))) {
-		const fb = await resolveFallback();
 		logger?.warn(`${tag}: falling back — file not eligible for merge`, {
 			path,
 			strategy: tag,
 			reason: `not a mergeable text file (localSize=${local.size}, remoteSize=${remote.size})`,
-			outcome: fb,
+			outcome: fallback,
 		});
-		return resolveWithStrategy(ctx, fb);
+		return resolveWithStrategy(ctx, fallback);
 	}
 
 	const decoder = new TextDecoder();
@@ -260,14 +245,13 @@ async function attemptThreeWayMerge(
 	try {
 		mergeResult = threeWayMerge(baseText, localText, remoteText);
 	} catch (mergeErr) {
-		const fb = await resolveFallback();
 		logger?.warn(`${tag}: falling back — merge threw an exception`, {
 			path,
 			strategy: tag,
 			reason: mergeErr instanceof Error ? mergeErr.message : String(mergeErr),
-			outcome: fb,
+			outcome: fallback,
 		});
-		return resolveWithStrategy(ctx, fb);
+		return resolveWithStrategy(ctx, fallback);
 	}
 
 	logger?.debug(`${tag}: merge complete`, {


### PR DESCRIPTION
Sweep out code that is defined but no longer reachable:

- Unused per-backend `*FileRecord` type aliases (Dropbox/Drive/OneDrive)
  and the now-unused `FileRecord` imports.
- Unused `mockApp` test helper (callers use a local stub).
- Unused `FileChangeResult` re-export from OneDrive's metadata-cache
  (Drive's re-export stays — it is used by tests).
- Drop the unneeded `export` on `OAuthTokenState` (internal-only).
- Retire the `keep_local` / `keep_remote` resolver strategies and the
  function-form `FallbackResolver`: these were only reachable via the
  removed interactive "ask" conflict strategy. The `keepLocal`/`keepRemote`
  helpers stay (newer-wins still uses them).
- Refresh conflict-resolution docs to drop the removed "ask" strategy and
  the retired internal strategies.

https://claude.ai/code/session_01C6oEXpS4sjw3tRr9jWEhrK