### PR TITLE
Add OneDrive backend and refactor incremental sync into shared caching layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,17 +17,19 @@ One row per directory; see the layer diagram and per-doc references for module d
 | Path | Responsibility |
 |------|----------------|
 | `main.ts` | Plugin entry point — lifecycle only: load settings, register commands, wire components, handle the OAuth protocol callback. |
-| `settings.ts` | `AirSyncSettings` type and `DEFAULT_SETTINGS`. |
+| `settings.ts` | `AirSyncSettings` type and `DEFAULT_SETTINGS`; `settings-normalize.ts` lifts a legacy per-type `backendData` map into the active flat bag on load. |
 | `sync/` | The sync pipeline and its orchestration: change tracking and detection (hot/warm/cold), the decision engine, rename optimization, plan execution (groups A–D), per-action state commit, conflict resolution and 3-way merge, the orchestrator (mutex/retry/status), the scheduler (vault events + triggers), the IndexedDB `SyncStateStore`, error classification, and the conflict-history audit writer. |
-| `fs/` | Backend-agnostic contracts and lifecycle: `IFileSystem`, `IAuthProvider`, `IBackendProvider`, `FileEntity`, the provider registry, `AuthError`, `BackendManager`, and the `ISecretStore`/token-store wrappers over Obsidian SecretStorage. |
+| `fs/` | Backend-agnostic contracts and lifecycle: `IFileSystem` + `IncrementalCheckpoint`, `IAuthProvider`, `IBackendProvider` + `WebFolderPicker`, `FileEntity`/`RemoteChecksum`, the provider registry, error classification (`errors.ts`), the OAuth PKCE helper (`oauth-pkce.ts`), the backend settings-renderer contract (`settings-renderer.ts`), `BackendManager`, and the `ISecretStore`/token-store wrappers over Obsidian SecretStorage. |
+| `fs/caching/` | Shared base for id-addressed remote backends: `CachingRemoteFs<T>` (path↔id resolution and the `IncrementalCheckpoint` checkpoint lifecycle, ADR 0001) and `AbstractMetadataCache<T>`. Google Drive, Dropbox, and OneDrive all build on it. |
 | `fs/local/` | `LocalFs` (Obsidian Vault API wrapper) plus the raw adapter for dot-prefixed paths. |
-| `fs/googledrive/` | The Google Drive backend: `GoogleDriveFs` with metadata cache, the REST v3 `GoogleDriveClient`, server + PKCE auth, the path↔ID `GoogleDriveMetadataCache`, incremental sync (changes.list), resumable upload, remote-vault resolution, the Google Drive types, and the built-in / custom OAuth providers. |
+| `fs/googledrive/` | The Google Drive backend: `GoogleDriveFs` with metadata cache, the REST v3 `GoogleDriveClient`, server + PKCE auth, the path↔ID `GoogleDriveMetadataCache`, incremental sync (changes.list), resumable upload, remote-vault resolution, the Google Drive types, and the built-in (`provider-base.ts`) / custom (`provider-custom.ts`) OAuth providers. |
 | `fs/dropbox/` | The Dropbox backend (App Folder scope): `DropboxFs` with a relative-path-keyed `DropboxMetadataCache`, the HTTP v2 `DropboxClient`, in-plugin Authorization Code + PKCE auth (worker-less), incremental sync (`list_folder/continue` + cursor), and the `"dropbox"` `content_hash` checksum. The vault is addressed solely by its **stable folder id** (`id:<id>/<subpath>` for every operation — no absolute path is stored), so a remote move/rename of the folder keeps syncing with no migration. The current absolute path is re-resolved from the id each cycle (`get_metadata`) only to relativize `list_folder`'s absolute results into vault-relative keys, and for the settings display. |
-| `ui/` | Settings UI: the main settings tab, the backend-connection section, and Google Drive / Dropbox-specific settings. |
+| `fs/onedrive/` | The OneDrive backend (App Folder scope, personal Microsoft accounts): `OneDriveFs` over the Microsoft Graph `OneDriveClient`, in-plugin PKCE auth, incremental sync (delta query), chunked `upload-session.ts`, remote-vault resolution, and the `"quickxor"` QuickXorHash checksum — computed locally (`utils/quickxor.ts`) so cross-side dedup works. |
+| `ui/` | Settings UI: the main settings tab, the backend-connection section, and Google Drive / Dropbox / OneDrive-specific settings and folder-pick modals. |
 | `store/` | IndexedDB plumbing: the `IDBHelper` transaction wrapper, the generic `MetadataStore<T>` file-metadata cache, and `content-codec` (deflate compression for stored 3-way merge base content). |
 | `logging/` | `Logger` — structured log writer (`.airsync/logs/`). |
 | `queue/` | Concurrency primitives: `AsyncPool` (bounded concurrency) and `AsyncMutex`. |
-| `utils/` | Helpers: `sha256()` / `md5()` hashing, path utilities (`getFileExtension`, etc.), and gitignore-style `isIgnored()` pattern matching. |
+| `utils/` | Helpers: `sha256()` / `md5()` hashing, the QuickXorHash implementation (`quickxor.ts`) for OneDrive, path utilities (`getFileExtension`, etc.), gitignore-style `isIgnored()` pattern matching, and line parsing (`parse-lines.ts`). |
 
 ## Layer architecture
 
@@ -79,9 +81,9 @@ One row per directory; see the layer diagram and per-doc references for module d
      └───────────────┬────────────────────┘
                      │
          ┌─────────────────────────────────────┐
-         │             IFileSystem             │
-         │  LocalFs │ GoogleDriveFs │ DropboxFs  │
-         └─────────────────────────────────────┘
+         │                IFileSystem                │
+         │  LocalFs │ GoogleDriveFs │ DropboxFs │ OneDriveFs │
+         └───────────────────────────────────────────┘
 ```
 
 `runSync` early-returns when no remote backend is present, the backend is connecting, or layout is not ready; it serializes via an `AsyncMutex`. A sync arriving while one runs sets a `syncPending` flag and the running cycle re-runs via a `do/while` loop (coalescing). Each cycle retries up to `MAX_RETRIES = 3`: `AuthError` (status 401) and a non-rate-limit HTTP 403 abort the whole sync immediately; HTTP 404 breaks the retry loop without special handling. For 429 or a rate-limit 403 carrying a `Retry-After` header, delay = `retryAfter * 1000` ms; otherwise exponential backoff with jitter = `2^(attempt-1) * 1000 * (0.5 + Math.random())` ms. See [docs/error-handling.md](docs/error-handling.md) for the full classification/recovery table.
@@ -91,17 +93,23 @@ One row per directory; see the layer diagram and per-doc references for module d
 ### FileEntity (fs/types.ts)
 
 ```typescript
+type ChecksumAlgo = "md5" | "sha1" | "sha256" | "dropbox" | "quickxor" | "opaque";
+interface RemoteChecksum { algo: ChecksumAlgo; value: string; }
+
 interface FileEntity {
   path: string;          // relative path from sync root
   isDirectory: boolean;
   size: number;          // bytes (0 for directories)
   mtime: number;         // Unix epoch ms (0 = unknown)
   hash: string;          // SHA-256 hex ("" = not computed)
+  remoteChecksum?: RemoteChecksum;         // remote-provided checksum, tagged with its algorithm
   backendMeta?: Record<string, unknown>;  // backend-specific, e.g. { googleDriveId } (Google Drive) or { dropboxId, rev } (Dropbox)
 }
 ```
 
 Invariant: mtime/hash comparisons must treat sentinels as "no data" — mtime 0 is not the epoch, and hash is always `""` for directories. `hasChanged`/`hasRemoteChanged` only use mtime when both values are > 0.
+
+`remoteChecksum` carries a remote-supplied content checksum when the backend returns `hash: ""`. It powers temporal change detection (remote-now vs last-sync) and, when the algo is locally reproducible (everything except `"opaque"`), cross-side dedup: Google Drive uses `"md5"`, Dropbox its block-based `"dropbox"` `content_hash`, OneDrive Microsoft's `"quickxor"`, and a pCloud-style opaque hash is `"opaque"`.
 
 ### SyncRecord (sync/types.ts)
 
@@ -115,6 +123,7 @@ interface SyncRecord {
   remoteMtime: number;     // remote mtime at last sync
   localSize: number;
   remoteSize: number;
+  remoteChecksum?: RemoteChecksum;  // remote checksum at last sync (for change detection)
   backendMeta?: Record<string, unknown>;
   syncedAt: number;        // when this sync completed
 }
@@ -177,7 +186,7 @@ interface SyncPlan {
 type SyncStatus = "idle" | "syncing" | "error" | "partial_error" | "not_connected";
 
 // User-facing conflict resolution strategy (settings.conflictStrategy)
-type ConflictStrategy = "auto_merge" | "duplicate" | "ask";
+type ConflictStrategy = "auto_merge" | "duplicate";
 
 // Source/destination path pair for rename detection (also used by IFileSystem.getChangedPaths)
 interface RenamePair {
@@ -212,12 +221,22 @@ interface IFileSystem {
   listDir(path: string): Promise<FileEntity[]>;
   delete(path: string): Promise<void>;
   rename(oldPath: string, newPath: string): Promise<void>;
-  getChangedPaths?(): Promise<{
+  checkpoint?: IncrementalCheckpoint;  // present only for backends with incremental sync
+  close?(): Promise<void>;
+}
+
+// A backend's incremental-sync capability — all-or-nothing. A backend that can
+// detect deltas MUST expose the full crash-safe checkpoint lifecycle, so the four
+// methods travel together on one object (ADR 0001).
+interface IncrementalCheckpoint {
+  getChangedPaths(): Promise<{
     modified: string[];
     deleted: string[];
     renamed?: RenamePair[];  // RenamePair = { oldPath, newPath, isFolder? }
   } | null>;
-  close?(): Promise<void>;
+  hasCheckpoint(): Promise<boolean>;   // committed delta cursor present? false ⇒ force a cold reconcile
+  resetCheckpoint(): Promise<void>;    // discard cursor + derived cache (used by Rescan)
+  commitCheckpoint(): Promise<void>;   // atomically flush cursor + cache, ONLY after a fully-successful cycle
 }
 ```
 
@@ -225,7 +244,7 @@ Key design points:
 
 - `list()` may return `hash: ""` for performance; use `stat()` when an accurate hash is needed. `LocalFs.stat()` is authoritative: on a vault-index miss it falls back to the filesystem adapter, so a not-yet-indexed file on disk is never reported absent (absence drives deletions).
 - **Dot-prefixed (hidden) paths bypass the indexed Vault API.** Obsidian's vault index excludes any hidden path (`.airsync`, `.obsidian`, nested `foo/.bar`), so `getAbstractFileByPath()` returns `null` and `vault.createBinary()` either returns `null` (→ NPE on `.stat`) or throws `File already exists`. `LocalFs` therefore routes every operation on a dot-prefixed path (`isDotPrefixed()`, `utils/path.ts`) through `DotPathAdapter` (the raw `vault.adapter`, which overwrites and is index-independent). This is a **mechanism** decision (which API to use) and is independent of sync **policy** (whether to sync it) — policy is `syncDotPaths` + `ignorePatterns`, enforced separately by `SyncOrchestrator.isExcluded()`. `list()` only enumerates hidden paths under configured `syncDotPaths` roots (it cannot scan every hidden folder, e.g. `.obsidian`), so a hidden path is synced only when opted in. `isExcluded()` also drops OS-generated junk (`desktop.ini`, `thumbs.db`, `.DS_Store` — `isSystemJunkFile()`) unconditionally on every backend, like the reserved metadata path: these are never worth syncing and some backends (Dropbox) reject them outright, which would otherwise fail every cycle and block the delta checkpoint.
-- `getChangedPaths()` is optional and should be called before `list()`. When implemented (e.g. Google Drive `changes.list`, Dropbox `list_folder/continue`) it supplies the remote-side changed/deleted/renamed paths consumed by both hot and warm change detection (the hot path is triggered by the local change tracker's dirty paths, not by this method). The `renamed` field lets backends report file moves for native rename optimization.
+- `checkpoint` is optional; when present, `checkpoint.getChangedPaths()` should be called before `list()`. When implemented (e.g. Google Drive `changes.list`, Dropbox `list_folder/continue`, OneDrive delta query) it supplies the remote-side changed/deleted/renamed paths consumed by both hot and warm change detection (the hot path is triggered by the local change tracker's dirty paths, not by this method). The `renamed` field lets backends report file moves for native rename optimization. The rest of the capability (`hasCheckpoint`/`resetCheckpoint`/`commitCheckpoint`) makes the delta cursor crash-safe — see the checkpoint lifecycle below.
 - `delete()` is idempotent (deleting a non-existent path is a no-op) and backends may use soft deletion (trash). Deleting a directory removes its children recursively; the caller must separately clean up the SyncRecord for each removed child path (`delete()` does not touch sync state).
 - `write()` auto-creates parent directories.
 - `rename(oldPath, newPath)` throws if `oldPath` does not exist or if `newPath` already exists (the rename optimizer relies on the latter to skip occupied destinations); it auto-creates parent directories. `mkdir()` is idempotent and throws if an intermediate component is an existing file.
@@ -238,30 +257,36 @@ Abstraction for a remote storage backend. main.ts and sync/ never import backend
 
 ```typescript
 interface IBackendProvider {
-  readonly type: string;             // "googledrive", "googledrive-custom", "dropbox". Stable, unique registry key;
+  readonly type: string;             // "googledrive", "googledrive-custom", "dropbox", "onedrive". Stable, unique registry key;
                                      // also indexes settings.backendData and per-backend secrets. Immutable once published.
   readonly displayName: string;
   readonly auth: IAuthProvider;
   createFs(app, settings, logger?): IFileSystem | null;
   isConnected(settings): boolean;
   getIdentity(settings): string | null;
-  resetTargetState?(settings): void;
-  hasCheckpoint?(settings): boolean;       // is a committed delta cursor present? false ⇒ force a cold reconcile
-  readBackendState?(fs, commitCheckpoint): Record<string, unknown>;  // advance the cursor only when commitCheckpoint (failed === 0)
+  createSettingsRenderer?(): IBackendSettingsRenderer;   // the backend's own settings-UI renderer (registry is the source of truth)
+  classifyError?(err): ErrorClassification;              // map this backend's I/O errors to a retry-policy kind
+  readBackendState?(): Record<string, unknown>;          // non-secret provider/auth state to persist in backendData (no FS arg)
   resolveRemoteVault?(app, settings, vaultName, logger?): Promise<RemoteVaultResolution>;  // find/create the default vault folder
-  startWebFolderPick?(settings): Promise<Record<string, unknown>>;            // open the web folder picker (Google Picker); OneDrive/Dropbox use an in-app modal instead
-  completeWebFolderPick?(params, settings, logger?): Promise<RemoteVaultResolution>;  // bind the picked folder (by id)
+  picker?: WebFolderPicker;          // web-hosted folder-pick flow (Google Picker); Dropbox/OneDrive pick in an in-app modal instead
   getRemoteVaultDisplayPath?(settings, logger?): Promise<string | null>;      // resolve the bound folder's path for settings
-  clearPluginSecrets?(): void;       // sweep this backend's plugin-owned secrets (used by the backend-switch reset)
+  clearCheckpointStore?(settings): Promise<void>;        // clear the per-target IndexedDB checkpoint without needing a live FS
   disconnect(settings): Promise<Record<string, unknown>>;
+  clearPluginSecrets?(): void;       // sweep this backend's plugin-owned secrets (used by the backend-switch reset)
+}
+
+// The web-hosted folder pick is one object so a backend can't ship half of it.
+interface WebFolderPicker {
+  startWebFolderPick(settings): Promise<Record<string, unknown>>;             // open the web picker; selection returns via an obsidian:// deep link
+  completeWebFolderPick(params, settings, logger?): Promise<RemoteVaultResolution>;  // bind the picked folder (by id)
 }
 ```
 
-`hasCheckpoint`/`readBackendState` together make the remote delta cursor crash-safe: the cursor is committed to `settings.backendData` only after a fully-successful cycle, and when no checkpoint is committed (`hasCheckpoint === false`: first sync, an interrupted/partial sync, or after a manual rescan) the orchestrator forces a full cold reconcile — delta detection alone can't surface remote files an interrupted sync left un-baselined.
+The remote delta cursor is crash-safe at the **filesystem** layer, not the provider (it moved there with ADR 0001): `IFileSystem.checkpoint` commits the cursor plus its derived cache to the backend's own IndexedDB store atomically, and only after a fully-successful cycle. When no checkpoint is committed (`checkpoint.hasCheckpoint() === false`: first sync, an interrupted/partial sync, or after a manual rescan) the orchestrator forces a full cold reconcile — delta detection alone can't surface remote files an interrupted sync left un-baselined. `readBackendState()` persists only non-secret provider/auth state (e.g. token expiry) to `settings.backendData`; it no longer carries the cursor, so it takes no FS argument.
 
 `settings.backendData` is a single flat bag holding **only the active backend's** parameters (tokens live in `SecretStorage`, keyed per backend — never in `backendData`). Switching backends hard-resets it: all params are wiped and every registered backend's plugin-owned secrets are swept (`clearPluginSecrets`), so the new backend starts disconnected and can't reuse another's token under the wrong OAuth client.
 
-Remote-vault binding is **explicit**, not automatic on connect. After auth the user either binds the convention folder `obsidian-air-sync/<Vault Name>` (`BackendManager.bindDefaultRemoteVault` → `resolveRemoteVault`, which find-or-creates it and migrates a legacy `obsidian-air-sync/<uuid>` vault if one matches) or picks any folder via the web Google Picker (`startWebFolderPick` → `completeWebFolderPick`, bound by id). The folder is the sole binding; there is no `.airsync/metadata.json`. See [docs/google-drive-backend.md](docs/google-drive-backend.md) for the Google Drive specifics.
+Remote-vault binding is **explicit**, not automatic on connect. After auth the user either binds the convention folder `obsidian-air-sync/<Vault Name>` (`BackendManager.bindDefaultRemoteVault` → `resolveRemoteVault`, which find-or-creates it and migrates a legacy `obsidian-air-sync/<uuid>` vault if one matches) or picks any folder via the web Google Picker (`provider.picker`: `startWebFolderPick` → `completeWebFolderPick`, bound by id; Dropbox and OneDrive use an in-app modal instead). The folder is the sole binding; there is no `.airsync/metadata.json`. See [docs/google-drive-backend.md](docs/google-drive-backend.md) for the Google Drive specifics.
 
 ### IAuthProvider (fs/auth.ts)
 
@@ -273,7 +298,7 @@ interface IAuthProvider {
 }
 ```
 
-The provider registry (`fs/registry.ts`) maps backend types to provider instances. New backends register here; no changes needed elsewhere. `initRegistry(secretStore)` must be called once during plugin load (`main.ts` onload) before any `getBackendProvider` call; it injects `ISecretStore` into the provider constructors. Until then the registry is empty and `getBackendProvider` returns undefined. Built-in providers: `GoogleDriveProvider` (type `googledrive`), `GoogleDriveCustomProvider` (type `googledrive-custom`), and `DropboxProvider` (type `dropbox`). On a duplicate `type`, the first registration wins (later ones are skipped in the type lookup).
+The provider registry (`fs/registry.ts`) maps backend types to provider instances. New backends register here; no changes needed elsewhere. `initRegistry(secretStore)` must be called once during plugin load (`main.ts` onload) before any `getBackendProvider` call; it injects `ISecretStore` into the provider constructors. Until then the registry is empty and `getBackendProvider` returns undefined. Built-in providers: `GoogleDriveProvider` (type `googledrive`), `GoogleDriveCustomProvider` (type `googledrive-custom`), `DropboxProvider` (type `dropbox`), and `OneDriveProvider` (type `onedrive`). On a duplicate `type`, the first registration wins (later ones are skipped in the type lookup).
 
 ## Detailed documentation
 
@@ -281,5 +306,6 @@ The provider registry (`fs/registry.ts`) maps backend types to provider instance
 - [Conflict resolution](docs/conflict-resolution.md) -- strategies, 3-way merge, conflict history
 - [Google Drive backend](docs/google-drive-backend.md) -- metadata cache, authentication, and the sole owner of incremental sync / cache invalidation
 - [Dropbox backend](docs/dropbox-backend.md) -- App Folder scope, id-only addressing, worker-less PKCE auth, in-app folder modal
+- [OneDrive backend](docs/onedrive-backend.md) -- App Folder scope (personal accounts), Microsoft Graph, delta-query incremental sync, locally-computed QuickXorHash, in-app folder modal
 - [Error handling](docs/error-handling.md) -- resilience: error classification, retry, rate limiting (recovery scenarios cross-reference the sync pipeline)
 - [OAuth worker & auth site](https://github.com/takezoh/air-sync-auth) -- server-side Google token exchange plus the static site (privacy/terms, the Google custom-OAuth callback, and the Google Drive Picker page), in the dedicated `air-sync-auth` repo (kept out of this plugin's tree). Dropbox no longer uses this site — its OAuth returns straight to `obsidian://air-sync-auth` and its folder pick is an in-app modal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,13 +20,14 @@ This file is the **agent operating guide** for this repo. Where to look:
 ```bash
 npm install        # Install dependencies
 npm run dev        # Development (watch)
-npm run build      # Production build (tsc -noEmit && esbuild)
+npm run build      # Production build (tsc -noEmit -skipLibCheck && node esbuild.config.mjs production)
 npm test           # vitest
 npm run test:watch # vitest watch
 npm run lint       # eslint --max-warnings 0
-npm run test:e2e   # opt-in e2e vs real Google Drive/Dropbox (creds-gated; NOT in the gate/CI; backends run in parallel — see docs/e2e-testing.md)
+npm run test:e2e   # opt-in e2e vs real Google Drive/Dropbox/OneDrive (creds-gated; NOT in the gate/CI; backends run in parallel — see docs/e2e-testing.md)
 npm run test:e2e:google   # …only Google Drive
 npm run test:e2e:dropbox  # …only Dropbox
+npm run test:e2e:onedrive # …only OneDrive
 ```
 
 ## The gate

--- a/README.md
+++ b/README.md
@@ -40,25 +40,6 @@ The first sync scans your remote folder, so it may take a little while. After th
 |---------|-------------|
 | `Air Sync: Sync now` | Run a sync manually |
 
-## Settings
-
-All settings live under **Settings → Air Sync**.
-
-| Setting | What it does |
-|---------|--------------|
-| Conflict strategy | How to resolve a file changed on two devices at once — **Auto merge** (recommended) or **Always create duplicate**. See [Conflict resolution strategies](#conflict-resolution-strategies). |
-| Remote backend | Which cloud service to sync with. Shown only when more than one backend is available. |
-| Rescan vault | Discards the remote sync checkpoint and fully reconciles on the next sync. Use it if sync seems stuck after an interruption (see Troubleshooting). |
-| Dot-prefixed paths to sync | Dot-prefixed folders to include in sync (e.g. `.templates`), one per line. |
-| Ignore patterns | Gitignore-style patterns to exclude from sync (e.g. `*.zip`, `large-assets/**`), one per line. |
-| Mobile max file size (MB) | Files larger than this are skipped on mobile. Default `10`. |
-| Keep screen awake during sync | Mobile only — prevents the screen from sleeping mid-sync so long syncs aren't interrupted. Default off. |
-| Show sync notifications | Show a brief notice summarizing each completed sync. Default off. |
-| Enable logging | Write sync logs to `.airsync/` in your vault for debugging. Default off. |
-| Log level | Minimum level of messages to log (Debug / Info / Warn / Error). Default Info. |
-
-> Auto merge uses a 3-way merge for text files; it is always on as part of the Auto-merge strategy and has no separate toggle.
-
 ---
 
 ## Advanced

--- a/README.md
+++ b/README.md
@@ -40,6 +40,25 @@ The first sync scans your remote folder, so it may take a little while. After th
 |---------|-------------|
 | `Air Sync: Sync now` | Run a sync manually |
 
+## Settings
+
+All settings live under **Settings → Air Sync**.
+
+| Setting | What it does |
+|---------|--------------|
+| Conflict strategy | How to resolve a file changed on two devices at once — **Auto merge** (recommended) or **Always create duplicate**. See [Conflict resolution strategies](#conflict-resolution-strategies). |
+| Remote backend | Which cloud service to sync with. Shown only when more than one backend is available. |
+| Rescan vault | Discards the remote sync checkpoint and fully reconciles on the next sync. Use it if sync seems stuck after an interruption (see Troubleshooting). |
+| Dot-prefixed paths to sync | Dot-prefixed folders to include in sync (e.g. `.templates`), one per line. |
+| Ignore patterns | Gitignore-style patterns to exclude from sync (e.g. `*.zip`, `large-assets/**`), one per line. |
+| Mobile max file size (MB) | Files larger than this are skipped on mobile. Default `10`. |
+| Keep screen awake during sync | Mobile only — prevents the screen from sleeping mid-sync so long syncs aren't interrupted. Default off. |
+| Show sync notifications | Show a brief notice summarizing each completed sync. Default off. |
+| Enable logging | Write sync logs to `.airsync/` in your vault for debugging. Default off. |
+| Log level | Minimum level of messages to log (Debug / Info / Warn / Error). Default Info. |
+
+> Auto merge uses a 3-way merge for text files; it is always on as part of the Auto-merge strategy and has no separate toggle.
+
 ---
 
 ## Advanced

--- a/docs/code-enforcement.md
+++ b/docs/code-enforcement.md
@@ -110,9 +110,12 @@ Each file owns one concept; oversized files signal a missing split.
 | **How** | `max-lines` (error) on `src/**/*.ts`; tests, mocks, and `test-helpers.ts` are exempt |
 | **Exception** | Split the module. Do **not** raise the cap |
 
-Three modules are grandfathered above the cap as known debt, each **pinned at its
-current size** so it cannot grow: `fs/googledrive/index.ts` (397), `fs/googledrive/auth.ts`
-(337), `sync/orchestrator.ts` (332). Ratchet these down by splitting; never raise them.
+Two modules are grandfathered above the cap as known debt, each **pinned at its
+current size** so it cannot grow: `fs/googledrive/auth.ts` (337) and
+`sync/orchestrator.ts` (332). Ratchet these down by splitting; never raise them.
+(`fs/googledrive/index.ts` was grandfathered here at 397; ADR 0001 lifted its
+cache/checkpoint machinery into `fs/caching/`, dropping it back under the 300 cap,
+so it is no longer grandfathered.)
 
 ## 7. Vault-index read centralization
 

--- a/docs/conflict-resolution.md
+++ b/docs/conflict-resolution.md
@@ -99,7 +99,7 @@ These are not exposed in the settings UI. Internally, `keep_newer` delegates the
 
 `ConflictHistory` (`conflict-history.ts`) is an audit-log writer for conflict resolutions, targeting `.airsync/conflicts/{device}.json`.
 
-> NOTE: as of this writing it is not yet wired into the sync pipeline — no production code constructs `ConflictRecord`s or calls `append()`; only its unit test exercises it. The shape below is the *intended* contract.
+It is wired into the sync pipeline via the orchestrator's `recordConflicts` hook: `main.ts` passes `recordConflicts: (records) => this.conflictHistory.append(records)` into `SyncOrchestrator`, so each resolved conflict is appended as a `ConflictRecord`.
 
 ```typescript
 interface ConflictRecord {

--- a/docs/google-drive-backend.md
+++ b/docs/google-drive-backend.md
@@ -85,7 +85,7 @@ The 410 fallback triggers `fullScanWithDelta()` which compares persisted metadat
 
 `GoogleDriveClient` (`client.ts`) wraps the Google Drive REST API v3 using Obsidian's `requestUrl` (CORS-free via Electron's net module).
 
-**Requested fields** (`FILE_FIELDS`): `id, name, mimeType, size, modifiedTime, parents, md5Checksum`
+**Requested fields** (`FILE_FIELDS`): `id, name, mimeType, size, modifiedTime, parents, md5Checksum, trashed` (`trashed` is requested so soft-deleted files can be detected and treated as removed)
 
 Key methods:
 


### PR DESCRIPTION
## Summary

This PR adds OneDrive as a third cloud backend (alongside Google Drive and Dropbox) and refactors the incremental-sync checkpoint machinery into a shared `fs/caching/` layer that all id-addressed backends can build on. It also introduces a `RemoteChecksum` type to support multiple checksum algorithms across backends and updates the conflict-resolution UI to remove the unused "ask" strategy.

## Key Changes

**New OneDrive Backend**
- Added `fs/onedrive/` with `OneDriveFs`, `OneDriveClient` (Microsoft Graph), in-plugin PKCE auth, delta-query incremental sync, and chunked upload support
- Implements locally-computed QuickXorHash (`utils/quickxor.ts`) for cross-side dedup
- Registered as `OneDriveProvider` (type `"onedrive"`) in the provider registry
- Includes in-app folder-pick modal (like Dropbox)

**Refactored Incremental Sync (ADR 0001)**
- Extracted shared checkpoint lifecycle into `fs/caching/` layer: `CachingRemoteFs<T>` (path↔id resolution, `IncrementalCheckpoint` lifecycle) and `AbstractMetadataCache<T>`
- Moved checkpoint state from `IBackendProvider` to `IFileSystem.checkpoint?: IncrementalCheckpoint` — the filesystem now owns the crash-safe cursor
- `IncrementalCheckpoint` bundles four methods (`getChangedPaths`, `hasCheckpoint`, `resetCheckpoint`, `commitCheckpoint`) as an all-or-nothing capability
- Google Drive and Dropbox now build on `CachingRemoteFs<T>`, reducing duplication
- Dropped `fs/googledrive/index.ts` back under the 300-line cap by lifting cache/checkpoint machinery

**Remote Checksum Support**
- Added `RemoteChecksum` type with algorithm tag (`"md5"` | `"sha1"` | `"sha256"` | `"dropbox"` | `"quickxor"` | `"opaque"`)
- `FileEntity.remoteChecksum` carries backend-supplied checksums when `hash: ""` for performance
- `SyncRecord.remoteChecksum` stores the checksum at last sync for temporal change detection
- Powers cross-side dedup when the algo is locally reproducible

**Interface & Type Updates**
- `IBackendProvider`: moved checkpoint methods to `IFileSystem`, added `createSettingsRenderer()`, `classifyError()`, `clearCheckpointStore()`, and `picker?: WebFolderPicker`
- `WebFolderPicker` interface extracted for web-hosted folder pick (Google Picker only; Dropbox/OneDrive use in-app modals)
- `ConflictStrategy` type narrowed to `"auto_merge" | "duplicate"` (removed unused `"ask"`)
- `IFileSystem` now includes `checkpoint?: IncrementalCheckpoint` and `close?()`

**Documentation & Settings**
- Updated `ARCHITECTURE.md` with OneDrive module description, new caching layer, and refactored interface contracts
- Added OneDrive backend documentation reference (`docs/onedrive-backend.md`)
- Expanded `README.md` Settings section with all user-facing options and conflict-resolution strategies
- Updated `CLAUDE.md` with OneDrive e2e test commands
- Updated `docs/code-enforcement.md` to reflect `fs/googledrive/index.ts` no longer being grandfathered
- Wired `ConflictHistory` into the sync pipeline via `recordConflicts` hook in `SyncOrchestrator`
- Updated Google Drive client to request `trashed` field for soft-delete detection

## Notable Implementation Details

- The checkpoint lifecycle is now **filesystem-owned** and committed atomically to the backend's IndexedDB store, not persisted in `settings.backendData` — this makes it crash-safe and independent of settings serialization
- `readBackendState()` no longer takes an FS argument and carries only non-secret provider/auth state (e.g. token expiry)
- Settings normalization (`

https://claude.ai/code/session_015cN8xewikKLhuhNhxoCMUU