### PR TITLE
Document why focus and visibilitychange events are both wired

### DIFF
--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -77,6 +77,16 @@ export class SyncScheduler {
 		void this.deps.orchestrator.runSync();
 	}
 
+	// `focus` and `visibilitychange` are deliberately BOTH wired on every
+	// platform — they are not redundant. `focus` is the only signal for a
+	// desktop app-to-app switch (alt-tab): Electron keeps the document
+	// `visible` in the background, so visibilitychange never fires. On mobile
+	// webviews window focus is unreliable on resume, so visibilitychange is the
+	// dependable foreground signal. Each covers a case the other misses, so
+	// dropping or platform-gating either one would lose a resume sync somewhere.
+	// The cost — a single resume firing both — is absorbed downstream: the
+	// `isSyncing()` guard in triggerSync, then runSync coalescing into one
+	// burst, then CycleSummary collapsing it to one notice (see commit 884b948).
 	private wireFocusEvent(): void {
 		this.deps.registerWindowEvent("focus", () => this.triggerSync());
 	}
@@ -117,6 +127,7 @@ export class SyncScheduler {
 		this.deps.registerWindowEvent("online", () => this.triggerSync());
 	}
 
+	// Paired with wireFocusEvent above (see that comment for why both exist).
 	private wireVisibilityEvent(): void {
 		this.deps.registerDocumentEvent("visibilitychange", () => {
 			// App-level visibility: read the main document (matching the focus/


### PR DESCRIPTION
## Summary

Added detailed comments explaining the rationale for wiring both `focus` and `visibilitychange` events on all platforms, rather than treating them as redundant or platform-gating either one.

## Key Changes

- Added comprehensive comment block to `wireFocusEvent()` explaining:
  - `focus` is the only signal for desktop app-to-app switches (alt-tab) in Electron, since the document remains `visible` in the background
  - `visibilitychange` is the dependable foreground signal on mobile webviews, where window focus is unreliable on resume
  - Each event covers a case the other misses, so dropping either would lose a resume sync somewhere
  - Downstream guards (`isSyncing()` in `triggerSync`, `runSync` coalescing, `CycleSummary` collapsing) absorb the cost of both firing on resume

- Added paired comment to `wireVisibilityEvent()` cross-referencing the explanation above

## Implementation Details

These comments document existing behavior and design decisions (referencing commit 884b948 for the downstream coalescing logic). No functional changes to the sync scheduler itself — this is purely documentation to prevent future maintainers from "optimizing" away either event handler based on incomplete understanding of platform differences.

https://claude.ai/code/session_0116sthq7AfDxs4rhEYnjUXU