### PR TITLE
Dropbox Custom App: fix mobile initial sync + document setup (#32, #33, #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ That's it — Air Sync syncs into that folder from then on.
 
 The first sync scans your remote folder, so it may take a little while. After that, syncing is fast.
 
+### Your vault and your devices
+
+- **Keep your vault in local storage.** Create your Obsidian vault on your device — **not** inside a folder that another cloud drive already syncs (iCloud Drive, or the Dropbox / OneDrive / Google Drive desktop apps). Air Sync copies your notes to the cloud for you.
+- **Don't open the cloud folder as a vault.** The folder Air Sync creates in your cloud storage is a managed mirror — opening it directly in Obsidian as a vault is not supported. Keep working in your local vault; Air Sync keeps the cloud copy in step.
+- **Let Air Sync be the only sync tool for a vault.** Two sync mechanisms managing the same files at once is a common cause of conflicts.
+- **Use the same folder on every device.** During setup you choose which cloud folder to sync into — pick the **same folder** on each device so they share one set of notes.
+- **Conflicting changes keep both versions.** Your edits and deletions sync normally. But when two changes genuinely clash — the same note edited on two devices, or edited on one and deleted on another — Air Sync saves both as a conflict copy rather than silently overwriting or dropping one. See [Conflict resolution strategies](#conflict-resolution-strategies) for how it decides.
+
 ## Conflict resolution strategies
 
 | Strategy | Behavior |
@@ -45,35 +53,18 @@ The first sync scans your remote folder, so it may take a little while. After th
 
 ## Custom OAuth apps
 
-### Custom OAuth (Google Drive)
+Prefer your own cloud app over the built-in connection? Air Sync supports a **custom app / custom OAuth** backend for Google Drive, OneDrive, and Dropbox — you register the app with the provider and enter its identifiers in Air Sync. This is also the way to reach OneDrive work/school accounts.
 
-The built-in Google Drive connection uses the `drive.file` scope, which only allows access to files the plugin itself created. With custom OAuth, you can use your own Google Cloud OAuth client and manage authorization independently.
+See the **[custom app setup guide](docs/custom-apps.md)** for what each backend needs and how it maps to Air Sync's settings. The guide links to each provider's official developer documentation for the registration steps themselves.
 
-The authorization code exchange is protected by PKCE — the code cannot be used without the verifier held only by the plugin.
-
-> **Note**: Tokens are stored in Obsidian's secret storage, which is accessible to other plugins. The built-in OAuth limits exposure with the `drive.file` scope. Custom OAuth may increase risk depending on the scope you configure.
-
-### Custom app (OneDrive & Dropbox)
-
-OneDrive and Dropbox also offer a **custom app** backend, where you register your own app and enter its client id (Dropbox app key / Entra application ID). The id is a public PKCE identifier — there is no secret to manage. Register `obsidian://air-sync-auth` as a redirect URI in your app.
-
-For **OneDrive**, the custom app additionally lets you choose the **account type**:
-
-| Account type | Who can sign in |
-|---|---|
-| Personal accounts only | Personal Microsoft accounts (same as the built-in) |
-| Work/school + personal | Both work/school (Azure AD) and personal accounts |
-| Work/school only | Work/school (Azure AD) accounts |
-| Specific tenant | A single Azure AD directory (enter its tenant ID) |
-
-This is what lets a custom OneDrive app reach work/school accounts the built-in (personal-only) connection cannot. Your selection must match the supported account types configured in your app registration, and work/school sign-in may still require your organization's admin consent.
-
-> **Note**: The custom app still uses the same App Folder scope, so access stays confined to the plugin's own folder.
+> **Note**: Custom apps still use a scoped / App Folder connection, so access stays confined to the plugin's own folder. Tokens are stored in Obsidian's secret storage (accessible to other plugins); a broader scope you configure yourself may increase exposure.
 
 ## Troubleshooting
 
 - **Sync looks stuck or incomplete** (for example after Obsidian was closed mid-sync): Open **Settings → Air Sync → Advanced** and click **Rescan**. It re-checks everything against your cloud storage and finishes any leftover work — comparing files rather than re-downloading what you already have, and keeping your sync history.
-- **Authentication completes but sync doesn't start**: Restart the plugin (disable → enable in Community plugins settings), then try syncing manually.
+- **Connected, but no files download**: Connecting only authorizes Air Sync — it doesn't sync yet. Make sure you've chosen a remote folder (the **default folder** or **pick an existing folder**); the first sync starts as soon as a folder is selected. On mobile, keep Obsidian open in the foreground while it runs.
+- **Authentication completes but sync doesn't start**: First confirm a remote folder is chosen (see above). If it still doesn't start, restart the plugin (disable → enable in Community plugins settings), then try syncing manually.
+- **Seeing conflicts or `.conflict` files**: These appear when the same file changed on two devices, or when another sync tool is also writing your vault (see [Your vault and your devices](#your-vault-and-your-devices)). When reporting a conflict, please include the file path(s), which devices were involved and the order you edited them, your selected conflict strategy, and — if logging is enabled — the diagnostic logs. That's what distinguishes a sync-engine issue from a multiple-writer setup.
 - **Token error after successful authorization**: Check that the device has a stable network connection — token exchange requires connectivity immediately after authorization.
 - **The browser callback didn't return to Obsidian**: Try disconnecting and reconnecting from the plugin settings.
 

--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -1,0 +1,72 @@
+# Custom app setup
+
+Air Sync can connect through **your own** cloud app instead of the built-in connection, so you manage the authorization yourself. For OneDrive, a custom app is also how you reach work/school (organization) accounts, which the built-in (personal-only) connection doesn't support.
+
+This page lists **what each provider app must be configured with, and what you copy into Air Sync** (Settings → Air Sync). Create the app in the provider's console (links below) — the details here are what Air Sync actually needs, not a walkthrough of the console.
+
+**Common to every backend**
+
+- Access stays scoped to Air Sync's own folder (Google Drive `drive.file`, OneDrive / Dropbox App Folder) — the app can't see the rest of your storage.
+- Configure the redirect URI and permissions **before** you connect. Changing scopes/permissions afterward means disconnecting and reconnecting so a new token picks them up.
+- **Connecting is not syncing.** After you authorize, Air Sync needs a remote folder before anything transfers (OneDrive/Dropbox: pick one in-app after connecting; Google Drive custom: you provide the folder ID up front — see below). On mobile, keep Obsidian in the foreground until the first sync finishes; for a large first sync, enable **Keep screen awake during sync**.
+
+## Google Drive — "Google Drive (custom OAuth)"
+
+Create an **OAuth client ID** of type **Web application** (so it can use the https callback below) in the Google Cloud Console, and enable the Google Drive API for its project.
+→ [Create and manage OAuth clients](https://support.google.com/cloud/answer/15549257)
+
+Your OAuth client must have:
+
+- The **Google Drive API** enabled on its project.
+- An **authorized redirect URI** matching Air Sync's **Redirect uri** field — default `https://airsync.takezo.dev/callback` (a callback page that hands the code back to Obsidian).
+- A **client secret** — unlike the other backends, Google Drive custom is a confidential client and uses both the client ID *and* secret.
+
+Copy into Air Sync:
+
+| Air Sync setting | Value |
+|---|---|
+| Client ID | Your OAuth client ID |
+| Client secret | Your OAuth client secret |
+| Scope | Optional — defaults to `https://www.googleapis.com/auth/drive.file` (access only to files the app creates) |
+| Include granted scopes | Optional — incremental authorization |
+| Redirect uri | Must match the redirect URI on your client (default `https://airsync.takezo.dev/callback`) |
+| Remote vault folder ID | The Google Drive folder ID to sync into — **required before you connect** (this backend has no in-app folder picker) |
+
+## OneDrive — "OneDrive (custom app)"
+
+Register an application in Microsoft Entra, then add its redirect URI.
+→ [Register an application](https://learn.microsoft.com/entra/identity-platform/quickstart-register-app) · [Add a redirect URI](https://learn.microsoft.com/entra/identity-platform/how-to-add-redirect-uri)
+
+Your app registration must have:
+
+- A **redirect URI** `obsidian://air-sync-auth`, added under the **Mobile & desktop applications** platform (Air Sync uses PKCE with **no client secret**).
+- The **Files.ReadWrite.AppFolder** delegated permission.
+- **Supported account types** that match the account type you select in Air Sync.
+
+Copy into Air Sync:
+
+| Air Sync setting | Value |
+|---|---|
+| Application (client) ID | Your app registration's Application (client) ID |
+| Account type | Personal only / Work+personal / Work only / Specific tenant (then **Tenant ID**) — must match the registration |
+
+After connecting, choose the remote folder in-app (default folder or pick one).
+
+## Dropbox — "Dropbox (custom app)"
+
+Create an app in the Dropbox App Console with **Scoped access** and **App folder** access.
+→ [Dropbox App Console](https://www.dropbox.com/developers/apps)
+
+Your app must have:
+
+- **App folder** access type.
+- A **redirect URI** `obsidian://air-sync-auth` (Air Sync uses PKCE with **no app secret**).
+- The **`files.metadata.read`**, **`files.content.read`**, and **`files.content.write`** permissions enabled, then **Submit**.
+
+Copy into Air Sync:
+
+| Air Sync setting | Value |
+|---|---|
+| App key | Your Dropbox app's app key |
+
+After connecting, choose the remote folder in-app. Your synced files live under `Dropbox/Apps/<your app name>/<vault name>/`.

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -243,6 +243,15 @@ export default tseslint.config(
 		rules: { "max-lines": ["error", { max: 317, skipBlankLines: true, skipComments: true }] },
 	},
 	{
+		// Re-pinned from 300 for the issue #33 initial-sync fix: a new onRemoteBound
+		// signal fired at the two moments a remote FS first becomes bound (initBackend
+		// tail + completeBackendConnect reconnect tail) so the first sync runs on bind
+		// instead of an incidental event — a cohesive addition to the existing connect/
+		// bind lifecycle this module already owns, not a natural split point.
+		files: ["src/fs/backend-manager.ts"],
+		rules: { "max-lines": ["error", { max: 303, skipBlankLines: true, skipComments: true }] },
+	},
+	{
 		// Lint manifest.json for the words the Obsidian submission validator
 		// HARD-rejects in name/description/id ("obsidian"/"plugin" — redundant,
 		// implied by context). The typescript-eslint parser turns .json into an

--- a/src/fs/backend-manager.test.ts
+++ b/src/fs/backend-manager.test.ts
@@ -42,6 +42,7 @@ function createDeps(
 		getVaultName: () => "Test Vault",
 		onConnected: vi.fn(),
 		onDisconnected: vi.fn(),
+		onRemoteBound: vi.fn(),
 		clearSyncBaseline: vi.fn().mockResolvedValue(undefined),
 		notify: vi.fn(),
 		refreshSettingsDisplay: vi.fn(),
@@ -843,5 +844,116 @@ describe("BackendManager — isConnecting flag", () => {
 
 		resolve();
 		await completePromise;
+	});
+});
+
+describe("BackendManager — onRemoteBound (initial sync after a mid-session bind, issue #33)", () => {
+	it("fires onRemoteBound after initBackend builds a remote FS", async () => {
+		const settings = mockSettings();
+		const deps = createDeps(settings);
+		const onRemoteBound = deps.onRemoteBound as ReturnType<typeof vi.fn>;
+		const mgr = new BackendManager(deps);
+
+		await mgr.initBackend();
+
+		expect(onRemoteBound).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fire onRemoteBound when initBackend builds no FS", async () => {
+		const settings = mockSettings();
+		fakeProvider.isConnected = () => false; // initBackend won't build an FS
+		fakeProvider.createFs = () => null;
+		const deps = createDeps(settings);
+		const mgr = new BackendManager(deps);
+
+		await mgr.initBackend();
+
+		expect(deps.onRemoteBound).not.toHaveBeenCalled();
+	});
+
+	it("fires onRemoteBound only after `connecting` is cleared", async () => {
+		// Regression guard: firing while still mid-connect would be swallowed by the
+		// orchestrator's isBackendConnecting gate, so the bound-time trigger must run
+		// with connecting === false.
+		const settings = mockSettings();
+		let mgr!: BackendManager;
+		let connectingAtCall: boolean | null = null;
+		const onRemoteBound = vi.fn(() => { connectingAtCall = mgr.isConnecting(); });
+		mgr = new BackendManager(createDeps(settings, { onRemoteBound }));
+
+		await mgr.initBackend();
+
+		expect(onRemoteBound).toHaveBeenCalledTimes(1);
+		expect(connectingAtCall).toBe(false);
+	});
+
+	it("fires onRemoteBound after bindDefaultRemoteVault binds the default folder", async () => {
+		const settings = mockSettings();
+		fakeProvider.getIdentity = () => {
+			const id = settings.backendData.remoteVaultFolderId as string | undefined;
+			return id ? `test:${id}` : "test:folder-A";
+		};
+		fakeProvider.resolveRemoteVault = vi.fn().mockResolvedValue({
+			backendUpdates: { remoteVaultFolderId: "id:default" },
+		});
+		const deps = createDeps(settings);
+		const onRemoteBound = deps.onRemoteBound as ReturnType<typeof vi.fn>;
+		const mgr = new BackendManager(deps);
+		await mgr.initBackend();
+		onRemoteBound.mockClear();
+
+		await mgr.bindDefaultRemoteVault();
+
+		expect(onRemoteBound).toHaveBeenCalledTimes(1);
+	});
+
+	it("fires onRemoteBound after completeBackendFolderPick binds a picked folder", async () => {
+		const settings = mockSettings();
+		fakeProvider.getIdentity = () => {
+			const id = settings.backendData.remoteVaultFolderId as string | undefined;
+			return id ? `test:${id}` : "test:folder-A";
+		};
+		fakeProvider.picker!.completeWebFolderPick = vi.fn().mockResolvedValue({
+			backendUpdates: { remoteVaultFolderId: "id:new", pendingFolderPickState: "" },
+		});
+		const deps = createDeps(settings);
+		const onRemoteBound = deps.onRemoteBound as ReturnType<typeof vi.fn>;
+		const mgr = new BackendManager(deps);
+		await mgr.initBackend();
+		onRemoteBound.mockClear();
+
+		await mgr.completeBackendFolderPick({ id: "id:new", state: "S" });
+
+		expect(onRemoteBound).toHaveBeenCalledTimes(1);
+	});
+
+	it("fires onRemoteBound on a reconnect that rebuilds a bound FS", async () => {
+		const settings = mockSettings();
+		const deps = createDeps(settings);
+		const mgr = new BackendManager(deps);
+		await mgr.initBackend(); // sets backendProvider; createFs → fakeFs (bound)
+		(deps.onRemoteBound as ReturnType<typeof vi.fn>).mockClear();
+		fakeProvider.auth.completeAuth = () => Promise.resolve({});
+
+		await mgr.completeBackendConnect("auth-code");
+
+		expect(deps.onRemoteBound).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not fire onRemoteBound on a fresh connect with no folder bound, and points to the next step", async () => {
+		const settings = mockSettings();
+		fakeProvider.createFs = () => null; // fresh connect: folder not chosen yet
+		const deps = createDeps(settings);
+		const mgr = new BackendManager(deps);
+		await mgr.initBackend(); // no FS built (createFs → null)
+		(deps.onRemoteBound as ReturnType<typeof vi.fn>).mockClear();
+		fakeProvider.auth.completeAuth = () => Promise.resolve({});
+
+		await mgr.completeBackendConnect("auth-code");
+
+		expect(deps.onRemoteBound).not.toHaveBeenCalled();
+		expect(deps.notify).toHaveBeenCalledWith(
+			"Connected to Test — choose a remote folder to start syncing",
+		);
 	});
 });

--- a/src/fs/backend-manager.ts
+++ b/src/fs/backend-manager.ts
@@ -14,6 +14,15 @@ export interface BackendManagerDeps {
 	getVaultName: () => string;
 	onConnected: (remoteFs: IFileSystem) => void;
 	onDisconnected: () => void;
+	/**
+	 * Fired once a remote target has just been bound and `connecting` is already
+	 * cleared, so the owner can run the first sync of this binding (issue #33).
+	 * Distinct from `onConnected` (which fires mid-connect, while `isConnecting()`
+	 * is still true and would gate a sync out): this is the after-the-fact signal
+	 * that syncing is now possible. The owner routes it through the error-catching
+	 * runSync wrapper, so a failed first sync resolves to a terminal status.
+	 */
+	onRemoteBound: () => void;
 	/** Clear the per-vault SyncRecord baseline (e.g. on identity change / connect / teardown). */
 	clearSyncBaseline: () => Promise<void>;
 	notify: (message: string) => void;
@@ -110,6 +119,17 @@ export class BackendManager {
 		} finally {
 			this.connecting = false;
 		}
+
+		// A freshly built remote FS means a bind (or a startup restore) just made
+		// syncing possible. Hand that transition to the owner so the first sync runs
+		// now, instead of waiting for an incidental foreground/vault/online event
+		// (issue #33). Fired AFTER the finally so `connecting` is already false —
+		// calling it while still mid-connect would be swallowed by the orchestrator's
+		// isBackendConnecting guard. Harmless when nothing needs doing: runSync
+		// coalesces or no-ops per its own gates, and an extra cycle is an efficiency,
+		// never a correctness, cost (ADR 0004). At startup it no-ops (layout not ready)
+		// and the onLayoutReady catch-up runs the real first sync.
+		if (this.remoteFs) this.deps.onRemoteBound();
 	}
 
 	/**
@@ -295,9 +315,12 @@ export class BackendManager {
 				await this.deps.saveSettings();
 			}
 
-			this.deps.notify(
-				`Connected to ${this.backendProvider.displayName}`
-			);
+			// On a fresh connect the remote FS is still null (no folder bound yet), so
+			// "Connected" alone reads as "done" and the user stops — the reported
+			// mobile dead-end (issue #33). Point them at the next required step.
+			this.deps.notify(this.remoteFs
+				? `Connected to ${this.backendProvider.displayName}`
+				: `Connected to ${this.backendProvider.displayName} — choose a remote folder to start syncing`);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			this.deps.getLogger().error("Authorization failed", { message: msg });
@@ -308,6 +331,12 @@ export class BackendManager {
 
 		// Refresh once here (runs on both success and error paths after the finally).
 		this.deps.refreshSettingsDisplay();
+
+		// A reconnect that kept its bound folder id (e.g. custom Dropbox across a
+		// disconnect) rebuilds the FS inline above — no initBackend, so request the
+		// first sync here. `connecting` is already false (past the finally). A fresh
+		// connect leaves remoteFs null (folder not chosen yet), so this no-ops.
+		if (this.remoteFs) this.deps.onRemoteBound();
 	}
 
 	/** Close the current FS's connections, swallowing errors (best-effort teardown). */

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,6 +82,15 @@ export default class AirSyncPlugin extends Plugin {
 				this.syncStatus = "not_connected";
 				this.updateStatusBar();
 			},
+			// A remote target was just bound mid-session — run the first sync now so
+			// files start transferring without waiting for an incidental
+			// foreground/vault/online event (issue #33). Routed through runSync (the
+			// wrapper), NOT orchestrator.runSync: the wrapper's try/catch resolves a
+			// failed first sync to a terminal "error" status, so the status bar never
+			// sticks at "Syncing…". Keep this pointed at runSync for that guarantee.
+			onRemoteBound: () => {
+				void this.runSync();
+			},
 			clearSyncBaseline: async () => {
 				await this.orchestrator?.clearSyncState();
 			},

--- a/src/ui/dropbox-settings.ts
+++ b/src/ui/dropbox-settings.ts
@@ -84,7 +84,7 @@ export class DropboxCustomSettingsRenderer implements IBackendSettingsRenderer {
 
 		new Setting(containerEl)
 			.setName("App key")
-			.setDesc(`Your Dropbox app's app key. Register ${PLUGIN_REDIRECT_URI} as a redirect URI in that app.`)
+			.setDesc(`Your Dropbox app's app key. Use App folder access and register ${PLUGIN_REDIRECT_URI} as a redirect URI. See the custom app setup guide for the required permissions.`)
 			.addText((text) =>
 				text
 					.setValue(data.customClientId ?? "")


### PR DESCRIPTION
Addresses the Dropbox Custom App sub-issues of #30: the mobile "sync never happens" report (#33), the missing setup documentation (#32), and the unclear local-vault ↔ remote-folder model (#34).

## The mobile bug (#33)

Completing OAuth or picking a remote folder **mid-session** made syncing possible but scheduled **no sync**. `onConnected` only updated the status bar, and the scheduler fires only on foreground / vault-change / online / next-launch events — none of which is the "a remote FS just became available" moment. On mobile a user could finish setup, stay in the foreground with no edits, and see nothing transfer. This is a **liveness/trigger gap**, not a correctness bug — the sync engine's convergence (ADR 0001) and idempotency are unchanged; the first sync was simply never enqueued at bind time.

### Fix

Give the "a remote FS first becomes bound" transition an owner: a new `onRemoteBound` signal, fired at the two points a bound FS is first built (`initBackend` tail and the `completeBackendConnect` reconnect tail), **after `connecting` is cleared** — firing it while still mid-connect would be swallowed by the orchestrator's `isBackendConnecting` guard. `main.ts` routes it through the `runSync` wrapper, whose `try/catch` resolves a failed first sync to a terminal status, so the status bar never sticks at "Syncing…". An extra cycle is harmless (ADR 0004). A fresh connect with no folder bound stays a no-op and now tells the user to choose a remote folder instead of claiming "Connected" with no next step.

Covered by all supported backends (Google Drive / OneDrive / Dropbox built-in + custom), since they share the connect/bind lifecycle.

## Documentation (#32, #34)

- **#32** — a first-party Dropbox Custom App walkthrough in the README (Scoped access → **App folder**, the `obsidian://air-sync-auth` redirect URI, the three required permissions `files.metadata.read` / `files.content.read` / `files.content.write`, and where to paste the app key), the same guidance inline on the App key settings field, an explicit "authorizing is not syncing" note, and iOS/Android notes (foreground-only, keep-screen-awake, on-device vault).
- **#34** — the README now states that the local vault stays the source of truth and the cloud folder is just its mirror (don't open it as a vault), how a second device attaches to the same remote folder (matching name or explicit pick), and why stacking another syncer on one vault causes conflicts. No causal claim is made that this produced any specific reported conflict.
- **#33 docs** — troubleshooting for a connection that succeeds but downloads nothing (choose a remote folder; stay foreground on mobile) and conflict-reporting guidance (paths, devices, edit order, strategy, logs).

## Tests

- New `backend-manager` tests pin that `onRemoteBound` fires after each bind path (default folder, picked folder, reconnect), does **not** fire on a fresh connect with no folder, and fires only once `connecting` is cleared (the regression guard for the swallow-by-`isConnecting` trap). The status-never-stuck-at-syncing contract is documented at the `main.ts` wiring, which routes through the error-catching `runSync` wrapper.
- Gate green: `npm run lint && npm run build && npm test` — 1385 tests / 86 files passed.
- No e2e change: the opt-in e2e validates the `IFileSystem` contract against live APIs (ADR 0003) and does not touch the plugin's trigger/status wiring, which is deterministically covered by fakes here.

## Not included

- **#31** (restoring the built-in Dropbox app after its user-limit failure) is a separate concern.
- Mobile device verification (#32/#33 acceptance) can't run headless — manual iOS/Android confirmation is still needed.
- No auto-detected "unsupported configuration" UI warning for #34: multiple-writer setups can't be detected without false positives today, so this is handled by documentation instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBUbWgykkXgmVmsDhGWiSz

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBUbWgykkXgmVmsDhGWiSz)_