### PR TITLE
Target public Obsidian 1.12.x: drop the 1.13 dev type dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"fake-indexeddb": "^6.2.5",
 				"globals": "14.0.0",
 				"jiti": "2.6.1",
-				"obsidian": "^1.13.1",
+				"obsidian": "^1.12.3",
 				"tslib": "2.4.0",
 				"typescript": "^5.8.3",
 				"typescript-eslint": "8.35.1",
@@ -5166,9 +5166,9 @@
 			}
 		},
 		"node_modules/obsidian": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.1.tgz",
-			"integrity": "sha512-qtTEA2pmhJzhuhJqzbBFRYhpIOqvW+krDYjtFynv66KbxBbumHBlsJfWw3I4jtnK/6fZwbQhCrmmDdRwXmX56w==",
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"fake-indexeddb": "^6.2.5",
 		"globals": "14.0.0",
 		"jiti": "2.6.1",
-		"obsidian": "^1.13.1",
+		"obsidian": "^1.12.3",
 		"tslib": "2.4.0",
 		"typescript": "^5.8.3",
 		"typescript-eslint": "8.35.1",

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,11 +1,4 @@
-import {
-	App,
-	Notice,
-	Platform,
-	PluginSettingTab,
-	Setting,
-	type SettingDefinitionItem,
-} from "obsidian";
+import { App, Notice, Platform, PluginSettingTab, Setting } from "obsidian";
 import type AirSyncPlugin from "../main";
 import type { ConflictStrategy } from "../sync/types";
 import { getAllBackendProviders, getBackendProvider } from "../fs/registry";
@@ -22,14 +15,16 @@ export class AirSyncSettingTab extends PluginSettingTab {
 		this.plugin = plugin;
 	}
 
-	// Obsidian 1.13+ renders a settings tab from getSettingDefinitions() when it
-	// returns a non-empty array; an empty array (the base default) tells it to use
-	// the imperative display() below instead — the backward-compat path every
-	// pre-1.13 tab relies on. We keep rendering imperatively because the
-	// backend-connection section is drawn by each backend's own renderer, which
-	// doesn't map onto declarative definitions. Defining this method also
-	// satisfies obsidianmd/settings-tab/prefer-setting-definitions.
-	getSettingDefinitions(): SettingDefinitionItem[] {
+	// Declarative settings API (Obsidian 1.13+). We target the current public
+	// release (1.12.x), which predates it, so this returns an empty array: on
+	// 1.13 an empty result makes Obsidian fall back to the imperative display()
+	// below (the same path every pre-1.13 tab uses), and on 1.12.x the method is
+	// simply never called. Its presence satisfies
+	// obsidianmd/settings-tab/prefer-setting-definitions. The return type is left
+	// inferred so this compiles against the 1.12.x types (which lack the
+	// SettingDefinitionItem type) while still overriding cleanly on 1.13. Populate
+	// it with real definitions once 1.13 is public and can be verified live.
+	getSettingDefinitions() {
 		return [];
 	}
 


### PR DESCRIPTION
## Summary
Follow-up to #36. The declarative settings API (`getSettingDefinitions` / `SettingDefinitionItem`) ships only in the **1.13 insider builds** — the current **public** Obsidian release is **1.12.7** (`desktop-releases.json` `latest`; 1.13.x is beta/insider only). This keeps the plugin's tooling aligned with what users actually run, without changing any runtime behavior.

## Changes
- **obsidian dev dependency** reverted `^1.13.1` → `^1.12.3` (the public line). The bundled `main.js` is unaffected — `obsidian` is an external, dev-only type dependency.
- **`getSettingDefinitions()`** no longer annotates its return with the 1.13-only `SettingDefinitionItem` type. The return type is left inferred, so it compiles against the 1.12.x types (which predate the declarative API) while still overriding cleanly on 1.13. It still returns `[]`, which keeps the imperative `display()` as the renderer on every version and satisfies `obsidianmd/settings-tab/prefer-setting-definitions` by presence.

## Not changed
- `minAppVersion` stays `1.11.4`; the imperative renderer, the `createFragment()` fix, and the bot-repro wiring from #36 are untouched.

## Verification
`npm run lint && npm run build && npm test` (1385 tests) and `npm run lint:bot-repro` (installs the latest `eslint-plugin-obsidianmd` — the same ruleset the submission bot uses) are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136CLBxiJYTJiPaUXsjQb9j

---
_Generated by [Claude Code](https://claude.ai/code/session_0136CLBxiJYTJiPaUXsjQb9j)_