### PR TITLE
Prevent destructive sync on ambiguous rename evidence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ main.js
 
 # e2e harness secrets + build artifacts (local-only, never committed)
 .env.e2e
+.env.e2e.authorize-url
 e2e/.bootstrap.bundle.mjs
 
 # obsidian

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,43 +58,35 @@ One row per directory; see the layer diagram and per-doc references for module d
      ┌───────────────▼────────────────────┐
      │            Pipeline                │
      │                                    │
-     │  collectChanges()                  │  ChangeDetector
-     │    collect (hot / warm / cold)     │    temperature modes
-     │    enrichHashesForInitialMatch()   │    local digest vs remoteChecksum
+     │  1 Observe                         │  ChangeDetector
+     │    collectChanges()                │    hot / warm / cold
+     │    observations + identity         │    evidence completion
      │        │                           │
      │        ▼                           │
-     │  projectScope()                    │  ScopeProjection
-     │    classify every evidence endpoint│    direction-aware matrix
+     │  2 Propose                         │  ScopeProjection / DecisionEngine
+     │    projectScope()                  │    classify evidence endpoints
+     │      → planSync()                  │    plain action proposal
+     │      → refinePlan()                │  RenameOptimizer
+     │                                    │    native rename optimization
      │        │                           │
      │        ▼                           │
-     │  planSync()                        │  DecisionEngine
-     │        │                           │    9 action types
-     │        ▼                           │
-     │  refinePlan()                      │  RenameOptimizer
-     │    optimizeLocalFileRenames         │    → rename_remote (hash-verified)
-     │    optimizeRemoteFileRenames        │    → rename_local  (trusted)
+     │  3 Admit                           │  PlanAdmission
+     │    captureCycleAdmissionSnapshot() │    immutable cycle contract
+     │      → admitDestructivePlan()      │    sole destructive authorization owner
+     │      → AuthorizedSyncPlan          │    exhaustive dispositions
      │        │                           │
      │        ▼                           │
-     │  captureCycleAdmissionSnapshot()   │  immutable cycle contract
-     │    proposal/evidence/observations  │    scope + backend/root namespace
-     │        │                           │
-     │        ▼                           │
-     │  admitDestructivePlan()            │  PlanAdmission
-     │    exhaustive dispositions         │    sole destructive authorization owner
-     │    → AuthorizedSyncPlan            │    nominal, proposal-ordered projection
-     │        │                           │
-     │        ▼                           │
-     │  executePlan()  (3 phases)         │  PlanExecutor
+     │  4 Execute                         │  PlanExecutor / StateCommitter
+     │    executePlan()  (3 phases)       │
      │    1 transfers: push/pull          │    AdaptivePool (AIMD); match/cleanup inline
      │    2 conflict (serial)             │    own phase (sibling-path safe)
      │    3 structural: 2 lanes ||        │    remote & local, concurrent
      │      per lane: rename then del     │    rename serial; delete pooled
+     │    commitAction() per success      │    per-path state
      │        │                           │
      │        ▼                           │
-     │  commitAction()  (per action)      │  StateCommitter
-     │        │                           │
-     │        ▼                           │
-     │  finalizeSyncCycle()               │  mechanical disposition/completion fold
+     │  5 Finalize                        │  cycle-level commit boundary
+     │    finalizeSyncCycle()             │    mechanical completion fold
      │    checkpoint, then retirement     │    no safety re-decision
      └───────────────┬────────────────────┘
                      │

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,8 +75,13 @@ One row per directory; see the layer diagram and per-doc references for module d
      │    optimizeRemoteFileRenames        │    → rename_local  (trusted)
      │        │                           │
      │        ▼                           │
+     │  captureCycleAdmissionSnapshot()   │  immutable cycle contract
+     │    proposal/evidence/observations  │    scope + backend/root namespace
+     │        │                           │
+     │        ▼                           │
      │  admitDestructivePlan()            │  PlanAdmission
-     │    defer unsafe identity components│    pure, whole-component, fail-closed
+     │    exhaustive dispositions         │    sole destructive authorization owner
+     │    → AuthorizedSyncPlan            │    nominal, proposal-ordered projection
      │        │                           │
      │        ▼                           │
      │  executePlan()  (3 phases)         │  PlanExecutor
@@ -87,6 +92,10 @@ One row per directory; see the layer diagram and per-doc references for module d
      │        │                           │
      │        ▼                           │
      │  commitAction()  (per action)      │  StateCommitter
+     │        │                           │
+     │        ▼                           │
+     │  finalizeSyncCycle()               │  mechanical disposition/completion fold
+     │    checkpoint, then retirement     │    no safety re-decision
      └───────────────┬────────────────────┘
                      │
          ┌─────────────────────────────────────┐

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,9 +4,9 @@
 
 1. **3-state sync** -- Compare local, remote, and last-sync-record to detect changes. Text conflicts use 3-way merge.
 2. **Swappable backends** -- All remote I/O goes through `IFileSystem` + `IBackendProvider`. Adding a backend requires no changes outside `fs/`.
-3. **Delta-first** -- Only process files that changed. O(n) full scans are allowed only on cold start and crash recovery (when no committed remote checkpoint exists).
+3. **Delta-first** -- Only process files that changed. O(n) full scans are allowed on cold start, same-session recovery, scope change, manual rescan, and unresolved local rename debt.
 4. **Pipeline as data** -- Each sync phase is a pure transformation: `ChangeSet → SyncPlan → Result`. I/O is isolated at boundaries; all intermediate states are testable.
-5. **Crash-safe by construction** -- State is committed only *after* success: per-file baselines after each action, and the remote delta checkpoint only when the whole cycle succeeds (`failed === 0`). An interrupted sync converges by re-syncing — delta-replay from the last committed checkpoint, or a full cold reconcile when none is committed.
+5. **Crash-safe by construction** -- State is committed only *after* success: per-file baselines after each admitted action, and the remote delta checkpoint only when no failure/deferral or unresolved remote identity edge remains. An interrupted sync converges by checkpoint replay or COLD reconcile; unresolved local rename edges additionally survive as bounded namespace debt.
 6. **Duplicate over delete** -- When in doubt, keep the file. Deleting an unwanted copy is easy; recovering a lost file is impossible.
 7. **Single responsibility per module** -- Each file owns one concept. Target 200-300 lines; split when exceeded.
 
@@ -19,7 +19,7 @@ One row per directory; see the layer diagram and per-doc references for module d
 | `main.ts` | Plugin entry point — lifecycle only: load settings, register commands, wire components, handle the OAuth protocol callback. |
 | `settings.ts` | `AirSyncSettings` type and `DEFAULT_SETTINGS`; `settings-normalize.ts` lifts a legacy per-type `backendData` map into the active flat bag on load. |
 | `config-sync.ts` | Experimental config-directory sync: augments `syncDotPaths`/`ignorePatterns` with the vault's config directory and a built-in pattern set when `enableConfigSync` is on, and `isOwnPluginDataPath()` — the unconditional guard `SyncOrchestrator.isExcluded()` uses to keep this plugin's own settings file from ever syncing. |
-| `sync/` | The sync pipeline and its orchestration: change tracking and detection (hot/warm/cold), the decision engine, rename optimization, plan execution (3-phase lane/tier scheduling), per-action state commit, conflict resolution and 3-way merge, the orchestrator (mutex/retry/status), the scheduler (vault events + triggers), the IndexedDB `SyncStateStore`, error classification, and the conflict-history audit writer. |
+| `sync/` | The sync pipeline and its orchestration: change tracking and evidence-complete detection (hot/warm/cold), direction-aware scope projection, the decision engine, rename optimization, fail-closed whole-component admission, plan execution (3-phase lane/tier scheduling), per-action state commit, checkpoint/debt finalization, conflict resolution and 3-way merge, the orchestrator (mutex/retry/status), the scheduler (vault events + triggers), the IndexedDB `SyncStateStore`, error classification, and the conflict-history audit writer. |
 | `fs/` | Backend-agnostic contracts and lifecycle: `IFileSystem` + `IncrementalCheckpoint`, `IAuthProvider`, `IBackendProvider` + `WebFolderPicker`, `FileEntity`/`RemoteChecksum`, the provider registry, error classification (`errors.ts`), the OAuth PKCE helper (`oauth-pkce.ts`), the backend settings-renderer contract (`settings-renderer.ts`), `BackendManager`, and the `ISecretStore`/token-store wrappers over Obsidian SecretStorage. |
 | `fs/caching/` | Shared base for id-addressed remote backends: `CachingRemoteFs<T>` (path↔id resolution and the `IncrementalCheckpoint` checkpoint lifecycle, ADR 0001) and `AbstractMetadataCache<T>`. Google Drive, Dropbox, and OneDrive all build on it. The id-keyed delta apply (`id-delta.ts`) makes their remote-rename detection order-independent for free (ADR 0006). |
 | `fs/local/` | `LocalFs` (Obsidian Vault API wrapper) plus the raw adapter for dot-prefixed paths. |
@@ -63,12 +63,20 @@ One row per directory; see the layer diagram and per-doc references for module d
      │    enrichHashesForInitialMatch()   │    local digest vs remoteChecksum
      │        │                           │
      │        ▼                           │
+     │  projectScope()                    │  ScopeProjection
+     │    classify every evidence endpoint│    direction-aware matrix
+     │        │                           │
+     │        ▼                           │
      │  planSync()                        │  DecisionEngine
      │        │                           │    9 action types
      │        ▼                           │
      │  refinePlan()                      │  RenameOptimizer
      │    optimizeLocalFileRenames         │    → rename_remote (hash-verified)
      │    optimizeRemoteFileRenames        │    → rename_local  (trusted)
+     │        │                           │
+     │        ▼                           │
+     │  admitDestructivePlan()            │  PlanAdmission
+     │    defer unsafe identity components│    pure, whole-component, fail-closed
      │        │                           │
      │        ▼                           │
      │  executePlan()  (3 phases)         │  PlanExecutor
@@ -99,6 +107,8 @@ interface RemoteChecksum { algo: ChecksumAlgo; value: string; }
 
 interface FileEntity {
   path: string;          // relative path from sync root
+  pathAuthority?: "actual_resolved" | "requested_echo";
+  identityKey?: string;  // opaque native ID, comparable only within one FS/root
   isDirectory: boolean;
   size: number;          // bytes (0 for directories)
   mtime: number;         // Unix epoch ms (0 = unknown)
@@ -125,6 +135,7 @@ interface SyncRecord {
   localSize: number;
   remoteSize: number;
   remoteChecksum?: RemoteChecksum;  // remote checksum at last sync (for change detection)
+  remoteIdentityKey?: string;       // last observed same-root native identity
   backendMeta?: Record<string, unknown>;
   syncedAt: number;        // when this sync completed
 }
@@ -141,7 +152,25 @@ interface MixedEntity {
   remote?: FileEntity;
   prevSync?: SyncRecord;
 }
+
+type PathObservation =
+  | { kind: "exact"; side: "local" | "remote"; requestedPath: string; entity: FileEntity }
+  | { kind: "alias"; side: "local" | "remote"; requestedPath: string; resolvedPath: string; entity: FileEntity }
+  | { kind: "present_unresolved"; side: "local" | "remote"; requestedPath: string; returnedPath: string; entity: FileEntity; source: "list" | "stat" }
+  | { kind: "absent"; side: "local" | "remote"; requestedPath: string; authority: "stat" | "checkpoint_deleted" }
+  | { kind: "unknown"; side: "local" | "remote"; requestedPath: string; reason: "not_observed" | "outside_tracked_root" };
+
+interface ChangeSet {
+  entries: MixedEntity[];                 // exact observations only
+  observations: PathObservation[];
+  identityEvidence: IdentityEvidence[];   // reported rename is one normative record
+  temperature: "hot" | "warm" | "cold";
+}
 ```
+
+`pathAuthority` is producer-qualified. A requested echo or unspecified authority is
+presence without exact-slot proof; a thrown `stat()` aborts the cycle and is never
+converted to absence. See [ADR 0008](docs/adr/0008-logical-identity-admission-fails-closed.md).
 
 ### SyncAction / SyncPlan (sync/types.ts)
 
@@ -283,7 +312,7 @@ interface WebFolderPicker {
 }
 ```
 
-The remote delta cursor is crash-safe at the **filesystem** layer, not the provider (it moved there with ADR 0001): `IFileSystem.checkpoint` commits the cursor plus its derived cache to the backend's own IndexedDB store atomically, and only after a fully-successful cycle. When no checkpoint is committed (`checkpoint.hasCheckpoint() === false`: first sync, an interrupted/partial sync, or after a manual rescan) the orchestrator forces a full cold reconcile — delta detection alone can't surface remote files an interrupted sync left un-baselined. `readBackendState()` persists only non-secret provider/auth state (e.g. token expiry) to `settings.backendData`; it no longer carries the cursor, so it takes no FS argument.
+The remote delta cursor is crash-safe at the **filesystem** layer, not the provider (it moved there with ADR 0001): `IFileSystem.checkpoint` commits the cursor plus its derived cache to the backend's own IndexedDB store atomically, and only after a cycle has no failed/deferred work and no unresolved remote identity edge. A missing checkpoint (first sync, cleared state, manual rescan) forces COLD. After a non-clean cycle with an older checkpoint still committed, same-session recovery forces COLD despite the advanced live cursor; restart instead reloads that older cursor and replays its delta. Scope changes and persisted local rename debt also force COLD. Local reported renames persist as bounded, namespace-scoped `RenameDebt` before plan I/O; remote evidence replays from the withheld checkpoint. `readBackendState()` persists only non-secret provider/auth state (e.g. token expiry) to `settings.backendData`; it no longer carries the cursor, so it takes no FS argument.
 
 `settings.backendData` is a single flat bag holding **only the active backend's** parameters (tokens live in `SecretStorage`, keyed per backend — never in `backendData`). Switching backends hard-resets it: all params are wiped and every registered backend's plugin-owned secrets are swept (`clearPluginSecrets`), so the new backend starts disconnected and can't reuse another's token under the wrong OAuth client.
 

--- a/docs/adr/0006-remote-rename-detection-is-order-independent.md
+++ b/docs/adr/0006-remote-rename-detection-is-order-independent.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted · 2026-06-14
 **Context area:** `fs/` backends — incremental sync / delta application (`fs/dropbox/incremental-sync.ts`, `fs/caching/id-delta.ts`)
-**Related:** [ADR 0001](0001-metadata-cache-is-subordinate-to-commit-last.md) (convergence — a missed rename is an efficiency bug, not a correctness one), [ADR 0002](0002-backends-verified-by-shared-behaviour-contracts.md) (the shared crash-safety contract this extends), [ADR 0003](0003-opt-in-e2e-validates-fakes-against-real-backends.md) (the opt-in e2e that backstops the delta SHAPE against live Dropbox), [dropbox-backend.md](../dropbox-backend.md)
+**Related:** [ADR 0001](0001-metadata-cache-is-subordinate-to-commit-last.md) (commit-last recovery), [ADR 0002](0002-backends-verified-by-shared-behaviour-contracts.md) (the shared crash-safety contract this extends), [ADR 0003](0003-opt-in-e2e-validates-fakes-against-real-backends.md) (the opt-in e2e that backstops the delta SHAPE against live Dropbox), [ADR 0008](0008-logical-identity-admission-fails-closed.md) (ambiguous rename fallback is not automatically safe), [dropbox-backend.md](../dropbox-backend.md)
 
 ## Context
 
@@ -72,10 +72,14 @@ Concretely, `applyDropboxDelta` (`fs/dropbox/incremental-sync.ts`):
    eviction and add them to the changed set, so they surface as deletions instead of
    orphaning locally until the next full scan.
 
-Bounding (from ADR 0001): a *missed* rename is never data loss — it degrades to delete+add,
-which still converges (the file is re-downloaded). So this is an **efficiency/quality**
-fix, not a correctness patch; the guard above exists to avoid *introducing* a correctness
-bug while making the common case efficient.
+Bounding: order-independent delta coalescing is still an efficiency/quality property at
+this backend layer, but a *missed or ambiguous* rename is **not by itself proof** that an
+independent delete+add fallback is safe. ADR 0008 requires the sync engine to preserve any
+rename/alias/stable-identity evidence it has and fail closed before execution when the
+fallback cannot prove resource survival. If a backend/cache defect omits the identity edge
+entirely, admission cannot invent it from spelling; that separate causality defect is
+tracked by Issue #46. The guards above remain necessary both for faithful evidence and to
+avoid introducing cache-level data loss.
 
 ## Consequences
 
@@ -111,7 +115,7 @@ unless noted):
 | Delete-then-recreate a **file** at the same path, **different id** | Not a rename: new file kept, `deleted(old)` guarded out, surfaced as a content change (`modified`). |
 | Delete-then-recreate a **folder** at the same path, **different id** | New folder kept; the old folder's children surface as deletions (evicted-subtree recording). |
 | Folder **moved onto a path freed by a deleted folder** (`X` deleted, `A`→`X`) | One `rename_local(A→X)`; the displaced old `X/*` children surface as deletions. |
-| **Rename `A`→`B` *and* a new file created at `A`** in the same sync | Delta level: the cache detects `A`→`B` by id and the new `A` (different id) survives — `deleted(A)` is guarded out. Plan level: it does **not** coalesce into a rename. `A` is now `modified` (replaced), not `deleted`, so the rename optimizer's `delete_*`+`pull`/`push` pattern does not match; it resolves as two independent transfers (`pull(B)`+`pull(A)`, or `push`+`push` for a local rename). Correct end state (`B` = old content, `A` = new file), just without the move optimization. The folder variant (rename folder `A`→`B`, new file at `A`) still coalesces the folder move and pulls the new `A` separately; because `A` is locally a directory until the rename runs, the file lands at `A` over one or two cycles. |
+| **Rename `A`→`B` *and* a new file created at `A`** in the same sync | Delta level: the cache detects `A`→`B` by id and the new `A` (different id) survives — `deleted(A)` is guarded out. Plan level: ADR 0008 admits only a postcondition that preserves both identities; an unrecognized fallback defers the whole connected component instead of assuming two independent transfers are safe. |
 | Entry **moved outside the vault root** (`relativize` → null) | Old path + descendants surfaced as deletions; the out-of-root destination is not tracked. |
 | Move **onto the reserved metadata path or the root itself** | Destination ignored (never cached); the old location is surfaced as gone. |
 | `file`/`folder` entry with **no `id`** | Handled — the stale-tombstone guard keys on path, not id. |
@@ -129,14 +133,11 @@ and **not** recreated (a live child cannot exist under a deleted parent).
 When a remote **folder rename's destination is already occupied locally**
 (`coalesceRemoteFolderRenames`, reason `destination_occupied`), the whole-folder
 `localFs.rename(A→B)` would collide, so the optimizer skips coalescing entirely and the
-children fall back to per-file `delete_local`+`pull` — i.e. **every child is re-downloaded**,
-even those whose own destination `B/x` is free. A finer fallback is possible: expand the
-folder pair into per-child pairs and route them through `optimizeRemoteFileRenames`, so each
-child whose destination is free becomes a `rename_local(A/x→B/x)` (no re-download) and only
-the genuinely-colliding child stays a `conflict`/`match` (its behaviour is unchanged from
-today, so no new dangling-delete risk). This is purely an efficiency win in a rare case —
-convergence already guarantees correctness — and is deliberately left unimplemented to keep
-the coalescer all-or-nothing.
+optimizer cannot prove one whole-folder rename. A finer fallback may be possible: expand the
+folder pair into complete per-child mappings and route them through file-rename optimization.
+That is safe only if ADR 0008 admission can prove the full occurrence mapping and every
+postcondition; incomplete mappings now defer the connected component. Executor ordering or a
+later convergence pass is not a substitute for that proof, so this remains unimplemented.
 
 **Pinned by tests** (keep green; extend, don't weaken):
 - `fs/dropbox/incremental-sync.test.ts` — DELETE-FIRST file & folder rename, child-before-parent
@@ -147,4 +148,6 @@ the coalescer all-or-nothing.
   renamed pair" cases, run against the real Dropbox/Google Drive/OneDrive FS.
 - `sync/convergence.test.ts` — remote folder/file rename collapses to one `rename_local` and
   reaches a fixed point on re-sync.
+- `sync/plan-admission.test.ts` and `sync/orchestrator.test.ts` — an ambiguous or incomplete
+  rename component is deferred before I/O and cannot advance the checkpoint (ADR 0008).
 - `e2e/dropbox.e2e.ts` — out-of-band folder rename via `getChangedPaths` against live Dropbox.

--- a/docs/adr/0008-logical-identity-admission-fails-closed.md
+++ b/docs/adr/0008-logical-identity-admission-fails-closed.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted · 2026-08-25
 **Context area:** `sync/` — change evidence, scope projection, destructive admission, checkpoint/debt lifecycle
-**Related:** [ADR 0001](0001-metadata-cache-is-subordinate-to-commit-last.md), [ADR 0002](0002-backends-verified-by-shared-behaviour-contracts.md), [ADR 0006](0006-remote-rename-detection-is-order-independent.md), [Issue #43](https://github.com/takezoh/obsidian-air-sync/issues/43), [Issue #45](https://github.com/takezoh/obsidian-air-sync/issues/45)
+**Related:** [ADR 0001](0001-metadata-cache-is-subordinate-to-commit-last.md), [ADR 0002](0002-backends-verified-by-shared-behaviour-contracts.md), [ADR 0006](0006-remote-rename-detection-is-order-independent.md), [Issue #43](https://github.com/takezoh/obsidian-air-sync/issues/43), [Issue #45](https://github.com/takezoh/obsidian-air-sync/issues/45), [Issue #47](https://github.com/takezoh/obsidian-air-sync/issues/47)
 
 ## Context
 

--- a/docs/adr/0008-logical-identity-admission-fails-closed.md
+++ b/docs/adr/0008-logical-identity-admission-fails-closed.md
@@ -1,0 +1,86 @@
+# ADR 0008 — Logical-identity admission fails closed before sync-plan execution
+
+**Status:** Accepted · 2026-08-25
+**Context area:** `sync/` — change evidence, scope projection, destructive admission, checkpoint/debt lifecycle
+**Related:** [ADR 0001](0001-metadata-cache-is-subordinate-to-commit-last.md), [ADR 0002](0002-backends-verified-by-shared-behaviour-contracts.md), [ADR 0006](0006-remote-rename-detection-is-order-independent.md), [Issue #43](https://github.com/takezoh/obsidian-air-sync/issues/43), [Issue #45](https://github.com/takezoh/obsidian-air-sync/issues/45)
+
+## Context
+
+A path-keyed decision table can represent one reported rename as two ordinary rows:
+the old path appears deleted while the new path appears added. If casing/alias
+resolution, scope filtering, or a partial observation prevents rename optimization,
+those rows can become an independent delete plus transfer. Executing them separately
+can destroy the only surviving copy even though the detector had evidence that the two
+paths described one logical resource.
+
+Absence from a listing is also not authoritative. Obsidian's vault index can
+under-report, and a backend `stat(P)` may return an entity whose `path` merely echoes P
+rather than proving the backend-resolved spelling. Content equality and case-folded
+spelling are not identity.
+
+The remote metadata-cache causality defect tracked by Issue #46 is separate. Cache
+repair may improve the evidence available to the engine, but destructive safety cannot
+depend on that repair being complete.
+
+## Decision
+
+1. `ChangeSet` preserves observations separately from exact-path entities. A non-null
+   `stat(P)` is `exact` or `alias` only when its producer marks the path
+   `actual_resolved`; `requested_echo` or missing authority is
+   `present_unresolved`. A thrown stat aborts the cycle and is never absence.
+
+2. Reported local/remote renames remain one normative `RenameEvidence` record through
+   collection, refinement, and admission. Backend-native `identityKey` values are
+   opaque, same-root evidence only. Equal non-empty keys relate occurrences; unequal
+   keys separate them. Missing keys provide no evidence.
+
+3. Scope is projected for both rename endpoints before entries are filtered. The
+   origin-aware matrix decides whether the only safe consequence is rename, transfer,
+   deletion, no-op, or deferral. `unknown`, `mobile_deferred`, and incomplete folder
+   mappings defer the whole connected component.
+
+4. `admitDestructivePlan` is the sole final owner of cross-path destructive
+   admissibility. It is pure and cycle-local. When it cannot prove a permitted
+   postcondition, it removes every action in the evidence-connected component —
+   including state-only `match`/`cleanup` — before `executePlan`. Disconnected safe
+   components retain their original order and may execute.
+
+5. Deferral is visible and non-clean: status is `partial_error`, notifications count
+   deferred components, structured logs identify reasons/evidence/scope/paths, the
+   checkpoint and scope fingerprint do not advance, and the next normal trigger uses a
+   COLD reevaluation without a tight retry loop.
+
+6. Crash recovery is bounded. An unresolved local reported edge and its endpoint
+   dispositions are persisted as namespace-scoped `RenameDebt` before plan I/O and
+   tracker acknowledgement. Remote edges are captured immediately when the delta
+   cursor yields them and are reconstructed after restart by withholding that cursor's
+   checkpoint. Debt/evidence is released only after success, proven two-sided
+   convergence, or an explicit scope no-op reaches a safe checkpoint. Backend/root
+   teardown is serialized with sync execution and clears the old namespace.
+
+7. SyncState schema version 6 cold-starts the incompatible baseline shape. Old
+   `SyncRecord` and merge-base stores are dropped rather than field-migrated; the first
+   no-baseline cycle is COLD and cannot derive deletion from legacy baseline absence.
+
+## Consequences
+
+- A suspicious rename may defer and require a later trigger or user intervention, but
+  it does not execute a partial destructive interpretation.
+- The durable state remains O(U): one record per namespace-unique unresolved local
+  edge, not a persistent identity graph or descendant closure.
+- Native IDs improve evidence but do not authorize cross-backend/root comparison.
+- Optimizers remain performance/plan-shaping steps. Their failure to match is not
+  permission to execute the fallback; admission independently proves or rejects it.
+- Issue #46 can be fixed without changing this boundary. Better cache causality should
+  reduce ambiguity, while this admission policy remains the safety net.
+
+## Rejected alternatives
+
+- Infer identity from lowercased paths, Unicode-looking equivalence, or equal hashes.
+- Treat an unresolved rename as two independent path actions and rely on execution
+  order, trash, or a later COLD scan to repair it.
+- Persist a general occurrence graph or every folder descendant.
+- Auto-duplicate every ambiguous component; duplication is conflict policy, not proof
+  that a destructive rename interpretation is safe.
+- Advance the remote cursor while an unresolved remote edge exists; that would erase
+  the only restart replay source.

--- a/docs/adr/0008-logical-identity-admission-fails-closed.md
+++ b/docs/adr/0008-logical-identity-admission-fails-closed.md
@@ -39,11 +39,12 @@ depend on that repair being complete.
    deletion, no-op, or deferral. `unknown`, `mobile_deferred`, and incomplete folder
    mappings defer the whole connected component.
 
-4. `admitDestructivePlan` is the sole final owner of cross-path destructive
-   admissibility. It is pure and cycle-local. When it cannot prove a permitted
-   postcondition, it removes every action in the evidence-connected component —
-   including state-only `match`/`cleanup` — before `executePlan`. Disconnected safe
-   components retain their original order and may execute.
+4. `admitDestructivePlan` is the sole final owner of destructive admissibility. It is
+   pure and cycle-local, consumes one immutable cycle snapshot, and emits exactly one
+   `authorized`, `resolved_no_action`, or `deferred` disposition for every relevant
+   component, including zero-action evidence components. Only Admission can issue the
+   nominal `AuthorizedSyncPlan` accepted by `executePlan`; disconnected authorized
+   actions retain proposal order.
 
 5. Deferral is visible and non-clean: status is `partial_error`, notifications count
    deferred components, structured logs identify reasons/evidence/scope/paths, the
@@ -54,9 +55,11 @@ depend on that repair being complete.
    dispositions are persisted as namespace-scoped `RenameDebt` before plan I/O and
    tracker acknowledgement. Remote edges are captured immediately when the delta
    cursor yields them and are reconstructed after restart by withholding that cursor's
-   checkpoint. Debt/evidence is released only after success, proven two-sided
-   convergence, or an explicit scope no-op reaches a safe checkpoint. Backend/root
-   teardown is serialized with sync execution and clears the old namespace.
+   checkpoint. Admission alone classifies success eligibility, two-sided convergence,
+   and explicit scope no-op. Finalization performs only action-completion/membership
+   folding; after a safe checkpoint commits it retires the evidence/debt made releasable
+   by those dispositions. Backend/root teardown is serialized with sync execution and
+   clears the old namespace.
 
 7. SyncState schema version 6 cold-starts the incompatible baseline shape. Old
    `SyncRecord` and merge-base stores are dropped rather than field-migrated; the first

--- a/docs/adr/adr-issue43-destructive-authorization.md
+++ b/docs/adr/adr-issue43-destructive-authorization.md
@@ -1,0 +1,80 @@
+---
+id: adr-20260825-issue43-destructive-authorization
+kind: adr
+title: Bind destructive execution to immutable Admission authority
+summary: Freeze cycle inputs before Admission and make its nominal output the sole executable destructive plan.
+status: accepted
+created: '2026-08-25'
+decision_makers:
+  - user
+consulted: []
+informed: []
+relations:
+  - type: originatedFrom
+    target: change-20260825-issue43-destructive-authorization
+source_paths:
+  - src/sync/sync-cycle-planning.ts
+  - src/sync/plan-admission.ts
+  - src/sync/plan-admission-graph.ts
+  - src/sync/plan-executor.ts
+  - src/sync/sync-cycle-finalization.ts
+  - src/sync/orchestrator.ts
+consequences:
+  positive:
+    - A proposal cannot reach the executor through supported typed production paths without Admission issuing permission from one stable input set.
+    - Zero-action uncertainty is represented explicitly and remains visible, checkpoint-holding, and recoverable.
+  negative:
+    - Executor tests and callers must obtain authorized plans through Admission, increasing fixture setup at the safety boundary.
+    - Snapshot and disposition types must evolve atomically across planning, execution, and finalization.
+  neutral:
+    - Existing RenameDebt, remote session evidence, SyncState v6, and Issue 46 backend ownership remain unchanged.
+confirmation: Focused admission/orchestrator/finalization tests prove nominal executor input, snapshot stability, actionless deferral, strict pre-Admission recovery, and independent OneDrive/A-B evidence causality.
+---
+
+# Bind destructive execution to immutable Admission authority
+
+## Context
+
+ADR 0008 makes Admission the final owner of destructive admissibility, but the current
+shape leaves two invalid states representable: zero-action evidence components can be
+discarded, and the executor accepts a plain proposal type. Mutable settings or namespace
+inputs between Admission and execution would also let one authorization be consumed
+against a different projection. Issue #46 is a separate OneDrive/cache evidence-
+production defect and cannot be proven by central exception-retention tests.
+
+## Decision
+
+The orchestrator captures one immutable cycle snapshot before Admission, containing the
+refined proposal, existing normative evidence, observations, scope projection, and the
+accepted backend/root namespace. Settings/root changes apply to a later snapshot, and
+backend/root teardown remains serialized with in-flight execution.
+
+Admission emits exactly one disposition for every relevant component, including those
+with zero actions, and is the only constructor of an opaque/nominal
+`AuthorizedSyncPlan`. The executor accepts only that carrier. Finalization consumes the
+same snapshot's dispositions plus mechanical completion and cannot re-evaluate safety.
+
+Actionless uncertainty is deferred, visible, checkpoint-holding, evidence-retaining,
+and requests a later COLD cycle without a tight retry. Only an exception strictly before
+Admission is treated by the orchestrator as evidence-acquisition recovery; it retains
+already yielded remote evidence and requests COLD without fabricating authorization.
+
+No lifecycle manager, persistent component graph, remote debt, or duplicate normative
+evidence DTO is introduced. Issue #46 remains independently owned and verified at the
+OneDrive backend/cache producer with its casing regression and an Admission-constant A/B
+pipeline test.
+
+## Rejected alternatives
+
+- Keep `executePlan(SyncPlan)` and rely on call-site convention; this leaves admission bypass representable.
+- Re-check settings/root version during execution; this creates mutable check/use semantics instead of keeping one in-flight input set stable.
+- Persist authorization or a component lifecycle graph; existing bounded recovery carriers already provide crash/session recovery.
+- Treat all zero-action components as resolved; unresolved observations would silently advance checkpoints.
+- Fold Issue #46 cache repair into pre-Admission recovery; that confuses evidence omission with evidence retention.
+
+## Consequences
+
+The frontmatter records the normative positive, negative, and neutral consequences. The
+implementation must compile planning, Admission, executor, orchestrator, and finalization
+changes together; no persisted-data migration or Issue #46 implementation coupling is
+introduced.

--- a/docs/changes/change-20260825-issue43-destructive-authorization/change.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/change.md
@@ -75,5 +75,8 @@ and simplify the Issue 43 branch around one immutable authorization contract.
 
 ## Closure Notes
 
-Pending implementation, independent review, branch-wide minimality audit, repository
-gate, and all-backend live E2E verification.
+Implemented the immutable Admission snapshot, exhaustive dispositions, nominal executor
+input, mechanical commit-last finalization, and strict pre-Admission COLD recovery.
+Main-session review and the branch-wide minimality audit found no remaining blocking
+issue; one redundant logging carrier was removed. Repository gates, dev-evidence scope
+checks, and live Google Drive, Dropbox, and OneDrive E2E all pass.

--- a/docs/changes/change-20260825-issue43-destructive-authorization/change.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/change.md
@@ -1,0 +1,79 @@
+---
+id: change-20260825-issue43-destructive-authorization
+kind: change
+title: Close destructive authorization at one decision boundary
+status: ready
+created: '2026-08-25'
+profile: sdd@1
+intent: Prevent ambiguous or incomplete sync evidence from authorizing destructive
+  actions by making Admission the single final permission boundary, while simplifying
+  the Issue 43 feature branch.
+outcomes:
+- Destructive execution accepts only an Admission-issued nominal plan bound to one
+  immutable cycle snapshot.
+- Actionless uncertainty is deferred, observable, checkpoint-holding, and recoverable
+  through a later COLD cycle.
+- Finalization performs mechanical completion and commit-last retirement without re-deciding
+  safety.
+- The full branch delta from bc83e326 is minimality-audited and Issue 46 causality
+  remains independently verified.
+scope:
+- .gitignore
+- ARCHITECTURE.md
+- docs/adr/
+- docs/code-enforcement.md
+- docs/e2e-testing.md
+- docs/sync-pipeline.md
+- e2e/
+- eslint.config.mts
+- src/
+non_goals:
+- Changing persisted sync-state schemas or adding migration logic.
+- Folding OneDrive Issue 46 evidence-production behavior into the central authorization
+  fix.
+- Adding a lifecycle manager, persistent component graph, remote debt, or duplicate
+  normative evidence carrier.
+change_classes:
+- behavior
+- boundary
+- responsibility
+- implementation_only
+governance:
+  gate: auto
+  reasons: []
+members:
+- role: requirements
+  path: changes/change-20260825-issue43-destructive-authorization/requirements.md
+  required: true
+- role: implementation
+  path: changes/change-20260825-issue43-destructive-authorization/implementation.md
+  required: true
+- role: verification
+  path: changes/change-20260825-issue43-destructive-authorization/verification.md
+  required: true
+promotion: []
+unresolved_decisions: []
+tags: []
+owners: []
+relations: []
+source_paths:
+- src/sync/plan-admission.ts
+- src/sync/plan-admission-graph.ts
+- src/sync/sync-cycle-planning.ts
+- src/sync/plan-executor.ts
+- src/sync/sync-cycle-finalization.ts
+- src/sync/orchestrator.ts
+summary: Centralize destructive authorization in Admission and simplify Issue 43 recovery
+  and finalization boundaries.
+updated: '2026-08-25'
+---
+
+## Summary
+
+Centralize final destructive permission in Admission, retain actionless uncertainty,
+and simplify the Issue 43 branch around one immutable authorization contract.
+
+## Closure Notes
+
+Pending implementation, independent review, branch-wide minimality audit, repository
+gate, and all-backend live E2E verification.

--- a/docs/changes/change-20260825-issue43-destructive-authorization/design-plan/design.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/design-plan/design.md
@@ -1,0 +1,293 @@
+# Issue #43 design — admission-owned destructive authorization
+
+**Revision:** `integrated-plan-v1`
+
+<!-- anchor: adr-0001-commit-last -->
+## ADR 0001 — commit-last remains authoritative
+
+Per-action state changes occur only after their I/O succeeds. A cycle checkpoint is
+committed only after all authorization dispositions and execution results are safe;
+rename debt and session evidence retire only after that checkpoint succeeds. A thrown
+checkpoint write propagates and leaves all recovery material intact.
+
+<!-- anchor: adr-0006-order-independent-rename -->
+## ADR 0006 — backend evidence production remains independent
+
+Backends own the shape and ordering of rename evidence. Admission can classify only
+evidence it receives and must not infer an omitted edge from spelling or cache state.
+Issue #46 therefore remains a OneDrive backend/cache evidence-production concern, not
+an exception-recovery or authorization subtask of Issue #43.
+
+<!-- anchor: adr-0008-logical-identity-admission -->
+## ADR 0008 — logical-identity admission remains authoritative
+
+Path observations, normative identity evidence, pre-filter scope projection,
+whole-component fail-closed admission, visible deferral, bounded local RenameDebt,
+remote checkpoint replay, and the v6 cold-start rule remain unchanged. This change
+closes two representational holes in that accepted boundary: zero-action relevant
+components receive a disposition, and execution receives a nominal admission product.
+
+<!-- anchor: adr-issue43-destructive-authorization -->
+## ADR Issue 43 — immutable admission authority
+
+The cycle composition root captures one immutable `CycleAdmissionSnapshot` before
+Admission. It contains the refined proposal, normative identity evidence, authoritative
+path observations, endpoint scope projection, and the accepted backend/root namespace.
+Admission is the sole constructor of an opaque/nominal `AuthorizedSyncPlan`; proposal
+and refinement results remain plain `SyncPlan`. `executePlan` accepts only
+`AuthorizedSyncPlan`, and finalization consumes the dispositions and completion results
+bound to the same snapshot.
+
+The snapshot is a shallow public contract over deeply immutable cycle inputs: no member
+is mutated after capture, and admission output refers to the captured members rather
+than copying evidence into another normative DTO. Backend/root teardown remains
+serialized with sync execution. A settings or root change therefore affects the next
+snapshot only and cannot alter an in-flight authorization. No lifecycle manager,
+persistent component graph, durable authorization token, or remote debt is introduced.
+
+<!-- anchor: fr-43-01 -->
+## FR-43-01 — proposal is not permission
+
+Decision Engine and rename refinement shall produce plain proposals only. Destructive
+permission shall be issued only by Admission from a complete immutable cycle snapshot.
+
+<!-- anchor: fr-43-02 -->
+## FR-43-02 — dispositions are exhaustive
+
+Admission shall emit exactly one `authorized`, `resolved_no_action`, or `deferred`
+disposition for every connected component containing an action, identity evidence, or
+an unresolved/unknown observation, including components containing zero actions.
+
+<!-- anchor: fr-43-03 -->
+## FR-43-03 — actionless uncertainty defers
+
+An actionless component whose identity, presence, scope, or permitted postcondition is
+not proven shall be visibly deferred. It executes no action, retains bound evidence and
+debt, prevents checkpoint advancement, and requests a later COLD cycle without setting
+a tight automatic retry.
+
+<!-- anchor: fr-43-04 -->
+## FR-43-04 — authorized execution only
+
+`executePlan` shall accept only the nominal `AuthorizedSyncPlan` issued by Admission.
+It shall receive the proposal-ordered projection of `authorized` actions and no action,
+including `match` or `cleanup`, from another disposition.
+
+<!-- anchor: fr-43-05 -->
+## FR-43-05 — one safety decision owner
+
+Admission alone shall classify scope no-op, two-sided convergence, identity
+consistency, alias targeting, and permitted destructive postconditions. Finalization
+shall not receive or re-evaluate scope projections, path observations, identity facts,
+or action shapes to establish safety.
+
+<!-- anchor: fr-43-06 -->
+## FR-43-06 — completion does not reauthorize
+
+Evidence and debt bound to an authorized component become releasable only when every
+bound action succeeds. A failed or blocked bound action retains them without changing
+the admission decision.
+
+<!-- anchor: fr-43-07 -->
+## FR-43-07 — checkpoint precedes retirement
+
+Releasable evidence and debt shall retire only after the safe cycle checkpoint commits.
+A checkpoint exception shall propagate and leave them unchanged.
+
+<!-- anchor: fr-43-08 -->
+## FR-43-08 — pre-Admission evidence-acquisition recovery
+
+Remote rename evidence shall be copied to the existing session buffer immediately when
+delta acquisition yields it. If stat, hashing, observation, or planning then throws
+before Admission is invoked, the orchestrator shall request later COLD recovery and
+retain that evidence. It shall not fabricate a disposition. Exceptions at or after the
+Admission boundary are not reclassified as this recovery case and follow existing
+fail-fast/commit-last semantics.
+
+<!-- anchor: fr-43-09 -->
+## FR-43-09 — disconnected progress remains ordered
+
+Disconnected authorized actions shall preserve proposal order and may commit per-file
+state while another component is deferred; the cycle checkpoint remains non-clean.
+
+<!-- anchor: fr-43-10 -->
+## FR-43-10 — deferral is observable
+
+Every deferred disposition, including an actionless one, shall contribute exactly once
+to partial status, notification count, structured diagnostics, checkpoint withholding,
+and the request for a later same-session COLD reevaluation.
+
+<!-- anchor: fr-43-11 -->
+## FR-43-11 — Issue #46 has separate causal proof
+
+Issue #43 verification shall not claim that pre-Admission retention fixes backend
+evidence omission. Issue #46 is proven independently by the OneDrive casing regression
+and an A/B pipeline test that holds Admission inputs and policy constant except for the
+backend/cache producer emitting versus omitting the required rename edge.
+
+<!-- anchor: nfr-43-01 -->
+## NFR-43-01 — deterministic pure admission
+
+Equal immutable snapshots shall produce equal disposition membership, reason ordering,
+and authorized action order without I/O or mutation.
+
+<!-- anchor: nfr-43-02 -->
+## NFR-43-02 — bounded state and minimal carriers
+
+The change shall add no lifecycle service, persistent component graph, remote debt, or
+duplicate normative evidence DTO. Existing namespace-bounded local RenameDebt and the
+session-local remote-evidence buffer remain the only recovery carriers.
+
+<!-- anchor: component-action-proposal -->
+## Component — action proposal
+
+`decision-engine.ts`, rename optimization, and `sync-cycle-planning.ts` own exact-path
+proposal generation and behavior-preserving rewrites. Their output is always a plain
+`SyncPlan`; optimizer misses never grant permission.
+
+<!-- anchor: component-admission -->
+## Component — snapshot and Admission
+
+`sync-cycle-planning.ts`, `plan-admission.ts`, `plan-admission-graph.ts`, and shared sync
+types own snapshot capture, relevant-component construction, the exhaustive disposition
+partition, and nominal authorization issuance. Admission's constructor/factory is the
+only plain-`SyncPlan` to `AuthorizedSyncPlan` conversion boundary.
+
+The outcome partition is exclusive and exhaustive:
+
+- `authorized`: at least one proposed action and a permitted postcondition is proven;
+- `resolved_no_action`: zero actions and explicit scope no-op or authoritative
+  two-sided convergence is proven;
+- `deferred`: every unknown, inconclusive, conflicting, incomplete, mismatched, or
+  otherwise unproved relevant component.
+
+Default is `deferred`. Exact-observation-only no-op paths with neither action nor
+identity evidence are irrelevant and need no component. A remote rename edge with a
+`present_unresolved` observation and zero actions is relevant and must be deferred.
+
+<!-- anchor: component-finalization -->
+## Component — mechanical finalization
+
+`sync-cycle-finalization.ts`, `rename-debt.ts`, and `execution-result.ts` fold each
+snapshot-bound disposition with mechanical completion. Deferred retains; resolved-no-
+action is releasable; authorized is releasable only when all bound actions succeeded.
+Checkpoint commit occurs before retirement. Policy-evaluating forms of
+`renameEvidenceResolved`, `resolvedRenameDebts`, and `unresolvedRenameEvidence` are
+removed or narrowed to mechanical consumers.
+
+<!-- anchor: component-orchestrator-recovery -->
+## Component — orchestration and recovery
+
+`orchestrator.ts` remains the composition root and serializes backend/root lifecycle
+with an in-flight cycle. It captures remote evidence before later fallible work, routes
+the immutable snapshot through Admission, passes only the nominal authorized plan to
+execution, reports dispositions, and handles only pre-Admission exceptions by retaining
+captured evidence and requesting a later COLD run.
+
+<!-- anchor: contract-proposal-boundary -->
+## Contract — proposal, snapshot, and nominal authorization boundary
+
+Decision rules:
+
+1. Plain proposal/refinement output is never accepted by `executePlan`.
+2. Snapshot capture occurs once after all required planning inputs exist and before
+   Admission; captured arrays/records and namespace are immutable for the cycle.
+3. Admission alone issues `AuthorizedSyncPlan`, branded by a module-private nominal
+   member or equivalent opaque constructor that ordinary typed callers cannot create.
+4. Execution and finalization use the same snapshot identity. Namespace/policy changes
+   are queued for a later cycle, while teardown cannot overlap execution.
+
+Normal witness: an exact deletion is admitted and retains original order. Adversarial
+witness: a typed caller passing a proposal directly to `executePlan` fails build, and a
+settings/root change between admission and execution cannot substitute new projection
+or namespace inputs.
+
+<!-- anchor: contract-admission-disposition -->
+## Contract — exhaustive admission disposition
+
+Inputs are the snapshot's proposal, evidence, observations, scope projection, and
+namespace, owned by the composition root and produced respectively by proposal,
+detector/tracker/backend, observation, scope policy, and active backend/root selection.
+They are required before Admission. Missing represented facts yield unknown/deferred;
+an acquisition exception before snapshot capture aborts into the pre-Admission recovery
+contract. Evidence remains normative in its existing owner and is referenced, not
+duplicated, by dispositions.
+
+The determinate/unknown/inconclusive/conflicting epistemic partition maps to exactly one
+disposition. Unknown, inconclusive, and conflicting always defer. The private membership
+carrier may use object references or cycle-local indices, provided it is deterministic,
+non-persistent, non-user-visible, and shared directly with finalization.
+
+Normal witness: authoritative two-sided convergence with zero actions is
+`resolved_no_action`. Adversarial witness: requested-echo presence with a rename edge
+and zero actions is one `deferred` component, never omission or resolution.
+
+<!-- anchor: contract-finalization-consumer -->
+## Contract — disposition-driven commit-last finalization
+
+Finalization receives the same snapshot's dispositions plus per-action succeeded,
+failed, and blocked results. It may perform only membership/completion folding. It must
+not inspect scope, observations, aliases, identities, or action shape to upgrade safety.
+A deferred disposition or incompletely executed bound component retains evidence and
+blocks the checkpoint. Once all work is releasable, checkpoint persistence precedes
+debt/session-evidence retirement.
+
+Normal witness: an authorized rename succeeds, checkpoint commits, then debt retires.
+Adversarial witnesses: a bound action failure retains evidence; a checkpoint exception
+leaves debt/evidence intact; disconnected successful work may commit per-file state but
+cannot advance the cycle checkpoint while another component is deferred.
+
+<!-- anchor: contract-preadmission-recovery -->
+## Contract — pre-Admission COLD recovery boundary
+
+The remote delta callback produces evidence into the existing session buffer before
+fallible stat/hash/planning. An exception strictly before Admission invocation retains
+the buffer, sets `recoverViaColdScan`, propagates through existing error reporting, and
+does not create authorization or a disposition. A later empty delta plus COLD/full
+observation resubmits the retained edge. There is no immediate retry loop.
+
+Normal witness: ordinary acquisition reaches snapshot capture once. Adversarial witness:
+a post-delta stat exception followed by an empty-delta retry still presents the edge to
+Admission. Separately, the Issue #46 OneDrive/A-B checks vary evidence production, not
+exception retention; passing this contract alone is never evidence that #46 is fixed.
+
+## Contract evolution and rollout
+
+The TypeScript consumers evolve atomically: snapshot capture, Admission output,
+executor parameter, orchestrator, finalization, and focused tests compile together.
+There is no persisted schema or wire migration; SyncState v6 and RenameDebt remain
+unchanged. Rollback reverts the code/doc set together and requires no data rollback.
+Baseline versus target discrimination is provided by the zero-action unresolved test,
+the direct-proposal type failure, the snapshot mutation/root-change test, and the
+finalization-no-redecision test.
+
+## Decision closure
+
+All draft inputs are closed. Admission is the sole authorization owner; actionless
+relevant components are retained; existing `AdmissionResult` is enriched; the nominal
+authorized carrier and immutable snapshot are adopted; commit-last and same-session
+COLD recovery are preserved; persistent disposition/lifecycle state and Issue #46
+fold-in are rejected; API changes are limited to the typed executor boundary; and
+purity is verified by deterministic tests and build without expanding the lint policy.
+The only delegated choice is the private cycle-local membership encoding described by
+`discretion-component-membership-carrier`.
+
+## Critique resolution
+
+- `issue-authorization-expiry-unenforced`: resolved by immutable pre-Admission snapshot
+  capture, snapshot-bound authorization/consumers, and serialized namespace teardown.
+- `issue-executor-admission-boundary-open`: resolved by the Admission-only nominal
+  `AuthorizedSyncPlan` constructor and executor parameter.
+- `issue-issue46-owner-verification-blank`: resolved by assigning evidence production
+  to the OneDrive backend/cache boundary and requiring the casing regression plus the
+  Admission-constant A/B pipeline test independently of Issue #43 recovery tests.
+
+## Verification witnesses
+
+Focused T0 tests cover exact delete, actionless unresolved/resolved components,
+determinism, bound failure retention, no finalization redecision, and checkpoint-before-
+retirement. T1 tests cover typed composition, direct-proposal rejection, immutable
+snapshot/root-policy stability, partial status, disconnected progress, and post-delta
+exception recovery. T2 independently covers OneDrive casing/evidence emission and the
+A/B pipeline causality. The repository gate remains lint, bot-reproduction lint, build,
+and unit tests.

--- a/docs/changes/change-20260825-issue43-destructive-authorization/design-plan/spine.yaml
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/design-plan/spine.yaml
@@ -1,0 +1,438 @@
+artifact: design-plan-spine
+version: 2
+granularity_profile: boundary-complete
+
+scope_expansion_signals:
+  - id: scope-signal-admission-finalization-boundary
+    kind: shared_boundary
+    target_ref: contract-finalization-consumer
+    witness: Finalization currently evaluates scope, observations, and action shapes after Admission; the target makes it a mechanical consumer of snapshot-bound dispositions.
+    requirement_refs: [FR-43-05, FR-43-06, FR-43-07]
+    authority_refs: [adr-0008-logical-identity-admission, adr-0001-commit-last]
+  - id: scope-signal-nominal-snapshot-contract
+    kind: critic_induced_contract
+    target_ref: contract-proposal-boundary
+    witness: Pass-2 found proposal bypass and mutable check/use inputs; the accepted authority requires an immutable snapshot and Admission-only nominal AuthorizedSyncPlan.
+    requirement_refs: [FR-43-01, FR-43-04, NFR-43-01]
+    authority_refs: [adr-issue43-destructive-authorization, input-authorized-plan-marker]
+  - id: scope-signal-no-lifecycle-service
+    kind: smaller_structural_alternative
+    target_ref: component-finalization
+    witness: Enriching the cycle-local Admission result and reusing existing recovery carriers avoids a lifecycle manager, persistent graph, and duplicate evidence DTO.
+    requirement_refs: [NFR-43-02]
+    authority_refs: [input-disposition-carrier, adr-issue43-destructive-authorization]
+
+requirements:
+  - id: FR-43-01
+    type: ubiquitous
+    priority: must
+    statement: Decision Engine and rename refinement produce plain proposals; only Admission issues destructive permission from a complete immutable cycle snapshot.
+  - id: FR-43-02
+    type: event-driven
+    priority: must
+    statement: Admission emits exactly one disposition for every relevant action-bearing or actionless evidence-connected component.
+  - id: FR-43-03
+    type: event-driven
+    priority: must
+    statement: Actionless uncertainty is visibly deferred, retains evidence and debt, withholds checkpoint advancement, and requests later COLD reevaluation without a tight retry.
+  - id: FR-43-04
+    type: ubiquitous
+    priority: must
+    statement: Execution accepts only Admission-issued nominal AuthorizedSyncPlan and receives only actions projected from authorized dispositions.
+  - id: FR-43-05
+    type: ubiquitous
+    priority: must
+    statement: Admission alone classifies scope no-op, convergence, identity consistency, alias targeting, and permitted destructive postconditions; finalization does not recompute them.
+  - id: FR-43-06
+    type: state-driven
+    priority: must
+    statement: Authorized-component evidence and debt become releasable only after every bound action succeeds; failure or block retains them without changing authorization.
+  - id: FR-43-07
+    type: state-driven
+    priority: must
+    statement: Releasable evidence and local debt retire only after safe checkpoint commit and remain intact when checkpoint persistence fails.
+  - id: FR-43-08
+    type: event-driven
+    priority: must
+    statement: Remote evidence is captured before later fallible work; an exception strictly before Admission retains it and requests COLD recovery without fabricating a disposition.
+  - id: FR-43-09
+    type: event-driven
+    priority: must
+    statement: Disconnected authorized actions preserve proposal order and may commit per-file state while another component is deferred, without checkpoint advancement.
+  - id: FR-43-10
+    type: event-driven
+    priority: must
+    statement: Every deferred disposition contributes exactly once to partial status, notification count, diagnostics, checkpoint withholding, and later COLD recovery.
+  - id: FR-43-11
+    type: ubiquitous
+    priority: must
+    statement: Issue 46 remains owned by OneDrive backend and cache evidence production and is verified independently by its casing regression and an Admission-constant A/B pipeline test.
+  - id: NFR-43-01
+    type: quality
+    priority: must
+    statement: Equal immutable snapshots produce equal disposition membership, reason ordering, and authorized action order without I/O or mutation.
+  - id: NFR-43-02
+    type: quality
+    priority: must
+    statement: The design adds no lifecycle manager, persistent component graph, remote debt, or duplicate normative evidence DTO.
+
+components:
+  - id: component-action-proposal
+    kind: existing
+    contract_refs: [contract-proposal-boundary]
+    paths:
+      - src/sync/decision-engine.ts
+      - src/sync/rename-optimizer.ts
+      - src/sync/sync-cycle-planning.ts
+  - id: component-admission
+    kind: planned
+    contract_refs: [contract-proposal-boundary, contract-admission-disposition]
+    paths:
+      - src/sync/plan-admission.ts
+      - src/sync/plan-admission-graph.ts
+      - src/sync/types.ts
+      - src/sync/sync-cycle-planning.ts
+  - id: component-finalization
+    kind: planned
+    contract_refs: [contract-finalization-consumer]
+    paths:
+      - src/sync/sync-cycle-finalization.ts
+      - src/sync/rename-debt.ts
+      - src/sync/execution-result.ts
+  - id: component-orchestrator-recovery
+    kind: planned
+    contract_refs: [contract-proposal-boundary, contract-finalization-consumer, contract-preadmission-recovery]
+    paths:
+      - src/sync/orchestrator.ts
+      - src/sync/remote-change-source.ts
+      - src/sync/sync-cycle-planning.ts
+
+contracts:
+  - id: contract-proposal-boundary
+    dimension: Immutable cycle snapshot and Admission-only nominal authorization separate proposal generation from destructive execution.
+    owner: component-admission
+    requirement_refs: [FR-43-01, FR-43-04, FR-43-09, NFR-43-01]
+    unit_refs:
+      - Chunk 1 — immutable admission disposition
+      - Chunk 3 — orchestrator integration
+      - Chunk 4 — persistent alignment and gate
+    adr_refs: [adr-0008-logical-identity-admission, adr-issue43-destructive-authorization]
+    verification:
+      - id: verify-direct-proposal-rejected
+        tier: T1
+        command: npm run build
+      - id: verify-snapshot-stability
+        tier: T1
+        command: npm test -- src/sync/orchestrator.test.ts
+      - id: verify-production-admission-path
+        tier: T1
+        command: npm test -- src/sync/orchestrator.test.ts
+  - id: contract-admission-disposition
+    dimension: Pure exhaustive component authorization, no-action resolution, and fail-closed deferral partition.
+    owner: component-admission
+    requirement_refs: [FR-43-02, FR-43-03, FR-43-05, FR-43-10, NFR-43-01, NFR-43-02]
+    unit_refs:
+      - Chunk 1 — immutable admission disposition
+      - Chunk 3 — orchestrator integration
+      - Chunk 4 — persistent alignment and gate
+    adr_refs: [adr-0008-logical-identity-admission, adr-issue43-destructive-authorization]
+    verification:
+      - id: verify-admission-disposition-matrix
+        tier: T0
+        command: npm test -- src/sync/plan-admission.test.ts
+      - id: verify-planning-composition
+        tier: T1
+        command: npm test -- src/sync/plan-admission.test.ts src/sync/orchestrator.test.ts
+    partition:
+      outcomes: [determinate, unknown, inconclusive, conflicting]
+      default_policy: Unknown, inconclusive, conflicting, incomplete, or otherwise unproved relevant components are deferred; only determinate accepted postconditions authorize or resolve without action.
+    discretion:
+      - id: discretion-component-membership-carrier
+        unit_ref: Chunk 1 — immutable admission disposition
+        question: Represent private cycle-local component membership by existing object references or input array indices.
+        scope:
+          files:
+            - src/sync/plan-admission.ts
+            - src/sync/plan-admission-graph.ts
+          component: component-admission
+          visibility: private
+        escalate_when:
+          - The representation becomes persisted, user-visible, logged as stable identity, or stable across cycles.
+          - It duplicates normative identity evidence or requires a lifecycle consumer to reconstruct membership.
+          - It changes connectivity, authorization outcomes, disposition order, or action order.
+        constraints:
+          - One carrier is shared directly by Admission diagnostics and finalization.
+          - Equal snapshots produce deterministic membership and disposition order.
+        preserves:
+          contract_refs: [contract-admission-disposition, contract-finalization-consumer]
+          invariant_refs: [FR-43-02, FR-43-05, NFR-43-02]
+        verification_refs: [verify-admission-disposition-matrix, verify-disposition-finalization]
+        difficulty_inputs:
+          decision_reasoning: local_tradeoff
+          boundary_reach: private
+          context_scope: files
+          reversibility: trivial
+          verification_strength: discriminating
+          runtime_risk: data_loss
+          coupling: coupled_within_unit
+          grounding: evidenced
+  - id: contract-finalization-consumer
+    dimension: Snapshot-bound mechanical completion and commit-last evidence or debt retirement without a second safety evaluator.
+    owner: component-finalization
+    requirement_refs: [FR-43-03, FR-43-05, FR-43-06, FR-43-07, FR-43-09, FR-43-10]
+    unit_refs:
+      - Chunk 2 — disposition-driven finalization
+      - Chunk 3 — orchestrator integration
+      - Chunk 4 — persistent alignment and gate
+    adr_refs: [adr-0008-logical-identity-admission, adr-0001-commit-last, adr-issue43-destructive-authorization]
+    verification:
+      - id: verify-disposition-finalization
+        tier: T0
+        command: npm test -- src/sync/sync-cycle-finalization.test.ts src/sync/rename-debt.test.ts
+      - id: verify-cycle-status-and-recovery
+        tier: T1
+        command: npm test -- src/sync/orchestrator.test.ts
+    partition:
+      outcomes: [determinate, unknown, inconclusive]
+      default_policy: Deferred or incompletely executed bound work retains evidence and debt and prevents a safe checkpoint; finalization never upgrades safety by inspecting planning facts.
+  - id: contract-preadmission-recovery
+    dimension: Immediate remote evidence capture and later COLD recovery only for exceptions strictly before Admission.
+    owner: component-orchestrator-recovery
+    requirement_refs: [FR-43-08, NFR-43-02]
+    unit_refs:
+      - Chunk 3 — orchestrator integration
+      - Chunk 4 — persistent alignment and gate
+    adr_refs: [adr-0008-logical-identity-admission, adr-0001-commit-last, adr-0006-order-independent-rename, adr-issue43-destructive-authorization]
+    verification:
+      - id: verify-post-delta-exception-retention
+        tier: T1
+        command: npm test -- src/sync/orchestrator.test.ts
+      - id: verify-issue46-independent-causality
+        tier: T2
+        command: npm run test:e2e:onedrive
+
+adrs:
+  - id: adr-0008-logical-identity-admission
+    status: accepted
+    decision_input_refs:
+      - input-single-authorization-owner
+      - input-actionless-unresolved
+      - input-disposition-carrier
+      - input-preadmission-exception
+      - decision-input-unified-final-authorization
+      - decision-input-actionless-component-retention
+  - id: adr-0001-commit-last
+    status: accepted
+    decision_input_refs:
+      - input-finalization-commit-last
+      - input-same-session-cold-recovery
+      - decision-input-checkpoint-carrier-shape
+  - id: adr-0006-order-independent-rename
+    status: accepted
+    decision_input_refs:
+      - input-issue46-cache-causality
+      - decision-input-issue46-fold-in
+  - id: adr-issue43-destructive-authorization
+    status: accepted
+    decision_input_refs:
+      - input-authorized-plan-marker
+      - decision-input-api-rename
+      - decision-input-new-persistent-disposition
+      - decision-input-purity-lint
+
+units:
+  - title: Chunk 1 — immutable admission disposition
+    chunk: "1"
+    contract_refs: [contract-proposal-boundary, contract-admission-disposition]
+    files:
+      - src/sync/plan-admission.ts
+      - src/sync/plan-admission-graph.ts
+      - src/sync/plan-admission.test.ts
+      - src/sync/types.ts
+      - src/sync/sync-cycle-planning.ts
+      - src/sync/plan-executor.ts
+    depends_on: []
+    acceptance:
+      - acceptance-exact-delete
+      - acceptance-direct-proposal-rejected
+      - acceptance-snapshot-stable
+      - acceptance-actionless-unresolved
+      - acceptance-actionless-resolved
+      - acceptance-authorized-only
+    objective: Capture one immutable snapshot, emit exhaustive dispositions, and issue the sole nominal authorized action projection.
+    output_format: Pure TypeScript snapshot, disposition, nominal authorization, and adversarial unit matrix.
+    tool_guidance: Keep proposal outputs plain, reference existing normative evidence, and retain relevant zero-action components.
+    task_boundaries: No I/O, lifecycle manager, persistence, notification, executor scheduling, or Issue 46 cache changes.
+    decision_closure_reason: Only the private membership carrier is delegated by discretion-component-membership-carrier.
+  - title: Chunk 2 — disposition-driven finalization
+    chunk: "2"
+    contract_refs: [contract-finalization-consumer]
+    files:
+      - src/sync/sync-cycle-finalization.ts
+      - src/sync/sync-cycle-finalization.test.ts
+      - src/sync/rename-debt.ts
+      - src/sync/rename-debt.test.ts
+      - src/sync/execution-result.ts
+    depends_on:
+      - Chunk 1 — immutable admission disposition
+    acceptance:
+      - acceptance-actionless-resolved
+      - acceptance-authorized-failure-retains
+      - acceptance-checkpoint-before-retirement
+      - acceptance-no-finalization-redecision
+    objective: Fold snapshot-bound disposition with mechanical completion and retire evidence only after safe checkpoint commit.
+    output_format: Narrow finalization and debt helpers with commit-last tests.
+    tool_guidance: Remove scope, observation, identity, alias, and action-shape safety evaluation from finalization.
+    task_boundaries: No lifecycle service, persistent graph, state schema, or checkpoint backend change.
+    decision_closure_reason: FR-43-05 through FR-43-07 fix owner, ordering, and failure semantics.
+  - title: Chunk 3 — orchestrator integration
+    chunk: "3"
+    contract_refs: [contract-proposal-boundary, contract-admission-disposition, contract-finalization-consumer, contract-preadmission-recovery]
+    files:
+      - src/sync/orchestrator.ts
+      - src/sync/orchestrator.test.ts
+      - src/sync/sync-cycle-planning.ts
+      - src/sync/remote-change-source.ts
+      - src/sync/sync-notification.ts
+      - src/sync/sync-notification.test.ts
+    depends_on:
+      - Chunk 2 — disposition-driven finalization
+    acceptance:
+      - acceptance-snapshot-stable
+      - acceptance-authorized-only
+      - acceptance-actionless-unresolved
+      - acceptance-disconnected-progress
+      - acceptance-post-delta-exception
+    objective: Route one frozen snapshot through authorization, execution, observability, finalization, and the strict pre-Admission COLD boundary.
+    output_format: Orchestrator and notification integration with multi-cycle regression tests.
+    tool_guidance: Serialize namespace teardown, do not map deferral to FailedActionTracker, and do not trigger an immediate retry.
+    task_boundaries: No backend cache repair, executor phase redesign, persistence, or automatic duplicate action.
+    decision_closure_reason: Production ownership, stability, and observable behavior are fixed by the accepted contract.
+  - title: Chunk 4 — persistent alignment and gate
+    chunk: "4"
+    contract_refs: [contract-proposal-boundary, contract-admission-disposition, contract-finalization-consumer, contract-preadmission-recovery]
+    files:
+      - docs/adr/adr-issue43-destructive-authorization.md
+      - docs/adr/0008-logical-identity-admission-fails-closed.md
+      - ARCHITECTURE.md
+      - docs/sync-pipeline.md
+    depends_on:
+      - Chunk 3 — orchestrator integration
+    acceptance:
+      - acceptance-doc-authority
+      - acceptance-issue46-independent
+      - acceptance-full-gate
+    objective: Align durable authority documentation, preserve Issue 46 causal separation, and verify the complete bounded change.
+    output_format: Minimal documentation updates and recorded focused/full-gate evidence.
+    tool_guidance: Run OneDrive casing and Admission-constant A/B verification independently; do not change Issue 46 implementation.
+    task_boundaries: No lint-policy expansion, backend behavior change, persistent design object, or Issue 46 fix claim.
+    decision_closure_reason: Purity enforcement is fixed to tests/build for this change; no consequential choice remains.
+
+acceptance:
+  - id: acceptance-exact-delete
+    criteria: An authoritative exact remote deletion with no cross-path evidence remains authorized and executable in original order.
+    requirement_refs: [FR-43-01, FR-43-02, FR-43-04]
+  - id: acceptance-direct-proposal-rejected
+    criteria: A typed caller cannot pass a plain proposal SyncPlan to executePlan and supported construction of AuthorizedSyncPlan exists only in Admission.
+    requirement_refs: [FR-43-01, FR-43-04]
+  - id: acceptance-snapshot-stable
+    criteria: A policy, settings, backend, or root change after snapshot capture affects only a later cycle and cannot change the in-flight authorization projection or namespace.
+    requirement_refs: [FR-43-01, FR-43-04, NFR-43-01]
+  - id: acceptance-actionless-unresolved
+    criteria: A present-unresolved or unknown evidence-connected zero-action component emits one deferred disposition, reports partial error, retains evidence/debt, withholds checkpoint, and requests later COLD recovery.
+    requirement_refs: [FR-43-02, FR-43-03, FR-43-10]
+  - id: acceptance-actionless-resolved
+    criteria: Admission alone classifies authoritative two-sided convergence or explicit scope no-op as resolved-no-action, after which checkpoint success precedes retirement.
+    requirement_refs: [FR-43-02, FR-43-05, FR-43-07]
+  - id: acceptance-authorized-only
+    criteria: Execution receives exactly ordered actions from authorized dispositions and none from deferred or resolved-no-action dispositions.
+    requirement_refs: [FR-43-01, FR-43-04, FR-43-09]
+  - id: acceptance-authorized-failure-retains
+    criteria: Failure or block of a bound authorized action retains evidence/debt and prevents checkpoint advancement without changing admission disposition.
+    requirement_refs: [FR-43-06, FR-43-07]
+  - id: acceptance-checkpoint-before-retirement
+    criteria: Checkpoint persistence failure propagates and leaves releasable evidence/debt intact because retirement has not begun.
+    requirement_refs: [FR-43-07]
+  - id: acceptance-no-finalization-redecision
+    criteria: Finalization cannot release a component from scope, observation, identity, alias, or action-shape evaluation without the corresponding Admission disposition.
+    requirement_refs: [FR-43-05, FR-43-06]
+  - id: acceptance-disconnected-progress
+    criteria: Disconnected authorized actions preserve order and may commit per-file state while another component defers, but the cycle checkpoint remains held.
+    requirement_refs: [FR-43-03, FR-43-09, FR-43-10]
+  - id: acceptance-post-delta-exception
+    criteria: A remote rename captured before a later pre-Admission exception survives an empty-delta retry and reaches Admission during later COLD observation.
+    requirement_refs: [FR-43-08]
+  - id: acceptance-issue46-independent
+    criteria: OneDrive casing regression and an Admission-constant A/B pipeline test distinguish backend edge emission from omission without relying on Issue 43 exception-retention behavior.
+    requirement_refs: [FR-43-11]
+  - id: acceptance-doc-authority
+    criteria: ADR and pipeline documentation identify immutable Admission disposition as sole safety resolution and finalization as a mechanical consumer while preserving Issue 46 separation.
+    requirement_refs: [FR-43-01, FR-43-05, FR-43-11]
+  - id: acceptance-full-gate
+    criteria: Repository lint, bot reproduction lint, build, and unit test gate all pass after the bounded change.
+    requirement_refs: [NFR-43-01, NFR-43-02]
+
+dispositions:
+  - decision_input_ref: input-single-authorization-owner
+    disposition: adopted — Admission alone classifies final destructive permission and no-action safety.
+    adr_refs: [adr-0008-logical-identity-admission, adr-issue43-destructive-authorization]
+    contract_refs: [contract-proposal-boundary, contract-admission-disposition, contract-finalization-consumer]
+  - decision_input_ref: input-actionless-unresolved
+    disposition: adopted — retain and visibly defer unresolved relevant components even with zero actions.
+    adr_refs: [adr-0008-logical-identity-admission]
+    contract_refs: [contract-admission-disposition, contract-finalization-consumer]
+  - decision_input_ref: input-disposition-carrier
+    disposition: adopted — enrich cycle-local AdmissionResult and reject a lifecycle service or persistent graph.
+    adr_refs: [adr-issue43-destructive-authorization]
+    contract_refs: [contract-admission-disposition, contract-finalization-consumer]
+  - decision_input_ref: input-membership-encoding
+    disposition: implementation_detail — private cycle-local encoding is delegated only by discretion-component-membership-carrier.
+    contract_refs: [contract-admission-disposition]
+  - decision_input_ref: input-preadmission-exception
+    disposition: adopted — immediate session capture and later COLD apply only before Admission.
+    adr_refs: [adr-0008-logical-identity-admission, adr-0001-commit-last, adr-issue43-destructive-authorization]
+    contract_refs: [contract-preadmission-recovery]
+  - decision_input_ref: input-admission-purity-enforcement
+    disposition: implementation_detail — deterministic tests and build enforce purity for this change; no lint-policy expansion is introduced.
+    contract_refs: [contract-admission-disposition]
+  - decision_input_ref: input-issue46-cache-causality
+    disposition: adopted — keep OneDrive/backend cache evidence causality separate and independently verified.
+    adr_refs: [adr-0006-order-independent-rename, adr-issue43-destructive-authorization]
+  - decision_input_ref: input-authorized-plan-marker
+    disposition: adopted — executePlan accepts only opaque or nominal AuthorizedSyncPlan issued by Admission.
+    adr_refs: [adr-issue43-destructive-authorization]
+    contract_refs: [contract-proposal-boundary]
+  - decision_input_ref: input-finalization-commit-last
+    disposition: adopted — checkpoint commit precedes evidence and debt retirement.
+    adr_refs: [adr-0001-commit-last]
+    contract_refs: [contract-finalization-consumer]
+  - decision_input_ref: input-same-session-cold-recovery
+    disposition: adopted — retained pre-Admission evidence is retried by a later COLD observation without a tight loop.
+    adr_refs: [adr-0001-commit-last, adr-issue43-destructive-authorization]
+    contract_refs: [contract-preadmission-recovery]
+  - decision_input_ref: decision-input-unified-final-authorization
+    disposition: subsumed — input-single-authorization-owner fixes the same Admission-only authority boundary.
+    adr_refs: [adr-0008-logical-identity-admission]
+    contract_refs: [contract-proposal-boundary, contract-admission-disposition]
+  - decision_input_ref: decision-input-checkpoint-carrier-shape
+    disposition: subsumed — input-disposition-carrier retains cycle-local dispositions and existing bounded debt or session carriers.
+    adr_refs: [adr-0001-commit-last, adr-issue43-destructive-authorization]
+    contract_refs: [contract-finalization-consumer]
+  - decision_input_ref: decision-input-actionless-component-retention
+    disposition: subsumed — input-actionless-unresolved fixes exhaustive relevant-component retention.
+    adr_refs: [adr-0008-logical-identity-admission]
+    contract_refs: [contract-admission-disposition]
+  - decision_input_ref: decision-input-new-persistent-disposition
+    disposition: rejected — persistent disposition state and lifecycle graphs add ownership without improving existing bounded recovery.
+    adr_refs: [adr-issue43-destructive-authorization]
+    contract_refs: [contract-admission-disposition, contract-finalization-consumer]
+  - decision_input_ref: decision-input-issue46-fold-in
+    disposition: rejected — Issue 46 evidence-production causality remains independent from authorization and exception retention.
+    adr_refs: [adr-0006-order-independent-rename, adr-issue43-destructive-authorization]
+  - decision_input_ref: decision-input-api-rename
+    disposition: adopted — API change is limited to nominal executor input and snapshot-bound Admission output; proposal APIs remain plain SyncPlan.
+    adr_refs: [adr-issue43-destructive-authorization]
+    contract_refs: [contract-proposal-boundary]
+  - decision_input_ref: decision-input-purity-lint
+    disposition: rejected — do not expand lint policy without repository authority; deterministic contract tests and build are required.
+    contract_refs: [contract-admission-disposition]

--- a/docs/changes/change-20260825-issue43-destructive-authorization/implementation.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/implementation.md
@@ -1,0 +1,167 @@
+---
+change: change-20260825-issue43-destructive-authorization
+role: implementation
+contracts:
+- contract-proposal-boundary
+- contract-admission-disposition
+- contract-finalization-consumer
+- contract-preadmission-recovery
+contract_projections:
+- id: contract-proposal-boundary
+  verifications:
+  - verify-direct-proposal-rejected
+  - verify-snapshot-stability
+  - verify-production-admission-path
+  discretion: []
+- id: contract-admission-disposition
+  verifications:
+  - verify-admission-disposition-matrix
+  - verify-planning-composition
+  discretion:
+  - discretion-component-membership-carrier
+- id: contract-finalization-consumer
+  verifications:
+  - verify-disposition-finalization
+  - verify-cycle-status-and-recovery
+  discretion: []
+- id: contract-preadmission-recovery
+  verifications:
+  - verify-post-delta-exception-retention
+  - verify-issue46-independent-causality
+  discretion: []
+adrs:
+- adr-0008-logical-identity-admission
+- adr-0001-commit-last
+- adr-0006-order-independent-rename
+- adr-issue43-destructive-authorization
+decision_dispositions:
+- decision_input_ref: input-single-authorization-owner
+  disposition: adopted — Admission alone classifies final destructive permission and
+    no-action safety.
+  adr_refs:
+  - adr-0008-logical-identity-admission
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-proposal-boundary
+  - contract-admission-disposition
+  - contract-finalization-consumer
+- decision_input_ref: input-actionless-unresolved
+  disposition: adopted — retain and visibly defer unresolved relevant components even
+    with zero actions.
+  adr_refs:
+  - adr-0008-logical-identity-admission
+  contract_refs:
+  - contract-admission-disposition
+  - contract-finalization-consumer
+- decision_input_ref: input-disposition-carrier
+  disposition: adopted — enrich cycle-local AdmissionResult and reject a lifecycle
+    service or persistent graph.
+  adr_refs:
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-admission-disposition
+  - contract-finalization-consumer
+- decision_input_ref: input-membership-encoding
+  disposition: implementation_detail — private cycle-local encoding is delegated only
+    by discretion-component-membership-carrier.
+  contract_refs:
+  - contract-admission-disposition
+- decision_input_ref: input-preadmission-exception
+  disposition: adopted — immediate session capture and later COLD apply only before
+    Admission.
+  adr_refs:
+  - adr-0008-logical-identity-admission
+  - adr-0001-commit-last
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-preadmission-recovery
+- decision_input_ref: input-admission-purity-enforcement
+  disposition: implementation_detail — deterministic tests and build enforce purity
+    for this change; no lint-policy expansion is introduced.
+  contract_refs:
+  - contract-admission-disposition
+- decision_input_ref: input-issue46-cache-causality
+  disposition: adopted — keep OneDrive/backend cache evidence causality separate and
+    independently verified.
+  adr_refs:
+  - adr-0006-order-independent-rename
+  - adr-issue43-destructive-authorization
+- decision_input_ref: input-authorized-plan-marker
+  disposition: adopted — executePlan accepts only opaque or nominal AuthorizedSyncPlan
+    issued by Admission.
+  adr_refs:
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-proposal-boundary
+- decision_input_ref: input-finalization-commit-last
+  disposition: adopted — checkpoint commit precedes evidence and debt retirement.
+  adr_refs:
+  - adr-0001-commit-last
+  contract_refs:
+  - contract-finalization-consumer
+- decision_input_ref: input-same-session-cold-recovery
+  disposition: adopted — retained pre-Admission evidence is retried by a later COLD
+    observation without a tight loop.
+  adr_refs:
+  - adr-0001-commit-last
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-preadmission-recovery
+- decision_input_ref: decision-input-unified-final-authorization
+  disposition: subsumed — input-single-authorization-owner fixes the same Admission-only
+    authority boundary.
+  adr_refs:
+  - adr-0008-logical-identity-admission
+  contract_refs:
+  - contract-proposal-boundary
+  - contract-admission-disposition
+- decision_input_ref: decision-input-checkpoint-carrier-shape
+  disposition: subsumed — input-disposition-carrier retains cycle-local dispositions
+    and existing bounded debt or session carriers.
+  adr_refs:
+  - adr-0001-commit-last
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-finalization-consumer
+- decision_input_ref: decision-input-actionless-component-retention
+  disposition: subsumed — input-actionless-unresolved fixes exhaustive relevant-component
+    retention.
+  adr_refs:
+  - adr-0008-logical-identity-admission
+  contract_refs:
+  - contract-admission-disposition
+- decision_input_ref: decision-input-new-persistent-disposition
+  disposition: rejected — persistent disposition state and lifecycle graphs add ownership
+    without improving existing bounded recovery.
+  adr_refs:
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-admission-disposition
+  - contract-finalization-consumer
+- decision_input_ref: decision-input-issue46-fold-in
+  disposition: rejected — Issue 46 evidence-production causality remains independent
+    from authorization and exception retention.
+  adr_refs:
+  - adr-0006-order-independent-rename
+  - adr-issue43-destructive-authorization
+- decision_input_ref: decision-input-api-rename
+  disposition: adopted — API change is limited to nominal executor input and snapshot-bound
+    Admission output; proposal APIs remain plain SyncPlan.
+  adr_refs:
+  - adr-issue43-destructive-authorization
+  contract_refs:
+  - contract-proposal-boundary
+- decision_input_ref: decision-input-purity-lint
+  disposition: rejected — do not expand lint policy without repository authority;
+    deterministic contract tests and build are required.
+  contract_refs:
+  - contract-admission-disposition
+milestones:
+- id: '1'
+- id: '2'
+- id: '3'
+- id: '4'
+reference_algorithms: []
+---
+
+# Implementation

--- a/docs/changes/change-20260825-issue43-destructive-authorization/requirements.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/requirements.md
@@ -1,0 +1,63 @@
+---
+change: change-20260825-issue43-destructive-authorization
+role: requirements
+functional_requirements:
+- id: FR-43-01
+  statement: Decision Engine and rename refinement produce plain proposals; only Admission
+    issues destructive permission from a complete immutable cycle snapshot.
+  priority: must
+- id: FR-43-02
+  statement: Admission emits exactly one disposition for every relevant action-bearing
+    or actionless evidence-connected component.
+  priority: must
+- id: FR-43-03
+  statement: Actionless uncertainty is visibly deferred, retains evidence and debt,
+    withholds checkpoint advancement, and requests later COLD reevaluation without
+    a tight retry.
+  priority: must
+- id: FR-43-04
+  statement: Execution accepts only Admission-issued nominal AuthorizedSyncPlan and
+    receives only actions projected from authorized dispositions.
+  priority: must
+- id: FR-43-05
+  statement: Admission alone classifies scope no-op, convergence, identity consistency,
+    alias targeting, and permitted destructive postconditions; finalization does not
+    recompute them.
+  priority: must
+- id: FR-43-06
+  statement: Authorized-component evidence and debt become releasable only after every
+    bound action succeeds; failure or block retains them without changing authorization.
+  priority: must
+- id: FR-43-07
+  statement: Releasable evidence and local debt retire only after safe checkpoint
+    commit and remain intact when checkpoint persistence fails.
+  priority: must
+- id: FR-43-08
+  statement: Remote evidence is captured before later fallible work; an exception
+    strictly before Admission retains it and requests COLD recovery without fabricating
+    a disposition.
+  priority: must
+- id: FR-43-09
+  statement: Disconnected authorized actions preserve proposal order and may commit
+    per-file state while another component is deferred, without checkpoint advancement.
+  priority: must
+- id: FR-43-10
+  statement: Every deferred disposition contributes exactly once to partial status,
+    notification count, diagnostics, checkpoint withholding, and later COLD recovery.
+  priority: must
+- id: FR-43-11
+  statement: Issue 46 remains owned by OneDrive backend and cache evidence production
+    and is verified independently by its casing regression and an Admission-constant
+    A/B pipeline test.
+  priority: must
+- id: NFR-43-01
+  statement: Equal immutable snapshots produce equal disposition membership, reason
+    ordering, and authorized action order without I/O or mutation.
+  priority: must
+- id: NFR-43-02
+  statement: The design adds no lifecycle manager, persistent component graph, remote
+    debt, or duplicate normative evidence DTO.
+  priority: must
+---
+
+# Requirements

--- a/docs/changes/change-20260825-issue43-destructive-authorization/verification.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/verification.md
@@ -4,3 +4,53 @@ role: verification
 ---
 
 # Verification
+
+## Contract verification
+
+- `contract-proposal-boundary`: Admission is the only production conversion from a
+  plain proposal to `AuthorizedSyncPlan`; `executePlan` rejects a plain `SyncPlan` at
+  compile time. Snapshot container and namespace stability are covered directly.
+- `contract-admission-disposition`: focused Admission tests cover exact deletes,
+  opposing deletes, aliases, stable identity, folder mappings, actionless convergence,
+  and actionless uncertainty. Every relevant component receives one disposition.
+- `contract-finalization-consumer`: finalization folds only Admission disposition
+  membership and execution completion. Tests cover no re-decision, checkpoint-before-
+  retirement, checkpoint failure, deferred retention, and partial execution.
+- `contract-preadmission-recovery`: orchestrator tests prove immediate remote-edge
+  capture, no tight retry after a later pre-Admission failure, retained evidence, and a
+  later forced COLD run. OneDrive tests independently prove casing-only rename emission
+  and Admission-constant A/B causality.
+
+## Verification results
+
+- Focused safety suite: 6 files, 169 tests passed.
+- Repository gate: `npm run lint`, `npm run lint:bot-repro`, `npm run build`, and
+  `npm test` passed; the full unit suite contains 95 files and 1,595 tests.
+- Live API E2E on the final source: Google Drive, Dropbox, and OneDrive all passed;
+  3 files and 151 tests, including shared rename-safety scenarios.
+- dev-evidence from `bc83e3262b05d9a02b7f6c4b6259a9f3f99ef319`: 116 changed
+  paths analyzed; `out-of-scope-changes.v2` and
+  `closure.evidence-readiness.v1` both returned PASS with no findings.
+- Main-session correctness review verdict: `approved`; no blocking finding remained.
+
+## Branch-wide minimality audit
+
+The audit covered the complete 116-file branch delta, not only the latest Admission
+change. Decision Engine remains an exact-path proposal producer and is unchanged from
+the requested base. Moving cross-path identity, endpoint scope, unresolved observations,
+and actionless components into it would combine evidence acquisition with permission
+and still require an executor guard, so it would not remove the necessary contract.
+
+The necessary boundaries are:
+
+1. backend/local producers establish authoritative observations and identity evidence;
+2. Admission alone classifies final permission and issues the nominal executable plan;
+3. executor performs only admitted actions;
+4. finalization mechanically folds completion and commits the checkpoint before
+   retiring evidence/debt;
+5. orchestrator retains only pre-Admission evidence failures for a later COLD run.
+
+No lifecycle manager, persistent component graph, remote debt, duplicate evidence DTO,
+or second authorization decision was added. One redundant planning/logging carrier
+(`actionTypes` plus `scopeProjection` beside the snapshot) was found and removed; logs
+now consume the same `AdmissionResult.snapshot` contract.

--- a/docs/changes/change-20260825-issue43-destructive-authorization/verification.md
+++ b/docs/changes/change-20260825-issue43-destructive-authorization/verification.md
@@ -1,0 +1,6 @@
+---
+change: change-20260825-issue43-destructive-authorization
+role: verification
+---
+
+# Verification

--- a/docs/code-enforcement.md
+++ b/docs/code-enforcement.md
@@ -100,6 +100,19 @@ functions — no I/O, no clock, no randomness — so every intermediate state is
 | **How** | `no-restricted-imports` + `no-restricted-syntax` (error), scoped to those files |
 | **Exception** | Pass timestamps/variation in as data. To add a new pure transform, list its file in `PURE_TRANSFORMS` |
 
+### Producer-qualified mock path evidence
+
+Sync tests must not choose path authority independently from the filesystem role.
+The canonical role factories keep mutation-backed local observations resolved and
+remote observations as request echoes until a test explicitly models provider confirmation.
+
+| | |
+|---|---|
+| **Prevents** | `src/sync/**/*.test.ts` importing the raw authority-parameterized `createMockFs`, which could give remote mutations invented `actual_resolved` evidence |
+| **Where** | `RAW_SYNC_MOCK_FS_IMPORT` in `eslint.config.mts` |
+| **How** | `no-restricted-imports` (error), scoped to sync tests |
+| **Exception** | Raw construction is reserved for dedicated mock contract tests under `src/__mocks__/`; sync tests use `createMockLocalFs()` or `createMockRemoteFs()` |
+
 ## 6. Single responsibility per module (Principle #7)
 
 Each file owns one concept. The `max-lines` cap is a **prompt to consider a

--- a/docs/code-enforcement.md
+++ b/docs/code-enforcement.md
@@ -136,9 +136,10 @@ the new size, with a comment saying why the split was deferred. The pin is a
 ratchet: it stops *silent* growth and flags the file as split-when-convenient — it
 is not a mandate to shrink the file by force.
 
-Four modules currently carry such overrides as known debt: `fs/googledrive/auth.ts`
-(337), `sync/orchestrator.ts` (385), `fs/caching/remote-fs.ts` (326), and
-`fs/backend-manager.ts` (341). Ratchet them down when a natural split presents itself.
+Five modules currently carry such overrides as known debt: `fs/googledrive/auth.ts`
+(337), `sync/orchestrator.ts` (406), `sync/plan-admission.ts` (398),
+`fs/caching/remote-fs.ts` (326), and `fs/backend-manager.ts` (341). Ratchet them down
+when a natural responsibility split presents itself.
 (`fs/googledrive/index.ts` was here at 397; ADR 0001 lifted its cache/checkpoint
 machinery into `fs/caching/`, dropping it back under 300, so it is no longer
 overridden.)

--- a/docs/code-enforcement.md
+++ b/docs/code-enforcement.md
@@ -124,7 +124,7 @@ ratchet: it stops *silent* growth and flags the file as split-when-convenient â€
 is not a mandate to shrink the file by force.
 
 Four modules currently carry such overrides as known debt: `fs/googledrive/auth.ts`
-(337), `sync/orchestrator.ts` (385), `fs/caching/remote-fs.ts` (317), and
+(337), `sync/orchestrator.ts` (385), `fs/caching/remote-fs.ts` (326), and
 `fs/backend-manager.ts` (341). Ratchet them down when a natural split presents itself.
 (`fs/googledrive/index.ts` was here at 397; ADR 0001 lifted its cache/checkpoint
 machinery into `fs/caching/`, dropping it back under 300, so it is no longer

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -102,6 +102,26 @@ npm run test:e2e:onedrive  # OneDrive only
 - **One token missing** → that backend warns and skips; the other runs.
 - **No tokens** → both warn and skip; exit 0.
 
+### Run it OUTSIDE an agent/CLI sandbox
+
+The e2e needs two things a command sandbox typically denies, and **both fail in ways that
+do not look like a sandbox problem**:
+
+- **Read access to `.env.e2e`.** A sandbox that masks the file (e.g. bind-mounting it to
+  `/dev/null`) leaves `readCreds` empty, so every backend takes the *skip* path and the run
+  exits **0 with a warning** — a green-looking run that never touched a live API. Check with
+  `ls -l .env.e2e`: a character device (`crw-rw-rw- … 1, 3`) instead of a regular file means
+  it is masked.
+- **Local sockets for the Electron net host.** `e2e/electron-net-setup.ts` starts an Electron
+  process so `requestUrl` runs on its real transport. Blocked loopback/dbus sockets surface as
+  `The platform failed to initialize` followed by
+  `Electron net host did not become healthy at http://127.0.0.1:<port>/health within 30000ms`,
+  and vitest then reports `No test files found` — the global-setup failure, not a missing test.
+
+So run the e2e from a plain shell. Under Claude Code that means
+`dangerouslyDisableSandbox: true` (or `/sandbox` to relax the policy); the sandboxed run is
+worse than useless because it is **green while proving nothing**.
+
 > Running Google individually needs `AIRSYNC_E2E_GOOGLE_CLIENT_ID`/`_CLIENT_SECRET` in
 > `.env.e2e` (the refresh token alone falls back to the built-in auth server, which can't
 > refresh a token minted by your own OAuth client). OneDrive likewise needs

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -9,12 +9,14 @@ The **opt-in e2e** runs that *same* contract against the **live** APIs to catch 
 ([ADR 0003](adr/0003-opt-in-e2e-validates-fakes-against-real-backends.md)). It is
 **local/manual only** — never part of `npm test`, the lint gate, or CI.
 
-The OneDrive suite also runs the Issue #45 composed rename-safety scenario: establish a
-baseline, perform a local-origin case-only rename, perform a remote-origin case-only
-rename through the real Graph delta, reset the checkpoint for a later COLD cycle, then
-assert one correctly-cased copy, preserved content, and no opposing delete. Its shared
-CRUD contract additionally verifies that native identity survives rename and changes on
-same-path replacement.
+Every backend suite also runs the Issue #45 composed rename-safety scenario: establish a
+persisted metadata checkpoint, perform a local-origin case-only rename, perform a
+remote-origin case-only rename through the real delta API, reset the checkpoint for a
+later COLD cycle, then assert one correctly-cased copy, preserved content, and no opposing
+delete. The shared CRUD contracts additionally verify that native identity survives rename
+and changes on same-path replacement. Supplying the real `MetadataStore` in this scenario
+is load-bearing: without it the scope fingerprint cannot commit, every cycle is COLD, and
+the fixture bypasses the WARM delta-evidence path used by the plugin.
 
 > **Use a throwaway test account, not a real vault.** The suite creates and then
 > recursively deletes an `airsync-e2e-*` folder on each run.
@@ -229,6 +231,15 @@ skipped or green.
   timestamp." mtime is not Dropbox's change-detection signal (that is the content-hash
   `remoteChecksum`), so nothing load-bearing is dropped. This is the documented divergence
   from ADR 0002, surfaced by this e2e.
+- **Dropbox case-only rename.** Dropbox documents that `move_v2` does not support
+  case-only renaming, and casing-only changes are not returned by `list_folder/continue`.
+  `DropboxFs.rename()` therefore uses a deterministic intermediate sibling path, resumes
+  the second leg when that path already contains the same stable id, rejects a foreign
+  occupant before mutation, and rolls the first leg back when the final move fails. The
+  live composed scenario performs the remote-origin rename through two raw client moves,
+  modelling another Dropbox client without pre-updating Air Sync's cache. See
+  [Issue #47](https://github.com/takezoh/obsidian-air-sync/issues/47) and the
+  [official Dropbox SDK route contract](https://dropbox.github.io/dropbox-sdk-js/Dropbox.html#filesMoveV2__anchor).
 - **OneDrive mtime.** Unlike Dropbox, `OneDriveFs` PATCHes `fileSystemInfo.lastModifiedDateTime`
   right after the content PUT, so the written mtime *is* preserved (not a server clock) — but
   this e2e proved Microsoft Graph stores it at **whole-second** precision (`12345 → 12000`,

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -9,6 +9,13 @@ The **opt-in e2e** runs that *same* contract against the **live** APIs to catch 
 ([ADR 0003](adr/0003-opt-in-e2e-validates-fakes-against-real-backends.md)). It is
 **local/manual only** — never part of `npm test`, the lint gate, or CI.
 
+The OneDrive suite also runs the Issue #45 composed rename-safety scenario: establish a
+baseline, perform a local-origin case-only rename, perform a remote-origin case-only
+rename through the real Graph delta, reset the checkpoint for a later COLD cycle, then
+assert one correctly-cased copy, preserved content, and no opposing delete. Its shared
+CRUD contract additionally verifies that native identity survives rename and changes on
+same-path replacement.
+
 > **Use a throwaway test account, not a real vault.** The suite creates and then
 > recursively deletes an `airsync-e2e-*` folder on each run.
 
@@ -23,7 +30,8 @@ npm run test:e2e                      # runs the contract against the live APIs
 ```
 
 With **no** credentials, `npm run test:e2e` warns and skips every backend and exits 0 — so
-it can never break anything if run by accident.
+it can never break anything if run by accident. A skipped run proves only that the harness
+is credential-gated; it is not live semantic evidence and must be reported as blocked.
 
 ## Prerequisites
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -2,18 +2,20 @@
 
 ## Pipeline overview
 
-Each sync cycle runs a 4-phase pipeline:
+Each sync cycle runs a fail-closed planning and execution pipeline:
 
-1. **Collect** -- `collectChanges()` gathers `MixedEntity[]` using the appropriate temperature mode
-2. **Decide** -- `planSync()` maps each `MixedEntity` to a `SyncAction`
-3. **Execute** -- `executePlan()` runs I/O in lane/tier phases (transfers → conflicts → structural; see [Execution phases](#execution-phases-lanetier-scheduling))
-4. **Commit** -- `commitAction()` persists each successful action's `SyncRecord` to IndexedDB
+1. **Collect evidence** -- `collectChanges()` returns exact `entries`, path `observations`, and normative `identityEvidence`
+2. **Project scope** -- `projectScope()` classifies every evidence endpoint before entry filtering
+3. **Decide** -- `planSync()` maps exact in-scope entries to actions
+4. **Refine** -- `refinePlan()` derives native rename actions without replacing the normative evidence
+5. **Admit** -- `admitDestructivePlan()` removes every action in an unsafe evidence-connected component
+6. **Execute/commit** -- `executePlan()` receives admitted actions only; successful actions commit per-path state, then `finalizeSyncCycle()` advances the checkpoint and retires debt only at a safe cycle boundary
 
-The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives this pipeline, applying scope filtering and mobile size limits between Collect and Decide.
+The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives the I/O boundaries. Scope projection, planning, and admission are composed by `prepareSyncCyclePlan()` without filesystem or state writes.
 
 **Scope filter (`SyncOrchestrator.isExcluded()`)** — a path is synced only if it passes **both** gates:
 
-1. **Dot-path scope** (`isDotPathOutOfScope`): a dot-prefixed/hidden path (`.airsync`, `.obsidian`, `.git`, …) is in scope only when it sits under a configured `syncDotPaths` root — `settings.syncDotPaths` augmented with the vault's config directory when `enableConfigSync` is on (`getEffectiveSyncDotPaths`, `config-sync.ts`). Normal paths always pass. This is applied symmetrically to local and remote entries, so an out-of-scope hidden path on the remote (e.g. another device's `.airsync/logs/`) is never pulled, and never produces a `delete_remote` (the gate runs before `planSync`).
+1. **Dot-path scope** (`isDotPathOutOfScope`): a dot-prefixed/hidden path (`.airsync`, `.obsidian`, `.git`, …) is in scope only when it sits under a configured `syncDotPaths` root — `settings.syncDotPaths` augmented with the vault's config directory when `enableConfigSync` is on (`getEffectiveSyncDotPaths`, `config-sync.ts`). Normal paths always pass. This is applied symmetrically to local and remote evidence. Both rename endpoints are classified before exact entries are filtered, so filtering cannot erase a constraint and leave its destructive half executable.
 2. **Ignore patterns** (`isIgnored`): gitignore-style `ignorePatterns` — likewise augmented with a built-in pattern set (`getEffectiveIgnorePatterns`) prepended when `enableConfigSync` is on while excluding device-specific workspace state. The `syncConfigJsonFiles`, `syncConfigPlugins`, `syncConfigSnippets`, `syncConfigThemes`, and `syncConfigIcons` settings independently add root `*.json`, `plugins/`, `snippets/`, `themes/`, and `icons/`. `community-plugins.json` is classified with `plugins/`, not with generic root JSON, because it is the active community plugin list; it therefore follows `syncConfigPlugins` even when `syncConfigJsonFiles` differs. Root JSON and plugins stay on by default solely for backward compatibility with the pre-toggle Config Sync behavior; all newly introduced subtree scopes default to off and require explicit opt-in. These settings are part of the scope fingerprint, so changing one forces a single cold reconcile and surfaces remote-only files that predate the delta cursor.
 
 `isExcluded()` also reserves two paths unconditionally, ahead of both gates, so neither `syncDotPaths` nor `ignorePatterns` can ever pull them back into scope:
@@ -26,15 +28,17 @@ The same `isExcluded()` gates the vault-event dirty tracking (scheduler), so pus
 
 ## Crash recovery
 
-The remote delta cursor (Google Drive's `changesStartPageToken`) is the engine's "synced up to here" checkpoint. It lives in the backend's IndexedDB store (`META_STORE`), **co-located with the file-map cache and committed in the same transaction** (see [ADR 0001](adr/0001-metadata-cache-is-subordinate-to-commit-last.md)). The orchestrator calls `provider.commitCheckpoint(fs)` **only after a fully-successful cycle** (`result.failed.length === 0`); a partial or interrupted cycle never calls it, so the cursor and cache both stay at the prior committed value.
+The remote delta cursor is the engine's "synced up to here" checkpoint. It lives in the backend's IndexedDB store (`META_STORE`), **co-located with the file-map cache and committed in the same transaction** (see [ADR 0001](adr/0001-metadata-cache-is-subordinate-to-commit-last.md)). `finalizeSyncCycle()` calls `remoteFs.checkpoint.commitCheckpoint()` only when there is no failed/deferred work and no unresolved remote rename evidence. A partial or interrupted cycle leaves cursor and cache at the prior committed value.
 
-At the start of each cycle the orchestrator asks `remoteFs.hasCheckpoint()` (async — it reads the store). When it is false — first sync, an interrupted/partial sync that never committed a checkpoint, or after a manual rescan — `executeSyncOnce` passes `forceFullScan: true` to `collectChanges`, forcing a **cold** reconcile (full remote `list()` × baselines). Cold is the only mode that rediscovers remote files an interrupted sync pulled-but-never-baselined or never reached: the delta-based hot/warm path is blind to them because the cursor has already moved past them (or they predate any cursor, as in an interrupted first sync). When a checkpoint *is* committed, the next sync replays the delta from it, re-detecting any un-synced change.
+At the start of each cycle the orchestrator asks `remoteFs.checkpoint.hasCheckpoint()` (async — it reads the store). `false` means first sync, cleared state, or manual rescan and forces COLD. COLD is also forced after a same-session failed/deferred cycle (`recoverViaColdScan`), after a scope-fingerprint change, and while local rename debt exists. A non-clean cycle after an established checkpoint does **not** erase that checkpoint: same-session recovery ignores the advanced live cursor and lists both sides, while a restart rebuilds the FS from the older committed cursor and replays the delta. This distinction is the two-path recovery contract in ADR 0001.
 
 A **same-session failure** also forces at least one subsequent cold cycle. This is load-bearing (ADR 0001 convergence path 2) — `result.failed` does not capture the full recovery gap (folder-rename descendants, remote-only orphans, detect-vs-execute races), so only a full cold scan re-derives it. After that cold recovery has been paid, the orchestrator may temporarily block only the same repeated **local-origin** poison action (`push`, `delete_remote`, `rename_remote`) whose error classification is `permanent` and carries a stable `permanentCode`. The key is `(backendType, action, path, "permanent", permanentCode)`, the same action signature must fail in two consecutive cycles, and the block lasts 5 minutes or until the action/content changes, succeeds, or fails with a non-eligible classification. The two-cycle threshold means the first failure still buys one mandatory cold recovery pass; the 5 minute TTL is a short mobile-friendly cooldown that prevents repeated poison I/O without persisting across plugin reloads. Blocked actions are reported as `result.blocked` and surface as `partial_error`; they are not treated as "Everything up to date".
 
+A **deferred identity component** is different from a failed action: it never reaches the executor. The cycle ends `partial_error`, reports a deferred count, withholds the checkpoint/scope fingerprint, and marks the next normal trigger for COLD without setting `syncPending` (no tight loop). A local reported rename is first stored as namespace-scoped `RenameDebt`; a remote edge is captured immediately when `getChangedPaths()` yields it, before later `stat`/hash/planning work can throw. Local debt survives restart directly; remote evidence survives restart because its delta checkpoint remains uncommitted. See [ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
+
 Remote-origin or ambiguous actions (`pull`, `delete_local`, `rename_local`, `conflict`) are never blocked, because advancing past them could hide remote changes. Transient and rate-limit failures are also never blocked; after the connection or provider recovers, the next sync must execute I/O again. Re-seeding failed paths for a "hot" recovery, skipping the first cold scan for "small" failure sets, or advancing the cursor while blindly ignoring remote-origin failures are **ADR 0001 prohibited patterns** (they re-open silent in-session data loss). The cost is **bounded and intentionally retained**: per-action `withIoRetry` keeps most transient/429 failures from ever reaching `result.failed`, and repeated cold scans are avoided only after the recovery debt has been paid and the remaining failure is a permanent local-origin poison action.
 
-The **Rescan vault** action (settings → Advanced) discards the committed checkpoint via the live FS (`remoteFs.resetCheckpoint()` — clears the cursor and cache) and triggers a sync, forcing one cold reconcile against the remote — a manual recovery for a vault that looks stuck or incomplete. It diffs against baselines (it does not re-download) and keeps sync history.
+The **Rescan vault** action (settings → Advanced) discards the committed checkpoint via the live FS (`remoteFs.checkpoint.resetCheckpoint()` — clears the cursor and cache) and triggers a sync, forcing one cold reconcile against the remote — a manual recovery for a vault that looks stuck or incomplete. It diffs against baselines (it does not re-download) and keeps sync history.
 
 A backend may keep a **non-authoritative cache** (the Google Drive `path↔id` map in IndexedDB) to avoid a network re-list. That cache is a performance optimization, not a third source of truth. Its only invariant — **never committed ahead of (nor behind) the committed cursor** — is now structural: the cursor lives *in* the cache's store and commits in the same transaction, so they cannot diverge (a failed flush lands neither and propagates, holding the cycle back). Before "optimizing" any of this, read [ADR 0001](adr/0001-metadata-cache-is-subordinate-to-commit-last.md): the recurring bugs here all came from treating the cache as authoritative.
 
@@ -59,13 +63,13 @@ Selected when the hot condition fails (tracker uninitialized, or initialized but
 - Calls `localFs.list()` for a full local listing
 - Calls `getChangedPaths()` for the remote delta
 - Compares the full local listing against all stored `SyncRecord`s to find local changes and deletions
-- Confirms every would-be local deletion against the authoritative filesystem (`confirmLocalDeletions`) so an under-reporting `list()` cannot delete an on-disk file — see [Deletion safety](#deletion-safety)
-- Unions both endpoints (newPath and oldPath) of every local rename pair from `getRenamePairs()` into the changed set, so warm mode produces the delete_remote+push actions the rename optimizer consumes
+- Confirms every baseline absence against the authoritative filesystem (`confirmBaselineAbsences`) so an under-reporting list cannot authorize deletion on either side — see [Deletion safety](#deletion-safety)
+- Adds both endpoints of every local reported rename from the cycle snapshot to the observations/change surface; the normative record is then `ChangeSet.identityEvidence`
 - Calls `remoteFs.stat()` only for paths identified as changed
 
 ### Cold -- O(n)
 
-Selected when `stateStore.getAll()` returns an empty array (first sync or after state clear), or forced via `forceFullScan` during [crash recovery](#crash-recovery) (no committed remote checkpoint).
+Selected when `stateStore.getAll()` returns an empty array (first sync or after state clear), or forced via `forceFullScan` for a missing checkpoint, same-session recovery, scope change, or persisted local rename debt.
 
 - Calls both `localFs.list()` and `remoteFs.list()`
 - Full outer join on path to build `MixedEntity[]` for every file on either side
@@ -85,21 +89,21 @@ After any temperature mode collects entries, `collectChanges()` runs `enrichHash
 
 Uses `AsyncPool(10)` for parallel local reads. Per-file errors are caught and skipped (file stays unenriched → treated as conflict, safe side).
 
-After initial-match enrichment, `enrichHashesForRenames()` runs for entries that are rename destinations (from `localTracker.getRenamePairs()`). In warm/cold mode, `list()` returns `hash: ""`, but the rename optimizer needs SHA-256 to verify content equivalence. This step calls `stat()` on rename destination entries to compute their hash. Only the `hash` field is updated; `mtime` and `size` from `list()` are preserved.
+After initial-match enrichment, `enrichHashesForRenames()` runs for destinations in the optimizer view derived from `ChangeSet.identityEvidence`. In warm/cold mode, `list()` returns `hash: ""`, but local-origin rename validation needs SHA-256 content equivalence. This step calls `stat()` on exact local destination entries. Only the `hash` field is updated; `mtime` and `size` from `list()` are preserved.
 
-`collectChanges()` runs three post-collection steps in order: `enrichHashesForInitialMatch` (all modes, `AsyncPool(10)`), `enrichHashesForRenames` (all modes, unthrottled `Promise.all`), and — warm mode only — `confirmLocalDeletions` (`AsyncPool(10)`; see [Deletion safety](#deletion-safety)).
+Before hash enrichment, `collectChanges()` creates observations for every rename endpoint, confirms unknown endpoints, confirms the opposite side of carried debt/evidence, and in WARM/COLD confirms every baseline absence. A thrown `stat()` aborts the attempt; it is never converted to absence. Hash enrichment then touches exact entries only, and `completeIdentityEvidence()` adds same-root stable-ID occurrences.
 
 ## Change detection
 
 ### Local changes
 
-`LocalChangeTracker` (`local-tracker.ts`) tracks dirty paths in memory via a `Set<string>`. Vault events (`create`, `modify`, `delete`) call `markDirty(path)`. The `rename` event calls `markRenamed(newPath, oldPath)`, which records the pair in a `renamePairs` map (used by the rename optimizer) and marks both paths dirty. Rename chains are collapsed (A→B→C becomes A→C). Each sync cycle captures a `snapshot()` of the tracker at the start (a frozen copy of `dirtyPaths` / `renamePairs` / `folderRenamePairs` / `initialized`) and acknowledges exactly that snapshot at the end: `acknowledge(snapshot)` deletes the snapshot's paths from the dirty set and clears each captured rename / folder-rename pair only when the live entry still matches the snapshot's value (so a mid-cycle rename reusing a key survives), then sets `initialized = true`. Acknowledging the start-of-cycle snapshot rather than the live set keeps a `markDirty` arriving mid-cycle for the next cycle instead of sweeping it (see [Acknowledge pattern](error-handling.md#acknowledge-pattern)).
+`LocalChangeTracker` (`local-tracker.ts`) tracks dirty paths in memory via a `Set<string>`. Vault events (`create`, `modify`, `delete`) call `markDirty(path)`. The `rename` event calls `markRenamed(newPath, oldPath)`, which records the producer pair and marks both paths dirty. Rename chains are collapsed (A→B→C becomes A→C). At collection, `collectLocalRenameEvidence()` converts the captured pair exactly once into the normative `RenameEvidence`; optimizer views are derived from that evidence rather than maintained as a second source of truth. Each sync cycle captures a `snapshot()` of the tracker at the start (a frozen copy of `dirtyPaths` / `renamePairs` / `folderRenamePairs` / `initialized`) and acknowledges exactly that snapshot at the end: `acknowledge(snapshot)` deletes the snapshot's paths from the dirty set and clears each captured rename / folder-rename pair only when the live entry still matches the snapshot's value (so a mid-cycle rename reusing a key survives), then sets `initialized = true`. Acknowledging the start-of-cycle snapshot rather than the live set keeps a `markDirty` arriving mid-cycle for the next cycle instead of sweeping it (see [Acknowledge pattern](error-handling.md#acknowledge-pattern)).
 
-Folder renames are tracked separately: a `rename` event whose target is a `TFolder` routes to `markFolderRenamed(newPath, oldPath)`, recording the pair in a distinct `folderRenamePairs` map (also chain-collapsing A→B→C to A→C), while files go to `markRenamed`. Unlike `markRenamed`, this does not mark any path dirty. The orchestrator reads the cycle snapshot's `folderRenamePairs` and passes it into `refinePlan()` as a separate argument, where `coalesceLocalFolderRenames` consumes it.
+Folder renames are captured separately at the event boundary: a `TFolder` routes to `markFolderRenamed(newPath, oldPath)`, recording a chain-collapsed producer pair while files use `markRenamed`. Unlike file rename capture, this does not mark every descendant dirty. Collection converts both maps into the same normative `RenameEvidence` shape (`isFolder` distinguishes them); `refinePlan(plan, identityEvidence)` receives that single evidence collection and derives its folder optimizer view.
 
 ### Remote changes
 
-`IFileSystem.getChangedPaths()` returns `{ modified, deleted, renamed? }` or `null`. `null` means no incremental data is available — fall back to warm/cold detection. The `renamed` array carries `{ oldPath, newPath, isFolder? }` pairs for native rename optimization. For the Google Drive implementation of this contract (changes.list, the 410 full-scan delta, fullScanWithDelta), see [Incremental sync](google-drive-backend.md#incremental-sync) and [Cache invalidation](google-drive-backend.md#cache-invalidation).
+`IFileSystem.checkpoint.getChangedPaths()` returns `{ modified, deleted, renamed? }` or `null`. `null` means no incremental data is available — fall back to warm/cold detection. The `renamed` array carries `{ oldPath, newPath, isFolder? }` as authoritative reported evidence. The acquisition owner captures that evidence before later detection work, so a retry cannot consume the live cursor and lose the constraint.
 
 ### Comparison functions
 
@@ -141,11 +145,12 @@ For no-baseline rows the localChanged/remoteChanged columns do not apply — `ha
 
 ## Deletion safety
 
-There is no volume-based abort gate. Deletion safety rests on three independent layers:
+There is no volume-based abort gate. Deletion safety rests on four independent layers:
 
 1. **Decision rules** -- an ambiguous case (a file gone on one side while the surviving side changed since baseline) is routed to `conflict` (keep both), never to a deletion; a missing baseline never yields a deletion.
 2. **layoutReady gate** -- sync does not run before the Obsidian vault index is loaded. `SyncScheduler` defers its event wiring, and `runSync()` is gated on `app.workspace.layoutReady`, so a `list()` that under-reports during startup cannot be mistaken for mass local deletions.
-3. **Authoritative absence** -- a would-be local deletion (a baseline path missing from the in-memory `list()`) is re-`stat()`'d against the filesystem before it is acted on. `LocalFs.stat()` falls back to the vault adapter on an index miss. Only warm change detection runs `confirmLocalDeletions()` (hot and cold do not), re-`stat()`-ing each candidate (an entry with a prior baseline but no `local`: `!e.local && e.prevSync`) via `AsyncPool(10)`; a non-directory file found on disk has its `entry.local` restored, moving it out of the deletion branches. Only a genuine absence (gone on disk too, or `stat()` returns null/throws) propagates. Deletions are additionally soft -- to trash on both sides -- so even a correct deletion stays recoverable.
+3. **Authoritative observation** -- listing absence is re-`stat()`'d before it can authorize deletion. `LocalFs.stat()` falls back to the vault adapter on an index miss. `actual_resolved` proves an exact/alias path; `requested_echo` proves presence only; `null` proves absence; a thrown stat aborts the cycle. HOT checkpoint tombstones remain authoritative remote absence (Issue #44).
+4. **Whole-component admission** -- rename, alias, unresolved-presence, and stable-ID edges connect related paths. If the refined plan cannot prove that every known resource survives under the direction-aware scope matrix, `admitDestructivePlan()` removes the entire component before execution. Deletions are additionally soft (trash), but recoverability is not used as authorization.
 
 ## Rename optimization
 
@@ -153,22 +158,43 @@ There is no volume-based abort gate. Deletion safety rests on three independent 
 
 ### Local renames — hash-verified (`optimize-local-renames.ts`)
 
-When `LocalChangeTracker` records a rename pair (from Obsidian's `rename` event), the optimizer matches `delete_remote(oldPath) + push(newPath)` → `rename_remote`. Hash verification is mandatory: `push.local.hash === del.baseline.hash` must hold, confirming content is unchanged. The centralised `isValidLocalRename()` function enforces this rule for both file and folder renames.
+For a local reported rename in `ChangeSet.identityEvidence`, the optimizer matches `delete_remote(oldPath) + push(newPath)` → `rename_remote`. Hash verification is mandatory: `push.local.hash === del.baseline.hash` must hold, confirming content is unchanged. The centralized `isValidLocalRename()` function enforces this rule for both file and folder renames.
 
-- **File renames** (`optimizeLocalFileRenames`): Matches individual rename pairs from `localTracker.getRenamePairs()`.
-- **Folder renames** (`coalesceLocalFolderRenames`): When a folder rename is detected, coalesces all descendant file rename actions into a single `rename_remote` with `isFolder: true`. Only coalesces when ALL descendants pass hash verification. Uncoalesced file renames fall through to individual file rename optimization.
+- **File renames** (`optimizeLocalFileRenames`): Consumes the derived file view of local `RenameEvidence`.
+- **Folder renames** (`coalesceLocalFolderRenames`): Consumes the derived folder view and coalesces all mapped descendant actions into one `rename_remote` with `isFolder: true`. Every descendant must pass hash verification; incomplete mappings are later deferred by admission.
 
 ### Remote renames — trusted (`optimize-remote-renames.ts`)
 
-When `getChangedPaths()` reports a rename pair, the optimizer matches `delete_local(oldPath) + pull(newPath)` → `rename_local`. The rename pair from the backend is authoritative, so no hash verification is needed. Surfacing that pair is the backend's job and is **order-independent** across all backends ([ADR 0006](adr/0006-remote-rename-detection-is-order-independent.md)): id-addressed backends (Google Drive, OneDrive) get it for free, while Dropbox's path-addressed delta (a `deleted(old)`+`add(new)` pair whose ordering Dropbox does not guarantee) reorders upserts-before-deletes so a folder rename never degrades to a file-by-file re-pull.
+When `getChangedPaths()` reports a rename pair, the optimizer attempts `delete_local(oldPath) + pull(newPath)` → `rename_local`. The report is authoritative rename evidence, so this optimization needs no content-hash inference. Surfacing that pair is the backend's job and is order-independent across all backends ([ADR 0006](adr/0006-remote-rename-detection-is-order-independent.md)). Optimization is not the safety boundary: whether the refined result may execute is decided afterward by admission.
 
-- **File renames** (`optimizeRemoteFileRenames`): Matches individual rename pairs from the backend. The match requires the old path to be a pure `delete_local` and the new path a `pull`; if a same-name file was created at the old path in the same sync, that path becomes a `pull`/`conflict` (not `delete_local`), so the rename correctly does NOT coalesce — the move and the new file resolve as two independent transfers (right end state, no move optimization). The local optimizer (`optimize-local-renames.ts`) is symmetric: it needs `delete_remote(old)` + `push(new)`.
+- **File renames** (`optimizeRemoteFileRenames`): Matches individual rename pairs from the backend. The match requires the old path to be a pure `delete_local` and the new path a `pull`. If a new object was created at the old path, native rename does not coalesce; admission permits the source-recreation fallback only when stable-ID evidence proves the moved and recreated objects are distinct and the actions preserve both. The local optimizer (`optimize-local-renames.ts`) is symmetric: it needs `delete_remote(old)` + `push(new)`.
 - **Folder renames** (`coalesceRemoteFolderRenames`): When a folder-level rename pair has `isFolder: true`, coalesce every `delete_local` child under the old prefix into one `rename_local` (`isFolder: true`). Rules: (1) Absorb a descendant whose matching `pull` is missing into the rename — rewrite its baseline to the new path; a genuine remote delete then propagates as `delete_local` next cycle (bias toward safe deletion). (2) Skip the whole folder (reason `destination_occupied`) if any action under the new prefix has a non-null local entity (`a.local != null`), falling back to the per-file actions. Detection is best-effort; a per-action `localFs.rename` failure is caught and recovers next cycle. See `optimize-remote-renames.ts` for rationale. Remaining file-level pairs fall through to individual file rename optimization.
-  - **Optimization opportunity (not implemented):** the `destination_occupied` skip re-downloads *every* child via `delete_local`+`pull`, even children whose own destination `B/x` is free. A finer fallback could expand the folder pair into per-child pairs and route them through `optimizeRemoteFileRenames`, turning each free-destination child into a `rename_local(A/x→B/x)` (no re-download) and leaving only the genuinely-colliding child as `conflict`/`match`. Purely an efficiency win in a rare case — convergence already guarantees correctness — left unimplemented to keep the coalescer all-or-nothing. See [ADR 0006](adr/0006-remote-rename-detection-is-order-independent.md).
+  - **Optimization opportunity (not implemented):** a destination-occupied folder rename may be decomposable into per-child mappings, but only a complete mapping whose postconditions pass admission may execute. Incomplete mappings defer; see [ADR 0006](adr/0006-remote-rename-detection-is-order-independent.md) and [ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
+
+## Destructive admission
+
+`prepareSyncCyclePlan()` projects scope before filtering, creates/refines the ordinary
+plan, then calls the pure `admitDestructivePlan()`. Admission builds connected
+components from actions plus rename/alias/stable-identity evidence and path
+observations. It admits an exact native rename, a proven direction-specific scope
+transition, or the recognized source-recreation postcondition. Otherwise it defers the
+whole component, including state-only actions; disconnected components remain
+executable in their original order.
+
+Endpoint dispositions are `included`, `policy_out`, `mobile_deferred`, or `unknown`.
+Any unknown/mobile endpoint and any incomplete folder descendant mapping defers. The
+full local/remote direction matrix and rejected identity inferences are recorded in
+[ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
+
+Before admitted I/O, local reported edges are upserted into the SyncState v6 rename-debt
+store under the active backend/root namespace. `finalizeSyncCycle()` owns the opposite
+boundary: safe checkpoint commit first, then resolved debt deletion and session-evidence
+release. Disconnect/root switch waits on the orchestrator mutex before clearing state,
+so an old-target in-flight cycle cannot recreate debt after teardown.
 
 ### Observability
 
-Each optimization step returns `RenameOptResult` with `applied` (successful renames) and `skipped` (with structured `reason`: `action_type_mismatch`, `hash_mismatch`, `hash_missing`, `no_descendants`, `destination_occupied`). `refinePlan()` logs these via the debug logger.
+Each optimization step returns `RenameOptResult` with `applied` (successful renames) and `skipped` (with structured `reason`: `action_type_mismatch`, `hash_mismatch`, `hash_missing`, `no_descendants`, `destination_occupied`). `refinePlan()` logs these via the debug logger. Admission logs each deferred component's reason, evidence kind/origin, endpoint dispositions, and paths (never content or credentials); status and the coalesced user notification include the deferred count.
 
 ## Execution phases (lane/tier scheduling)
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -8,10 +8,10 @@ Each sync cycle runs a fail-closed planning and execution pipeline:
 2. **Project scope** -- `projectScope()` classifies every evidence endpoint before entry filtering
 3. **Decide** -- `planSync()` maps exact in-scope entries to actions
 4. **Refine** -- `refinePlan()` derives native rename actions without replacing the normative evidence
-5. **Admit** -- `admitDestructivePlan()` removes every action in an unsafe evidence-connected component
-6. **Execute/commit** -- `executePlan()` receives admitted actions only; successful actions commit per-path state, then `finalizeSyncCycle()` advances the checkpoint and retires debt only at a safe cycle boundary
+5. **Admit** -- the orchestrator captures one `CycleAdmissionSnapshot`; `admitDestructivePlan()` assigns every relevant component one disposition and issues the only `AuthorizedSyncPlan`
+6. **Execute/commit** -- `executePlan()` accepts that nominal plan only; successful actions commit per-path state, then `finalizeSyncCycle()` mechanically folds the same dispositions with completion and retires debt only after a safe checkpoint
 
-The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives the I/O boundaries. Scope projection, planning, and admission are composed by `prepareSyncCyclePlan()` without filesystem or state writes.
+The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives the I/O boundaries. `prepareSyncCycleSnapshot()` performs pure scope projection, proposal, refinement, and snapshot capture. The orchestrator then invokes Admission once at an explicit cut point; proposal output is never executable permission.
 
 **Scope filter (`SyncOrchestrator.isExcluded()`)** — a path is synced only if it passes **both** gates:
 
@@ -24,7 +24,7 @@ The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives the I/O boundarie
 
 The same `isExcluded()` gates the vault-event dirty tracking (scheduler), so push and pull use one scope rule across hot and cold paths.
 
-`runSync()` is gated on a connected remote (`remoteFs` present), layout-ready, and not-connecting; it serializes via an `AsyncMutex`. A call arriving while a sync runs sets `syncPending` and returns; the lock holder re-runs in a `do/while (syncPending)` loop, acknowledging each cycle's start-of-cycle snapshot at the end of each non-fatal cycle (coalescing). Each cycle (`executeSyncOnce`) is wrapped by `executeWithRetry`, which retries up to `MAX_RETRIES = 3` with exponential backoff plus jitter (`2^(attempt-1) * 1000 * (0.5 + Math.random())` ms), honoring `Retry-After` (×1000) on 429/403. `AuthError`, a non-rate-limit 403, and 404 abort without retry; a fatal abort returns early and leaves the dirty set un-acknowledged so it is retried next run.
+`runSync()` is gated on a connected remote (`remoteFs` present), layout-ready, and not-connecting; it serializes via an `AsyncMutex`. A call arriving while a sync runs sets `syncPending` and returns; the lock holder re-runs in a `do/while (syncPending)` loop, acknowledging each cycle's start-of-cycle snapshot at the end of each non-fatal cycle (coalescing). Each cycle (`executeSyncOnce`) is wrapped by `executeWithRetry`, which normally retries up to `MAX_RETRIES = 3` with exponential backoff plus jitter (`2^(attempt-1) * 1000 * (0.5 + Math.random())` ms), honoring `Retry-After` (×1000) on 429/403. `AuthError`, a non-rate-limit 403, and 404 abort without retry. An exception after remote rename evidence was yielded but strictly before Admission also does not tight-retry: the evidence is retained, the run reports an error, and the next normal trigger is forced COLD. A fatal abort leaves the dirty set un-acknowledged so it is retried next run.
 
 ## Crash recovery
 
@@ -34,7 +34,7 @@ At the start of each cycle the orchestrator asks `remoteFs.checkpoint.hasCheckpo
 
 A **same-session failure** also forces at least one subsequent cold cycle. This is load-bearing (ADR 0001 convergence path 2) — `result.failed` does not capture the full recovery gap (folder-rename descendants, remote-only orphans, detect-vs-execute races), so only a full cold scan re-derives it. After that cold recovery has been paid, the orchestrator may temporarily block only the same repeated **local-origin** poison action (`push`, `delete_remote`, `rename_remote`) whose error classification is `permanent` and carries a stable `permanentCode`. The key is `(backendType, action, path, "permanent", permanentCode)`, the same action signature must fail in two consecutive cycles, and the block lasts 5 minutes or until the action/content changes, succeeds, or fails with a non-eligible classification. The two-cycle threshold means the first failure still buys one mandatory cold recovery pass; the 5 minute TTL is a short mobile-friendly cooldown that prevents repeated poison I/O without persisting across plugin reloads. Blocked actions are reported as `result.blocked` and surface as `partial_error`; they are not treated as "Everything up to date".
 
-A **deferred identity component** is different from a failed action: it never reaches the executor. The cycle ends `partial_error`, reports a deferred count, withholds the checkpoint/scope fingerprint, and marks the next normal trigger for COLD without setting `syncPending` (no tight loop). A local reported rename is first stored as namespace-scoped `RenameDebt`; a remote edge is captured immediately when `getChangedPaths()` yields it, before later `stat`/hash/planning work can throw. Local debt survives restart directly; remote evidence survives restart because its delta checkpoint remains uncommitted. See [ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
+A **deferred identity component** is different from a failed action: it never reaches the executor, even when it contains zero actions. The cycle ends `partial_error`, reports each deferred disposition exactly once, withholds the checkpoint/scope fingerprint, and marks the next normal trigger for COLD without setting `syncPending` (no tight loop). A local reported rename is first stored as namespace-scoped `RenameDebt`; a remote edge is captured immediately when `getChangedPaths()` yields it, before later `stat`/hash/planning work can throw. Local debt survives restart directly; remote evidence survives restart because its delta checkpoint remains uncommitted. See [ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
 
 Remote-origin or ambiguous actions (`pull`, `delete_local`, `rename_local`, `conflict`) are never blocked, because advancing past them could hide remote changes. Transient and rate-limit failures are also never blocked; after the connection or provider recovers, the next sync must execute I/O again. Re-seeding failed paths for a "hot" recovery, skipping the first cold scan for "small" failure sets, or advancing the cursor while blindly ignoring remote-origin failures are **ADR 0001 prohibited patterns** (they re-open silent in-session data loss). The cost is **bounded and intentionally retained**: per-action `withIoRetry` keeps most transient/429 failures from ever reaching `result.failed`, and repeated cold scans are avoided only after the recovery debt has been paid and the remaining failure is a permanent local-origin poison action.
 
@@ -173,13 +173,20 @@ When `getChangedPaths()` reports a rename pair, the optimizer attempts `delete_l
 
 ## Destructive admission
 
-`prepareSyncCyclePlan()` projects scope before filtering, creates/refines the ordinary
-plan, then calls the pure `admitDestructivePlan()`. Admission builds connected
-components from actions plus rename/alias/stable-identity evidence and path
-observations. It admits an exact native rename, a proven direction-specific scope
-transition, or the recognized source-recreation postcondition. Otherwise it defers the
-whole component, including state-only actions; disconnected components remain
-executable in their original order.
+`prepareSyncCycleSnapshot()` projects scope before filtering, creates/refines the plain
+`SyncPlan` proposal, and freezes the proposal, normative evidence, observations, scope,
+and backend/root namespace into one cycle snapshot. The orchestrator passes that value
+once to pure `admitDestructivePlan()`. Admission builds connected components from
+actions plus rename/alias/stable-identity evidence and path observations and emits
+exactly one `authorized`, `resolved_no_action`, or `deferred` disposition per relevant
+component, including evidence-connected components with zero actions.
+
+Admission alone proves exact deletion authority, native rename, a direction-specific
+scope transition, two-sided convergence, or the recognized source-recreation
+postcondition. Unknown, conflicting, incomplete, or otherwise unproved components
+defer as a whole, including state-only actions. Only actions from `authorized`
+dispositions are projected, in proposal order, into the nominal `AuthorizedSyncPlan`;
+`executePlan()` cannot accept a plain proposal through the supported typed API.
 
 Endpoint dispositions are `included`, `policy_out`, `mobile_deferred`, or `unknown`.
 Any unknown/mobile endpoint and any incomplete folder descendant mapping defers. The
@@ -187,10 +194,12 @@ full local/remote direction matrix and rejected identity inferences are recorded
 [ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
 
 Before admitted I/O, local reported edges are upserted into the SyncState v6 rename-debt
-store under the active backend/root namespace. `finalizeSyncCycle()` owns the opposite
-boundary: safe checkpoint commit first, then resolved debt deletion and session-evidence
-release. Disconnect/root switch waits on the orchestrator mutex before clearing state,
-so an old-target in-flight cycle cannot recreate debt after teardown.
+store under the snapshot's backend/root namespace. `finalizeSyncCycle()` does not
+re-evaluate scope, observations, identities, aliases, or action shapes: it folds the
+snapshot-bound dispositions with succeeded action membership. A safe checkpoint commits
+first; only then are mechanically releasable debt and session evidence retired.
+Disconnect/root switch waits on the orchestrator mutex before clearing state, so an
+old-target in-flight cycle cannot recreate debt after teardown.
 
 ### Observability
 

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -2,16 +2,27 @@
 
 ## Pipeline overview
 
-Each sync cycle runs a fail-closed planning and execution pipeline:
+Each sync cycle has five top-level responsibility stages:
 
-1. **Collect evidence** -- `collectChanges()` returns exact `entries`, path `observations`, and normative `identityEvidence`
-2. **Project scope** -- `projectScope()` classifies every evidence endpoint before entry filtering
-3. **Decide** -- `planSync()` maps exact in-scope entries to actions
-4. **Refine** -- `refinePlan()` derives native rename actions without replacing the normative evidence
-5. **Admit** -- the orchestrator captures one `CycleAdmissionSnapshot`; `admitDestructivePlan()` assigns every relevant component one disposition and issues the only `AuthorizedSyncPlan`
-6. **Execute/commit** -- `executePlan()` accepts that nominal plan only; successful actions commit per-path state, then `finalizeSyncCycle()` mechanically folds the same dispositions with completion and retires debt only after a safe checkpoint
+1. **Observe** -- `collectChanges()` returns exact `entries`, path `observations`, and normative `identityEvidence`.
+2. **Propose** -- scope is projected before filtering, then `planSync()` and `refinePlan()` produce a plain action proposal.
+3. **Admit** -- the proposal and its evidence are captured in one `CycleAdmissionSnapshot`; `admitDestructivePlan()` assigns every relevant component one disposition and issues the only `AuthorizedSyncPlan`.
+4. **Execute** -- `executePlan()` accepts that nominal plan only and successful actions commit their per-path state.
+5. **Finalize** -- `finalizeSyncCycle()` mechanically folds the same dispositions with execution completion, commits a safe checkpoint, and only then retires released evidence and debt.
 
-The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives the I/O boundaries. `prepareSyncCycleSnapshot()` performs pure scope projection, proposal, refinement, and snapshot capture. The orchestrator then invokes Admission once at an explicit cut point; proposal output is never executable permission.
+These stages describe responsibility boundaries, not one separately scheduled pass per helper function. Evidence completion is part of **Observe**; scope projection and rename refinement are internal to **Propose**; snapshot capture and component-graph construction are internal to **Admit**. They add no extra network scan merely by being named.
+
+The lower-level cycle sequence within those boundaries is:
+
+1. `collectChanges()` selects HOT/WARM/COLD collection, records authoritative path observations and identity evidence, confirms uncertain absences, and completes required hashes/identity facts.
+2. `projectScope()` classifies every evidence endpoint before exact entries are filtered.
+3. `planSync()` produces per-path actions; `refinePlan()` may replace compatible action pairs with native rename proposals.
+4. `captureCycleAdmissionSnapshot()` fixes the proposal, evidence, observations, scope, and namespace for this cycle.
+5. `admitDestructivePlan()` builds evidence-connected components, assigns dispositions, and projects the proposal-ordered `AuthorizedSyncPlan`.
+6. `executePlan()` runs only that authorized projection; each successful action calls `commitAction()` for per-path state.
+7. `finalizeSyncCycle()` folds disposition membership with execution completion, commits the checkpoint when safe, then retires released evidence and debt.
+
+The orchestrator (`SyncOrchestrator.executeSyncOnce()`) drives the I/O boundaries. `prepareSyncCycleSnapshot()` composes the pure **Propose** transformations and captures the input at the **Admit** boundary. The orchestrator then invokes Admission once at an explicit cut point; proposal output is never executable permission.
 
 **Scope filter (`SyncOrchestrator.isExcluded()`)** — a path is synced only if it passes **both** gates:
 

--- a/e2e/bootstrap.ts
+++ b/e2e/bootstrap.ts
@@ -5,7 +5,7 @@ import { DROPBOX_AUTH } from "../src/fs/auth-config";
 import { buildOneDriveAuthorizeUrl, OneDriveAuth } from "../src/fs/onedrive/auth";
 import { buildOAuthState, computeS256Challenge, generateRandomString } from "../src/fs/oauth-pkce";
 import { loadDotEnvE2e } from "./helpers/env";
-import { loopbackPort, startLoopback, writeEnvE2e } from "./helpers/loopback";
+import { announceAuthorizeUrl, loopbackPort, startLoopback, writeEnvE2e } from "./helpers/loopback";
 
 /**
  * One-time helper to mint a refresh token for the e2e suite (ADR 0003) WITHOUT a
@@ -40,7 +40,7 @@ async function bootstrapGoogle(): Promise<void> {
 		const url = await auth.getAuthorizationUrl();
 		const state = auth.getAuthState();
 		if (!state) throw new Error("Google authorization state was not generated.");
-		stdout.write(`\nOpen this URL and authorize Google Drive:\n${url}\n\nWaiting for the redirect...\n`);
+		announceAuthorizeUrl("Google Drive", url);
 		const params = await loopback.waitForCallback(state);
 		await auth.handleAuthCallback(params);
 		const path = writeEnvE2e("AIRSYNC_E2E_GOOGLE_REFRESH_TOKEN", auth.getTokenState().refreshToken);
@@ -64,7 +64,7 @@ async function bootstrapDropbox(): Promise<void> {
 			state,
 			redirectUri: loopback.redirectUri,
 		});
-		stdout.write(`\nOpen this URL and authorize Dropbox:\n${url}\n\nWaiting for the redirect...\n`);
+		announceAuthorizeUrl("Dropbox", url);
 		const params = await loopback.waitForCallback(state);
 		if (params.state !== state) throw new Error("State mismatch — possible CSRF; aborting.");
 		if (!params.code) throw new Error("No authorization code in the callback.");
@@ -95,7 +95,7 @@ async function bootstrapOnedrive(): Promise<void> {
 			state,
 			redirectUri: loopback.redirectUri,
 		});
-		stdout.write(`\nOpen this URL and authorize OneDrive:\n${url}\n\nWaiting for the redirect...\n`);
+		announceAuthorizeUrl("OneDrive", url);
 		const params = await loopback.waitForCallback(state);
 		if (params.state !== state) throw new Error("State mismatch — possible CSRF; aborting.");
 		if (!params.code) throw new Error("No authorization code in the callback.");

--- a/e2e/dropbox.e2e.ts
+++ b/e2e/dropbox.e2e.ts
@@ -2,7 +2,9 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { DropboxAuth } from "../src/fs/dropbox/auth";
 import { DROPBOX_AUTH } from "../src/fs/auth-config";
 import { DropboxFs } from "../src/fs/dropbox/index";
+import type { DropboxEntry } from "../src/fs/dropbox/types";
 import { runIFileSystemContract, bytes } from "../src/fs/ifilesystem-contract.test";
+import { MetadataStore } from "../src/store/metadata-store";
 import { RetryingDropboxClient } from "./helpers/dropbox-retry-client";
 import { readCreds } from "./helpers/env";
 import {
@@ -10,6 +12,7 @@ import {
 	makeDropboxChild,
 	makeDropboxParent,
 } from "./helpers/isolation";
+import { runRenameSafetyE2E } from "./helpers/rename-safety";
 
 /**
  * Opt-in real-cloud e2e (ADR 0003): runs the SAME `runIFileSystemContract` the
@@ -67,8 +70,31 @@ if (!creds) {
 		// DropboxFs reports server_modified (the upload wall-clock) as mtime, so a
 		// written mtime does not round-trip (unlike the fake, which echoes it back).
 		// Verified by this e2e; see ADR 0003 / dropbox/types.ts.
-		{ computesHashOnStat: false, preservesWrittenMtime: false },
+		{ computesHashOnStat: false, preservesWrittenMtime: false, stableIdentity: true },
 	);
+
+	runRenameSafetyE2E("DropboxFs", {
+		backendType: "dropbox",
+		makeBackend: async () => {
+			const childId = await makeDropboxChild(client, parentPath);
+			const store = new MetadataStore<DropboxEntry>(crypto.randomUUID(), {
+				dbNamePrefix: "air-sync-dropbox-e2e-rename",
+				version: 1,
+			});
+			const fs = new DropboxFs(client, childId, undefined, store);
+			return {
+				fs,
+				renameOutOfBand: async (file, newPath) => {
+					// Dropbox move_v2 cannot perform a case-only rename directly. Model a
+					// second device/Web UI with two raw client moves, bypassing DropboxFs's
+					// cache so the delta remains the only observation source.
+					const tempPath = `${childId}/.airsync-e2e-case-${crypto.randomUUID()}`;
+					await client.move(`${childId}/${file.path}`, tempPath);
+					await client.move(tempPath, `${childId}/${newPath}`);
+				},
+			};
+		},
+	});
 
 	// The IFileSystem contract above never drives `getChangedPaths()`, so the delta's
 	// rename SHAPE is unverified against real Dropbox — exactly the ADR 0003 blind spot.

--- a/e2e/googledrive.e2e.ts
+++ b/e2e/googledrive.e2e.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, describe } from "vitest";
 import { GoogleDriveClient } from "../src/fs/googledrive/client";
 import { GoogleDriveFs } from "../src/fs/googledrive/index";
+import type { GoogleDriveFile } from "../src/fs/googledrive/types";
 import { runIFileSystemContract } from "../src/fs/ifilesystem-contract.test";
+import { MetadataStore } from "../src/store/metadata-store";
 import {
 	createGoogleE2EAuth,
 	GOOGLE_E2E_REFRESH_TOKEN_ENV,
@@ -12,6 +14,7 @@ import {
 	makeGoogleDriveChild,
 	makeGoogleDriveParent,
 } from "./helpers/isolation";
+import { runRenameSafetyE2E } from "./helpers/rename-safety";
 
 /**
  * Opt-in real-cloud e2e (ADR 0003): runs the SAME `runIFileSystemContract` the
@@ -58,6 +61,24 @@ if (!creds) {
 		// A fresh empty child folder per test → satisfies the contract's
 		// empty-start assumption. Runs in beforeEach, after the beforeAll above.
 		async () => new GoogleDriveFs(client, await makeGoogleDriveChild(client, parentId)),
-		{ computesHashOnStat: false }, // Google Drive round-trips full-ms mtime → default preservesWrittenMtime: true
+		{ computesHashOnStat: false, stableIdentity: true }, // Google Drive round-trips full-ms mtime → default preservesWrittenMtime: true
 	);
+
+	runRenameSafetyE2E("GoogleDriveFs", {
+		backendType: "googledrive",
+		makeBackend: async () => {
+			const childId = await makeGoogleDriveChild(client, parentId);
+			const store = new MetadataStore<GoogleDriveFile>(crypto.randomUUID(), {
+				dbNamePrefix: "air-sync-googledrive-e2e-rename",
+				version: 1,
+			});
+			const fs = new GoogleDriveFs(client, childId, undefined, store);
+			return {
+				fs,
+				renameOutOfBand: async (file, newPath) => {
+					await client.updateFileMetadata(file.identityKey!, { name: newPath });
+				},
+			};
+		},
+	});
 }

--- a/e2e/helpers/loopback.ts
+++ b/e2e/helpers/loopback.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import { readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { spawn } from "node:child_process";
+import { stdout } from "node:process";
 
 /**
  * Loopback OAuth capture for the e2e token bootstrap (ADR 0003). Starts a local
@@ -48,11 +50,23 @@ export function startLoopback(port: number): Promise<LoopbackCapture> {
 		}
 		const params = Object.fromEntries(url.searchParams.entries());
 		if (!expectedState || params.state !== expectedState) {
+			// A state mismatch is NOT an expiry: the provider echoes `state` back
+			// untouched, so a wrong value means the authorize URL that was opened is not
+			// the one this run printed (a stale tab, or a hand-copied URL). Say that —
+			// and log it, because otherwise the terminal just sits on "Waiting for the
+			// redirect..." while the browser shows an error, with no way to connect the two.
+			const detail = !expectedState
+				? "no authorization is in progress"
+				: `state mismatch (expected ${expectedState.slice(0, 12)}…, got ${(params.state ?? "(absent)").slice(0, 12)}…)`;
+			process.stderr.write(`\n[loopback] rejected callback: ${detail}\n`);
 			response.statusCode = 409;
 			response.setHeader("Content-Type", "text/html; charset=utf-8");
 			response.end(
-				"<!doctype html><meta charset=\"utf-8\"><h2>Authorization attempt expired</h2>" +
-					"<p>Use the most recently opened Google authorization tab.</p>",
+				"<!doctype html><meta charset=\"utf-8\"><body style=\"font-family:sans-serif\">" +
+					"<h2>⚠ Callback rejected</h2>" +
+					`<p>${detail}.</p>` +
+					"<p>Open the authorize URL printed by this bootstrap run — copying it by hand " +
+					"corrupts <code>state</code>. Still waiting for a matching callback.</p></body>",
 			);
 			return;
 		}
@@ -85,6 +99,47 @@ export function startLoopback(port: number): Promise<LoopbackCapture> {
 			});
 		});
 	});
+}
+
+/**
+ * Where {@link announceAuthorizeUrl} parks the authorize URL. A fixed path in the
+ * repo root (gitignored alongside `.env.e2e`) so the URL can be opened WITHOUT being
+ * retyped: printing it to stdout is not enough when the terminal is driven by a tool
+ * or an agent, and hand-copying an `authorize` URL silently corrupts the opaque
+ * `state`/`code_challenge` — which the loopback then rejects as a mismatch.
+ */
+export const AUTHORIZE_URL_FILE = ".env.e2e.authorize-url";
+
+/**
+ * Print the authorize URL AND write it to {@link AUTHORIZE_URL_FILE}, then try to
+ * open it in the default browser. Best-effort: a missing opener is not an error, the
+ * file and the printed URL remain.
+ */
+export function announceAuthorizeUrl(backend: string, url: string): void {
+	const path = resolve(process.cwd(), AUTHORIZE_URL_FILE);
+	writeFileSync(path, `${url}\n`);
+	stdout.write(
+		`\nAuthorize ${backend}:\n${url}\n\n` +
+			`(also written to ${AUTHORIZE_URL_FILE} — open THAT rather than copying the URL by hand)\n\n` +
+			"Waiting for the redirect...\n",
+	);
+	// Detached + unref'd, never spawnSync: an opener that does not exit (a WSL helper
+	// handing off to a Windows browser does not) would otherwise block Node's event loop,
+	// and the loopback server could not answer the very redirect it is waiting for — the
+	// browser would just spin on the callback URL.
+	//
+	// A missing opener surfaces as an ASYNC 'error' (ENOENT), never a throw, so the
+	// fallback chain has to advance from that handler — a synchronous loop would always
+	// stop at the first candidate whether or not it exists. `explorer.exe` precedes
+	// `xdg-open` because on WSL both resolve but only the former reaches a browser.
+	const tryOpen = (candidates: string[]): void => {
+		const [opener, ...rest] = candidates;
+		if (!opener) return;
+		const child = spawn(opener, [url], { stdio: "ignore", detached: true });
+		child.on("error", () => tryOpen(rest));
+		child.unref();
+	};
+	tryOpen(["wslview", "explorer.exe", "xdg-open", "open"]);
 }
 
 /**

--- a/e2e/helpers/loopback.ts
+++ b/e2e/helpers/loopback.ts
@@ -108,7 +108,7 @@ export function startLoopback(port: number): Promise<LoopbackCapture> {
  * or an agent, and hand-copying an `authorize` URL silently corrupts the opaque
  * `state`/`code_challenge` — which the loopback then rejects as a mismatch.
  */
-export const AUTHORIZE_URL_FILE = ".env.e2e.authorize-url";
+const AUTHORIZE_URL_FILE = ".env.e2e.authorize-url";
 
 /**
  * Print the authorize URL AND write it to {@link AUTHORIZE_URL_FILE}, then try to

--- a/e2e/helpers/loopback.ts
+++ b/e2e/helpers/loopback.ts
@@ -64,7 +64,7 @@ export function startLoopback(port: number): Promise<LoopbackCapture> {
 			response.end(
 				"<!doctype html><meta charset=\"utf-8\"><body style=\"font-family:sans-serif\">" +
 					"<h2>⚠ Callback rejected</h2>" +
-					`<p>${detail}.</p>` +
+					"<p>The callback did not match the current authorization run.</p>" +
 					"<p>Open the authorize URL printed by this bootstrap run — copying it by hand " +
 					"corrupts <code>state</code>. Still waiting for a matching callback.</p></body>",
 			);
@@ -77,7 +77,7 @@ export function startLoopback(port: number): Promise<LoopbackCapture> {
 			`<!doctype html><meta charset="utf-8"><body style="font-family:sans-serif">` +
 				(ok
 					? `<h2>✓ Authorized</h2><p>You can close this tab and return to the terminal.</p>`
-					: `<h2>⚠ No authorization code in callback</h2><pre>${JSON.stringify(params)}</pre>`) +
+					: `<h2>⚠ No authorization code in callback</h2><p>See the terminal for details.</p>`) +
 				`</body>`,
 		);
 		if (ok) resolveParams(params);
@@ -130,8 +130,7 @@ export function announceAuthorizeUrl(backend: string, url: string): void {
 	//
 	// A missing opener surfaces as an ASYNC 'error' (ENOENT), never a throw, so the
 	// fallback chain has to advance from that handler — a synchronous loop would always
-	// stop at the first candidate whether or not it exists. `explorer.exe` precedes
-	// `xdg-open` because on WSL both resolve but only the former reaches a browser.
+	// stop at the first candidate whether or not it exists.
 	const tryOpen = (candidates: string[]): void => {
 		const [opener, ...rest] = candidates;
 		if (!opener) return;
@@ -139,7 +138,7 @@ export function announceAuthorizeUrl(backend: string, url: string): void {
 		child.on("error", () => tryOpen(rest));
 		child.unref();
 	};
-	tryOpen(["wslview", "explorer.exe", "xdg-open", "open"]);
+	tryOpen(["wslview", "xdg-open", "open"]);
 }
 
 /**

--- a/e2e/helpers/rename-safety.ts
+++ b/e2e/helpers/rename-safety.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { describe, expect, it, vi } from "vitest";
-import { createMockFs } from "../../src/__mocks__/sync-test-helpers";
+import { createMockLocalFs } from "../../src/__mocks__/sync-test-helpers";
 import type { IFileSystem } from "../../src/fs/interface";
 import type { FileEntity } from "../../src/fs/types";
 import { DEFAULT_SETTINGS } from "../../src/settings";
@@ -36,7 +36,7 @@ export function runRenameSafetyE2E(label: string, options: RenameSafetyOptions):
 				remoteDeltas.push(delta);
 				return delta;
 			};
-			const localFs = createMockFs("local");
+			const localFs = createMockLocalFs();
 			const tracker = new LocalChangeTracker();
 			const settings = {
 				...DEFAULT_SETTINGS,
@@ -75,12 +75,35 @@ export function runRenameSafetyE2E(label: string, options: RenameSafetyOptions):
 				await checkpoint.resetCheckpoint();
 				await orchestrator.runSync();
 
+				const nestedContent = bytes("folder-descendant-preserved");
+				await localFs.write("Drafts/nested/note.md", nestedContent, 1000);
+				tracker.markDirty("Drafts/nested/note.md");
+				await orchestrator.runSync();
+				expect((await remoteFs.stat("Drafts"))?.pathAuthority).toBe("requested_echo");
+				expect((await remoteFs.stat("Drafts/nested/note.md"))?.pathAuthority)
+					.toBe("requested_echo");
+
+				await localFs.rename("Drafts", "Published");
+				tracker.markFolderRenamed("Published", "Drafts");
+				for (let attempt = 0; attempt < 10 && !remoteRename.mock.calls.some(([old, next]) =>
+					old === "Drafts" && next === "Published"); attempt++) {
+					await orchestrator.runSync();
+					if (!remoteRename.mock.calls.some(([old, next]) =>
+						old === "Drafts" && next === "Published")) {
+						await new Promise((resolve) => setTimeout(resolve, 1000));
+					}
+				}
+				expect(remoteRename).toHaveBeenCalledWith("Drafts", "Published");
+				expect(new TextDecoder().decode(await remoteFs.read("Published/nested/note.md")))
+					.toBe("folder-descendant-preserved");
+
 				await localFs.rename("Case.md", "case.md");
 				tracker.markRenamed("case.md", "Case.md");
 				await orchestrator.runSync();
 				expect(remoteRename).toHaveBeenCalledWith("Case.md", "case.md");
-				expect((await remoteFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
-					.toEqual(["case.md"]);
+				expect((await remoteFs.list()).filter((item) => !item.isDirectory)
+					.map((item) => item.path).sort())
+					.toEqual(["Published/nested/note.md", "case.md"]);
 
 				const moved = await remoteFs.stat("case.md");
 				expect(moved).not.toBeNull();
@@ -103,12 +126,18 @@ export function runRenameSafetyE2E(label: string, options: RenameSafetyOptions):
 				await checkpoint.resetCheckpoint();
 				await orchestrator.runSync();
 				expect(remoteList).toHaveBeenCalledTimes(listsBeforeCold + 1);
-				expect((await localFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
-					.toEqual(["CASE.md"]);
-				expect((await remoteFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
-					.toEqual(["CASE.md"]);
+				expect((await localFs.list()).filter((item) => !item.isDirectory)
+					.map((item) => item.path).sort())
+					.toEqual(["CASE.md", "Published/nested/note.md"]);
+				expect((await remoteFs.list()).filter((item) => !item.isDirectory)
+					.map((item) => item.path).sort())
+					.toEqual(["CASE.md", "Published/nested/note.md"]);
 				expect(new TextDecoder().decode(await localFs.read("CASE.md"))).toBe("case-preserved");
 				expect(new TextDecoder().decode(await remoteFs.read("CASE.md"))).toBe("case-preserved");
+				expect(new TextDecoder().decode(await localFs.read("Published/nested/note.md")))
+					.toBe("folder-descendant-preserved");
+				expect(new TextDecoder().decode(await remoteFs.read("Published/nested/note.md")))
+					.toBe("folder-descendant-preserved");
 				expect(localDelete).not.toHaveBeenCalled();
 				expect(remoteDelete).not.toHaveBeenCalled();
 				expect(statuses.at(-1)).toBe("idle");

--- a/e2e/helpers/rename-safety.ts
+++ b/e2e/helpers/rename-safety.ts
@@ -1,0 +1,121 @@
+import "fake-indexeddb/auto";
+import { describe, expect, it, vi } from "vitest";
+import { createMockFs } from "../../src/__mocks__/sync-test-helpers";
+import type { IFileSystem } from "../../src/fs/interface";
+import type { FileEntity } from "../../src/fs/types";
+import { DEFAULT_SETTINGS } from "../../src/settings";
+import { LocalChangeTracker } from "../../src/sync/local-tracker";
+import { SyncOrchestrator } from "../../src/sync/orchestrator";
+import { bytes } from "../../src/fs/ifilesystem-contract.test";
+
+interface RenameSafetyBackend {
+	fs: IFileSystem;
+	renameOutOfBand: (file: FileEntity, newPath: string) => Promise<void>;
+}
+
+interface RenameSafetyOptions {
+	backendType: string;
+	makeBackend: () => Promise<RenameSafetyBackend>;
+}
+
+/**
+ * Register the same live, orchestrator-composed rename-safety scenario for every
+ * backend. The backend seam is deliberately below IFileSystem: it models a rename
+ * performed by another device/web UI so only the remote delta can reveal it.
+ */
+export function runRenameSafetyE2E(label: string, options: RenameSafetyOptions): void {
+	describe(`${label} rename safety — composed multi-cycle sync (real)`, () => {
+		it("preserves one correctly-cased copy across both rename origins and later COLD", async () => {
+			const { fs: remoteFs, renameOutOfBand } = await options.makeBackend();
+			if (!remoteFs.checkpoint) throw new Error(`${label} has no incremental checkpoint`);
+			const checkpoint = remoteFs.checkpoint;
+			const remoteDeltas: Awaited<ReturnType<typeof checkpoint.getChangedPaths>>[] = [];
+			const getChangedPaths = checkpoint.getChangedPaths.bind(checkpoint);
+			checkpoint.getChangedPaths = async () => {
+				const delta = await getChangedPaths();
+				remoteDeltas.push(delta);
+				return delta;
+			};
+			const localFs = createMockFs("local");
+			const tracker = new LocalChangeTracker();
+			const settings = {
+				...DEFAULT_SETTINGS,
+				vaultId: `${options.backendType}-e2e-${crypto.randomUUID()}`,
+				backendType: options.backendType,
+				lastSyncedIdentity: `${options.backendType}:rename-safety`,
+			};
+			const statuses: string[] = [];
+			const orchestrator = new SyncOrchestrator({
+				getSettings: () => settings,
+				saveSettings: vi.fn().mockResolvedValue(undefined),
+				configDir: () => ".obsidian",
+				pluginId: () => "air-sync",
+				localFs: () => localFs,
+				remoteFs: () => remoteFs,
+				backendProvider: () => null,
+				onStatusChange: (status) => { statuses.push(status); },
+				onProgress: vi.fn(),
+				notify: vi.fn(),
+				isMobile: () => false,
+				localTracker: tracker,
+			});
+			const localDelete = vi.spyOn(localFs, "delete");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+			const localRename = vi.spyOn(localFs, "rename");
+			const remoteRename = vi.spyOn(remoteFs, "rename");
+			const remoteList = vi.spyOn(remoteFs, "list");
+			const observedLocalRename = (oldPath: string, newPath: string): boolean =>
+				localRename.mock.calls.some(([old, next]) => old === oldPath && next === newPath);
+
+			try {
+				const content = bytes("case-preserved");
+				await localFs.write("Case.md", content, 1000);
+				await remoteFs.write("Case.md", content, 1000);
+				// Re-observe the live backend instead of trusting a mutation echo.
+				await checkpoint.resetCheckpoint();
+				await orchestrator.runSync();
+
+				await localFs.rename("Case.md", "case.md");
+				tracker.markRenamed("case.md", "Case.md");
+				await orchestrator.runSync();
+				expect(remoteRename).toHaveBeenCalledWith("Case.md", "case.md");
+				expect((await remoteFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
+					.toEqual(["case.md"]);
+
+				const moved = await remoteFs.stat("case.md");
+				expect(moved).not.toBeNull();
+				expect(moved!.identityKey).toBeTruthy();
+				await renameOutOfBand(moved!, "CASE.md");
+				// Remote APIs may publish mutations to their delta feeds after the mutation
+				// response. Poll only through normal WARM cycles; COLD must remain a later,
+				// independent convergence check rather than the first repair mechanism.
+				for (let attempt = 0; attempt < 10 && !observedLocalRename("case.md", "CASE.md"); attempt++) {
+					await orchestrator.runSync();
+					if (!observedLocalRename("case.md", "CASE.md")) {
+						await new Promise((resolve) => setTimeout(resolve, 1000));
+					}
+				}
+				expect(remoteDeltas.some((delta) => delta?.renamed?.some((pair) =>
+					pair.oldPath === "case.md" && pair.newPath === "CASE.md"))).toBe(true);
+				expect(localRename).toHaveBeenCalledWith("case.md", "CASE.md");
+
+				const listsBeforeCold = remoteList.mock.calls.length;
+				await checkpoint.resetCheckpoint();
+				await orchestrator.runSync();
+				expect(remoteList).toHaveBeenCalledTimes(listsBeforeCold + 1);
+				expect((await localFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
+					.toEqual(["CASE.md"]);
+				expect((await remoteFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
+					.toEqual(["CASE.md"]);
+				expect(new TextDecoder().decode(await localFs.read("CASE.md"))).toBe("case-preserved");
+				expect(new TextDecoder().decode(await remoteFs.read("CASE.md"))).toBe("case-preserved");
+				expect(localDelete).not.toHaveBeenCalled();
+				expect(remoteDelete).not.toHaveBeenCalled();
+				expect(statuses.at(-1)).toBe("idle");
+			} finally {
+				await orchestrator.close();
+				await remoteFs.close?.();
+			}
+		});
+	});
+}

--- a/e2e/onedrive.e2e.ts
+++ b/e2e/onedrive.e2e.ts
@@ -1,19 +1,17 @@
-import "fake-indexeddb/auto";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe } from "vitest";
 import { OneDriveAuth } from "../src/fs/onedrive/auth";
 import { OneDriveClient } from "../src/fs/onedrive/client";
 import { OneDriveFs } from "../src/fs/onedrive/index";
-import { bytes, runIFileSystemContract } from "../src/fs/ifilesystem-contract.test";
-import { createMockFs } from "../src/__mocks__/sync-test-helpers";
-import { LocalChangeTracker } from "../src/sync/local-tracker";
-import { SyncOrchestrator } from "../src/sync/orchestrator";
-import { DEFAULT_SETTINGS } from "../src/settings";
+import type { OneDriveItem } from "../src/fs/onedrive/types";
+import { runIFileSystemContract } from "../src/fs/ifilesystem-contract.test";
+import { MetadataStore } from "../src/store/metadata-store";
 import { readCreds } from "./helpers/env";
 import {
 	cleanupOneDriveParent,
 	makeOneDriveChild,
 	makeOneDriveParent,
 } from "./helpers/isolation";
+import { runRenameSafetyE2E } from "./helpers/rename-safety";
 
 /**
  * Opt-in real-cloud e2e (ADR 0003): runs the SAME `runIFileSystemContract` the
@@ -81,77 +79,21 @@ if (!creds || !clientId) {
 		{ computesHashOnStat: false, mtimePrecisionMs: 1000, stableIdentity: true },
 	);
 
-	describe("OneDrive rename safety — composed multi-cycle sync (real)", () => {
-		it("preserves one correctly-cased copy across both rename origins and later COLD", async () => {
+	runRenameSafetyE2E("OneDriveFs", {
+		backendType: "onedrive",
+		makeBackend: async () => {
 			const childId = await makeOneDriveChild(client, parentId);
-			const remoteFs = new OneDriveFs(client, childId);
-			const localFs = createMockFs("local");
-			const tracker = new LocalChangeTracker();
-			const settings = {
-				...DEFAULT_SETTINGS,
-				vaultId: `onedrive-e2e-${crypto.randomUUID()}`,
-				backendType: "onedrive",
-				lastSyncedIdentity: `onedrive:${childId}`,
-			};
-			const statuses: string[] = [];
-			const orchestrator = new SyncOrchestrator({
-				getSettings: () => settings,
-				saveSettings: vi.fn().mockResolvedValue(undefined),
-				configDir: () => ".obsidian",
-				pluginId: () => "air-sync",
-				localFs: () => localFs,
-				remoteFs: () => remoteFs,
-				backendProvider: () => null,
-				onStatusChange: (status) => { statuses.push(status); },
-				onProgress: vi.fn(),
-				notify: vi.fn(),
-				isMobile: () => false,
-				localTracker: tracker,
+			const store = new MetadataStore<OneDriveItem>(crypto.randomUUID(), {
+				dbNamePrefix: "air-sync-onedrive-e2e-rename",
+				version: 1,
 			});
-			const localDelete = vi.spyOn(localFs, "delete");
-			const remoteDelete = vi.spyOn(remoteFs, "delete");
-			const localRename = vi.spyOn(localFs, "rename");
-			const remoteRename = vi.spyOn(remoteFs, "rename");
-			const remoteList = vi.spyOn(remoteFs, "list");
-
-			try {
-				const content = bytes("case-preserved");
-				await localFs.write("Case.md", content, 1000);
-				await remoteFs.write("Case.md", content, 1000);
-				// Discard mutation-backed requested-echo cache state. The initial cycle
-				// must re-observe the live backend and establish a clean baseline.
-				await remoteFs.checkpoint.resetCheckpoint();
-				await orchestrator.runSync();
-
-				await localFs.rename("Case.md", "case.md");
-				tracker.markRenamed("case.md", "Case.md");
-				await orchestrator.runSync();
-				expect(remoteRename).toHaveBeenCalledWith("Case.md", "case.md");
-
-				const moved = await remoteFs.stat("case.md");
-				expect(moved?.identityKey).toBeTruthy();
-				await client.move(moved!.identityKey!, "CASE.md", undefined);
-				await orchestrator.runSync();
-				expect(localRename).toHaveBeenCalledWith("case.md", "CASE.md");
-
-				// A later COLD cycle must confirm convergence without an opposing delete.
-				const listsBeforeCold = remoteList.mock.calls.length;
-				await remoteFs.checkpoint.resetCheckpoint();
-				await orchestrator.runSync();
-				expect(remoteList).toHaveBeenCalledTimes(listsBeforeCold + 1);
-				expect((await localFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
-					.toEqual(["CASE.md"]);
-				expect((await remoteFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
-					.toEqual(["CASE.md"]);
-				expect(new TextDecoder().decode(await localFs.read("CASE.md"))).toBe("case-preserved");
-				expect(new TextDecoder().decode(await remoteFs.read("CASE.md"))).toBe("case-preserved");
-				expect(localDelete).not.toHaveBeenCalled();
-				expect(remoteDelete).not.toHaveBeenCalled();
-				expect(statuses.at(-1)).toBe("idle");
-			} finally {
-				await orchestrator.close();
-				await remoteFs.close();
-			}
-		});
+			const fs = new OneDriveFs(client, childId, undefined, store);
+			return {
+				fs,
+				renameOutOfBand: async (file, newPath) => {
+					await client.move(file.identityKey!, newPath, undefined);
+				},
+			};
+		},
 	});
 }

--- a/e2e/onedrive.e2e.ts
+++ b/e2e/onedrive.e2e.ts
@@ -1,8 +1,18 @@
-import { afterAll, beforeAll, describe } from "vitest";
+import "fake-indexeddb/auto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	addFile,
+	createMockFs,
+	mockSettings,
+} from "../src/__mocks__/sync-test-helpers";
 import { OneDriveAuth } from "../src/fs/onedrive/auth";
 import { OneDriveClient } from "../src/fs/onedrive/client";
 import { OneDriveFs } from "../src/fs/onedrive/index";
+import type { OneDriveItem } from "../src/fs/onedrive/types";
 import { runIFileSystemContract } from "../src/fs/ifilesystem-contract.test";
+import { MetadataStore } from "../src/store/metadata-store";
+import { LocalChangeTracker } from "../src/sync/local-tracker";
+import { SyncOrchestrator } from "../src/sync/orchestrator";
 import { readCreds } from "./helpers/env";
 import {
 	cleanupOneDriveParent,
@@ -75,4 +85,100 @@ if (!creds || !clientId) {
 		// unit contract stays exact and only this live run carries the precision knob.
 		{ computesHashOnStat: false, mtimePrecisionMs: 1000 },
 	);
+
+	describe("OneDrive sync convergence — case-only local rename (real)", () => {
+		it("keeps one local and remote copy with the requested casing across follow-up delta cycles", async () => {
+			const childId = await makeOneDriveChild(client, parentId);
+			const runId = crypto.randomUUID();
+			const metadataStore = new MetadataStore<OneDriveItem>(runId, {
+				dbNamePrefix: "air-sync-onedrive-e2e-case-rename",
+				version: 1,
+			});
+			const remoteFs = new OneDriveFs(client, childId, undefined, metadataStore);
+			const localFs = createMockFs("case-insensitive-local");
+			const localTracker = new LocalChangeTracker();
+
+			// Model Windows/Obsidian: querying the old spelling after a case-only
+			// rename resolves the same file under its new, case-preserved path.
+			const exactStat = localFs.stat.bind(localFs);
+			localFs.stat = async (path) => {
+				const exact = await exactStat(path);
+				if (exact) return exact;
+				const alias = [...localFs.files.keys()].find(
+					(candidate) => candidate.toLowerCase() === path.toLowerCase(),
+				);
+				return alias ? exactStat(alias) : null;
+			};
+
+			// A delete performed by sync emits a vault delete event in production.
+			// Preserve that event in the tracker so the following cycle can expose
+			// whether delete_local cascades into delete_remote.
+			const exactDelete = localFs.delete.bind(localFs);
+			localFs.delete = async (path) => {
+				const actualPath =
+					[...localFs.files.keys()].find(
+						(candidate) => candidate.toLowerCase() === path.toLowerCase(),
+					) ?? path;
+				await exactDelete(actualPath);
+				localTracker.markDirty(actualPath);
+			};
+
+			const settings = mockSettings({
+				backendType: "onedrive",
+				vaultId: `e2e-case-rename-${runId}`,
+			});
+			const orchestrator = new SyncOrchestrator({
+				getSettings: () => settings,
+				saveSettings: () => Promise.resolve(),
+				configDir: () => ".obsidian",
+				pluginId: () => "air-sync",
+				localFs: () => localFs,
+				remoteFs: () => remoteFs,
+				backendProvider: () => null,
+				onStatusChange: () => {},
+				onProgress: () => {},
+				notify: () => {},
+				isMobile: () => false,
+				localTracker,
+			});
+
+			try {
+				addFile(localFs, "PRUEBA.md", "case-only rename survives", Date.now());
+				await orchestrator.runSync();
+				expect(
+					(await remoteFs.list()).filter((entry) => !entry.isDirectory).map((entry) => entry.path),
+				).toEqual(["PRUEBA.md"]);
+
+				await localFs.rename("PRUEBA.md", "PRUEBa.md");
+				localTracker.markRenamed("PRUEBa.md", "PRUEBA.md");
+
+				// Cover the local rename, OneDrive's follow-up delta, and additional
+				// convergence cycles. Before the fix these cycles deleted both copies.
+				for (let cycle = 0; cycle < 4; cycle++) {
+					await orchestrator.runSync();
+				}
+
+				const localFiles = (await localFs.list()).filter((entry) => !entry.isDirectory);
+				const remoteFiles = (await remoteFs.list()).filter((entry) => !entry.isDirectory);
+				const localPath = localFiles[0]?.path;
+				const remotePath = remoteFiles[0]?.path;
+				const decode = (content: ArrayBuffer): string => new TextDecoder().decode(content);
+
+				expect({
+					localPaths: localFiles.map((entry) => entry.path),
+					remotePaths: remoteFiles.map((entry) => entry.path),
+					localContent: localPath ? decode(await localFs.read(localPath)) : null,
+					remoteContent: remotePath ? decode(await remoteFs.read(remotePath)) : null,
+				}).toEqual({
+					localPaths: ["PRUEBa.md"],
+					remotePaths: ["PRUEBa.md"],
+					localContent: "case-only rename survives",
+					remoteContent: "case-only rename survives",
+				});
+			} finally {
+				await orchestrator.close();
+				await metadataStore.close();
+			}
+		});
+	});
 }

--- a/e2e/onedrive.e2e.ts
+++ b/e2e/onedrive.e2e.ts
@@ -1,8 +1,13 @@
-import { afterAll, beforeAll, describe } from "vitest";
+import "fake-indexeddb/auto";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { OneDriveAuth } from "../src/fs/onedrive/auth";
 import { OneDriveClient } from "../src/fs/onedrive/client";
 import { OneDriveFs } from "../src/fs/onedrive/index";
-import { runIFileSystemContract } from "../src/fs/ifilesystem-contract.test";
+import { bytes, runIFileSystemContract } from "../src/fs/ifilesystem-contract.test";
+import { createMockFs } from "../src/__mocks__/sync-test-helpers";
+import { LocalChangeTracker } from "../src/sync/local-tracker";
+import { SyncOrchestrator } from "../src/sync/orchestrator";
+import { DEFAULT_SETTINGS } from "../src/settings";
 import { readCreds } from "./helpers/env";
 import {
 	cleanupOneDriveParent,
@@ -73,6 +78,80 @@ if (!creds || !clientId) {
 		// precision (this e2e proved 12345 → 12000), so it round-trips only to the
 		// second: mtimePrecisionMs 1000. The OneDrive fake echoes full ms, hence the
 		// unit contract stays exact and only this live run carries the precision knob.
-		{ computesHashOnStat: false, mtimePrecisionMs: 1000 },
+		{ computesHashOnStat: false, mtimePrecisionMs: 1000, stableIdentity: true },
 	);
+
+	describe("OneDrive rename safety — composed multi-cycle sync (real)", () => {
+		it("preserves one correctly-cased copy across both rename origins and later COLD", async () => {
+			const childId = await makeOneDriveChild(client, parentId);
+			const remoteFs = new OneDriveFs(client, childId);
+			const localFs = createMockFs("local");
+			const tracker = new LocalChangeTracker();
+			const settings = {
+				...DEFAULT_SETTINGS,
+				vaultId: `onedrive-e2e-${crypto.randomUUID()}`,
+				backendType: "onedrive",
+				lastSyncedIdentity: `onedrive:${childId}`,
+			};
+			const statuses: string[] = [];
+			const orchestrator = new SyncOrchestrator({
+				getSettings: () => settings,
+				saveSettings: vi.fn().mockResolvedValue(undefined),
+				configDir: () => ".obsidian",
+				pluginId: () => "air-sync",
+				localFs: () => localFs,
+				remoteFs: () => remoteFs,
+				backendProvider: () => null,
+				onStatusChange: (status) => { statuses.push(status); },
+				onProgress: vi.fn(),
+				notify: vi.fn(),
+				isMobile: () => false,
+				localTracker: tracker,
+			});
+			const localDelete = vi.spyOn(localFs, "delete");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+			const localRename = vi.spyOn(localFs, "rename");
+			const remoteRename = vi.spyOn(remoteFs, "rename");
+			const remoteList = vi.spyOn(remoteFs, "list");
+
+			try {
+				const content = bytes("case-preserved");
+				await localFs.write("Case.md", content, 1000);
+				await remoteFs.write("Case.md", content, 1000);
+				// Discard mutation-backed requested-echo cache state. The initial cycle
+				// must re-observe the live backend and establish a clean baseline.
+				await remoteFs.checkpoint.resetCheckpoint();
+				await orchestrator.runSync();
+
+				await localFs.rename("Case.md", "case.md");
+				tracker.markRenamed("case.md", "Case.md");
+				await orchestrator.runSync();
+				expect(remoteRename).toHaveBeenCalledWith("Case.md", "case.md");
+
+				const moved = await remoteFs.stat("case.md");
+				expect(moved?.identityKey).toBeTruthy();
+				await client.move(moved!.identityKey!, "CASE.md", undefined);
+				await orchestrator.runSync();
+				expect(localRename).toHaveBeenCalledWith("case.md", "CASE.md");
+
+				// A later COLD cycle must confirm convergence without an opposing delete.
+				const listsBeforeCold = remoteList.mock.calls.length;
+				await remoteFs.checkpoint.resetCheckpoint();
+				await orchestrator.runSync();
+				expect(remoteList).toHaveBeenCalledTimes(listsBeforeCold + 1);
+				expect((await localFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
+					.toEqual(["CASE.md"]);
+				expect((await remoteFs.list()).filter((item) => !item.isDirectory).map((item) => item.path))
+					.toEqual(["CASE.md"]);
+				expect(new TextDecoder().decode(await localFs.read("CASE.md"))).toBe("case-preserved");
+				expect(new TextDecoder().decode(await remoteFs.read("CASE.md"))).toBe("case-preserved");
+				expect(localDelete).not.toHaveBeenCalled();
+				expect(remoteDelete).not.toHaveBeenCalled();
+				expect(statuses.at(-1)).toBe("idle");
+			} finally {
+				await orchestrator.close();
+				await remoteFs.close();
+			}
+		});
+	});
 }

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -275,12 +275,18 @@ export default defineConfig(
 		rules: { "max-lines": ["error", { max: 337, skipBlankLines: true, skipComments: true }] },
 	},
 	{
-		// Re-pinned from 374 for the scope-fingerprint fix (compute + compare the
-		// current vs committed scope fingerprint in runSync, thread it through
-		// executeWithRetry/executeSyncOnce to commitCheckpoint) — cohesive addition
-		// to the existing cold-reconcile decision, not a natural split point.
+		// Re-pinned from 385: the explicit pre-Admission try/catch and the single
+		// admitDestructivePlan cut point must remain together in the composition root;
+		// extracting either would hide which exceptions own COLD evidence recovery.
 		files: ["src/sync/orchestrator.ts"],
-		rules: { "max-lines": ["error", { max: 385, skipBlankLines: true, skipComments: true }] },
+		rules: { "max-lines": ["error", { max: 406, skipBlankLines: true, skipComments: true }] },
+	},
+	{
+		// Admission is the one pure owner of final destructive authorization. Splitting
+		// its component policy from disposition issuance would add an internal policy
+		// boundary and make the safety decision span modules solely to satisfy a count.
+		files: ["src/sync/plan-admission.ts"],
+		rules: { "max-lines": ["error", { max: 398, skipBlankLines: true, skipComments: true }] },
 	},
 	{
 		// Re-pinned from 317: replay-free post-delta snapshots must stay under the

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -261,12 +261,11 @@ export default defineConfig(
 		rules: { "max-lines": ["error", { max: 385, skipBlankLines: true, skipComments: true }] },
 	},
 	{
-		// New override for the scope-fingerprint fix: CachingRemoteFs now persists
-		// a scope fingerprint alongside the delta cursor (getScopeFingerprint,
-		// commitCheckpoint's context param, resetCheckpoint clearing it) — cohesive
-		// addition to the existing checkpoint machinery, not a natural split point.
+		// Re-pinned from 317: replay-free post-delta snapshots must stay under the
+		// same cache mutex/cursor owner as getChangedPaths. Splitting that method
+		// would break the atomic observation boundary this class enforces.
 		files: ["src/fs/caching/remote-fs.ts"],
-		rules: { "max-lines": ["error", { max: 317, skipBlankLines: true, skipComments: true }] },
+		rules: { "max-lines": ["error", { max: 326, skipBlankLines: true, skipComments: true }] },
 	},
 	{
 		// Re-pinned from 303 for the top-level Google Picker callback. The

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -47,6 +47,14 @@ const FS_INTERFACE_IMPORT = {
 		"Design principle #4 (pipeline as data): pure transform modules must not depend on IFileSystem. Operate on the FileEntity/SyncRecord data passed in.",
 };
 
+/** Sync tests must select a filesystem role, not hand-author stronger path evidence. */
+const RAW_SYNC_MOCK_FS_IMPORT = {
+	name: "../__mocks__/sync-test-helpers",
+	importNames: ["createMockFs"],
+	message:
+		"Use createMockLocalFs() or createMockRemoteFs() so mutation path authority matches the producer role. The raw constructor is reserved for mock contract tests.",
+};
+
 /**
  * The pure transform stages of the sync pipeline. Each is a deterministic
  * `data → data` function (principle #4): no I/O, no clock, no randomness.
@@ -224,6 +232,20 @@ export default defineConfig(
 				NO_DATE_NOW,
 				NO_MATH_RANDOM,
 				NO_MANUAL_CONTENT_LENGTH,
+			],
+		},
+	},
+	{
+		// Producer-qualified path evidence: sync tests choose a local/remote role;
+		// only the dedicated mock contract may select authority directly.
+		files: ["src/sync/**/*.test.ts"],
+		rules: {
+			"no-restricted-imports": [
+				"error",
+				{
+					paths: [AXIOS_IMPORT, RAW_SYNC_MOCK_FS_IMPORT],
+					patterns: [NODE_API_IMPORTS, BACKEND_SPECIFIC_IMPORTS],
+				},
 			],
 		},
 	},

--- a/src/__mocks__/mock-fs.test.ts
+++ b/src/__mocks__/mock-fs.test.ts
@@ -12,12 +12,12 @@ runIFileSystemContract("createMockFs", () => createMockFs("test"), {
 
 describe("createMockFs path authority", () => {
 	it("distinguishes mutation echoes from resolved observations", async () => {
-		const fs = createMockFs("test");
+		const fs = createMockFs("test", "requested_echo");
 
 		expect((await fs.write("dir/a.md", bytes("a"), 1000)).pathAuthority)
 			.toBe("requested_echo");
 		expect((await fs.mkdir("empty")).pathAuthority).toBe("requested_echo");
-		expect((await fs.stat("dir/a.md"))?.pathAuthority).toBe("actual_resolved");
-		expect((await fs.stat("empty"))?.pathAuthority).toBe("actual_resolved");
+		expect((await fs.stat("dir/a.md"))?.pathAuthority).toBe("requested_echo");
+		expect((await fs.stat("empty"))?.pathAuthority).toBe("requested_echo");
 	});
 });

--- a/src/__mocks__/mock-fs.test.ts
+++ b/src/__mocks__/mock-fs.test.ts
@@ -1,5 +1,6 @@
+import { describe, expect, it } from "vitest";
 import { createMockFs } from "./sync-test-helpers";
-import { runIFileSystemContract } from "../fs/ifilesystem-contract.test";
+import { bytes, runIFileSystemContract } from "../fs/ifilesystem-contract.test";
 
 // The canonical in-memory test double (createMockFs) must model the same
 // IFileSystem semantics LocalFs / GoogleDriveFs do — path normalization, rename
@@ -7,4 +8,16 @@ import { runIFileSystemContract } from "../fs/ifilesystem-contract.test";
 // backend-agnostic contract so it cannot silently drift from the real backends.
 runIFileSystemContract("createMockFs", () => createMockFs("test"), {
 	computesHashOnStat: true,
+});
+
+describe("createMockFs path authority", () => {
+	it("distinguishes mutation echoes from resolved observations", async () => {
+		const fs = createMockFs("test");
+
+		expect((await fs.write("dir/a.md", bytes("a"), 1000)).pathAuthority)
+			.toBe("requested_echo");
+		expect((await fs.mkdir("empty")).pathAuthority).toBe("requested_echo");
+		expect((await fs.stat("dir/a.md"))?.pathAuthority).toBe("actual_resolved");
+		expect((await fs.stat("empty"))?.pathAuthority).toBe("actual_resolved");
+	});
 });

--- a/src/__mocks__/mock-fs.test.ts
+++ b/src/__mocks__/mock-fs.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { createMockFs } from "./sync-test-helpers";
+import {
+	addFile,
+	confirmMockPath,
+	createMockFs,
+	createMockLocalFs,
+	createMockRemoteFs,
+} from "./sync-test-helpers";
 import { bytes, runIFileSystemContract } from "../fs/ifilesystem-contract.test";
 
 // The canonical in-memory test double (createMockFs) must model the same
 // IFileSystem semantics LocalFs / GoogleDriveFs do — path normalization, rename
 // validation, copy-on-read, type-collision errors. Drive it through the shared
 // backend-agnostic contract so it cannot silently drift from the real backends.
-runIFileSystemContract("createMockFs", () => createMockFs("test"), {
+runIFileSystemContract("createMockFs", () => createMockFs("test", "actual_resolved"), {
 	computesHashOnStat: true,
 });
 
@@ -19,5 +25,49 @@ describe("createMockFs path authority", () => {
 		expect((await fs.mkdir("empty")).pathAuthority).toBe("requested_echo");
 		expect((await fs.stat("dir/a.md"))?.pathAuthority).toBe("requested_echo");
 		expect((await fs.stat("empty"))?.pathAuthority).toBe("requested_echo");
+	});
+
+	it.each([
+		["local", createMockLocalFs, "actual_resolved"],
+		["remote", createMockRemoteFs, "requested_echo"],
+	] as const)("preserves %s mutation authority through observations and rename", async (
+		_role, createFs, expectedAuthority,
+	) => {
+		const fs = createFs();
+		await fs.write("dir/a.md", bytes("a"), 1000);
+		await fs.mkdir("empty");
+		await fs.rename("dir", "moved");
+
+		expect((await fs.stat("moved/a.md"))?.pathAuthority).toBe(expectedAuthority);
+		expect((await fs.stat("empty"))?.pathAuthority).toBe(expectedAuthority);
+		expect(new Map((await fs.list()).map((entity) => [entity.path, entity.pathAuthority])))
+			.toMatchObject(new Map([
+				["moved", expectedAuthority],
+				["moved/a.md", expectedAuthority],
+				["empty", expectedAuthority],
+			]));
+	});
+
+	it.each([
+		["local", createMockLocalFs],
+		["remote", createMockRemoteFs],
+	] as const)("treats %s addFile fixtures as producer-resolved seeds", async (
+		_role, createFs,
+	) => {
+		const fs = createFs();
+		addFile(fs, "seed/note.md", "observed");
+
+		expect((await fs.stat("seed"))?.pathAuthority).toBe("actual_resolved");
+		expect((await fs.stat("seed/note.md"))?.pathAuthority).toBe("actual_resolved");
+	});
+
+	it("requires an explicit provider-confirmation transition for remote mutations", async () => {
+		const fs = createMockRemoteFs();
+		await fs.write("dir/a.md", bytes("a"), 1000);
+		expect((await fs.stat("dir/a.md"))?.pathAuthority).toBe("requested_echo");
+
+		confirmMockPath(fs, "dir");
+
+		expect((await fs.stat("dir/a.md"))?.pathAuthority).toBe("actual_resolved");
 	});
 });

--- a/src/__mocks__/mock-remote-change-detection.test.ts
+++ b/src/__mocks__/mock-remote-change-detection.test.ts
@@ -10,7 +10,7 @@ import {
 // detection contract as every real backend. It is NOT checksumBased (no
 // remoteChecksum), so the metadata-touch case does not apply.
 runRemoteChangeDetectionContract("createMockFs", () => {
-	const fs = createMockFs("remote");
+	const fs = createMockFs("remote-contract", "requested_echo");
 	const path = "note.md";
 	return Promise.resolve({
 		async observeWritten() {

--- a/src/__mocks__/sync-test-helpers.ts
+++ b/src/__mocks__/sync-test-helpers.ts
@@ -1,5 +1,5 @@
 import type { IFileSystem } from "../fs/interface";
-import type { FileEntity } from "../fs/types";
+import type { FileEntity, PathAuthority } from "../fs/types";
 import type { RenamePair, SyncRecord } from "../sync/types";
 import type { SyncStateStore } from "../sync/state";
 import type { AirSyncSettings } from "../settings";
@@ -17,7 +17,10 @@ import { normalizeSyncPath, validateRename } from "../utils/path";
  * when an accurate hash is needed). The `.files` map is exposed so tests can
  * seed/inspect state directly (e.g. attach a `remoteChecksum`).
  */
-export function createMockFs(name: string): IFileSystem & {
+export function createMockFs(
+	name: string,
+	mutationPathAuthority: PathAuthority = "actual_resolved",
+): IFileSystem & {
 	files: Map<string, { content: ArrayBuffer; entity: FileEntity }>;
 } {
 	const files = new Map<
@@ -42,7 +45,7 @@ export function createMockFs(name: string): IFileSystem & {
 					content: new ArrayBuffer(0),
 					entity: {
 						path: current,
-						pathAuthority: "actual_resolved",
+						pathAuthority: mutationPathAuthority,
 						isDirectory: true,
 						size: 0,
 						mtime: 0,
@@ -103,7 +106,7 @@ export function createMockFs(name: string): IFileSystem & {
 			ensureParents(path);
 			const entity: FileEntity = {
 				path,
-				pathAuthority: "actual_resolved",
+				pathAuthority: mutationPathAuthority,
 				isDirectory: false,
 				size: content.byteLength,
 				mtime,
@@ -113,8 +116,9 @@ export function createMockFs(name: string): IFileSystem & {
 			// mutation of the caller's buffer must not change stored content.
 			files.set(path, { content: content.slice(0), entity });
 			// list() reads the stored entity (hash ""); the return value carries the
-			// computed hash, mirroring a real backend's write(). Mutation responses
-			// echo the requested path; a later list/stat resolves the stored path.
+			// computed hash, mirroring a real backend's write(). Remote-cache tests
+			// inject requested_echo so later stat/list cannot silently claim that a
+			// mutation path was producer-resolved; local tests retain actual_resolved.
 			return { ...entity, pathAuthority: "requested_echo", hash: await sha256(content) };
 		},
 		async mkdir(path: string) {

--- a/src/__mocks__/sync-test-helpers.ts
+++ b/src/__mocks__/sync-test-helpers.ts
@@ -42,6 +42,7 @@ export function createMockFs(name: string): IFileSystem & {
 					content: new ArrayBuffer(0),
 					entity: {
 						path: current,
+						pathAuthority: "actual_resolved",
 						isDirectory: true,
 						size: 0,
 						mtime: 0,
@@ -50,7 +51,7 @@ export function createMockFs(name: string): IFileSystem & {
 				});
 			}
 		}
-		return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+		return { path, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" };
 	}
 
 	function ensureParents(path: string): void {
@@ -102,6 +103,7 @@ export function createMockFs(name: string): IFileSystem & {
 			ensureParents(path);
 			const entity: FileEntity = {
 				path,
+				pathAuthority: "actual_resolved",
 				isDirectory: false,
 				size: content.byteLength,
 				mtime,
@@ -111,8 +113,9 @@ export function createMockFs(name: string): IFileSystem & {
 			// mutation of the caller's buffer must not change stored content.
 			files.set(path, { content: content.slice(0), entity });
 			// list() reads the stored entity (hash ""); the return value carries the
-			// computed hash, mirroring a real backend's write().
-			return { ...entity, hash: await sha256(content) };
+			// computed hash, mirroring a real backend's write(). Mutation responses
+			// echo the requested path; a later list/stat resolves the stored path.
+			return { ...entity, pathAuthority: "requested_echo", hash: await sha256(content) };
 		},
 		async mkdir(path: string) {
 			// Stays async so mkdirInternal's type-collision throw rejects.
@@ -301,6 +304,7 @@ export function addFile(
 			if (!fs.files.has(current)) {
 				const dirEntity: FileEntity = {
 					path: current,
+					pathAuthority: "actual_resolved",
 					isDirectory: true,
 					size: 0,
 					mtime: 0,
@@ -315,6 +319,7 @@ export function addFile(
 	}
 	const entity: FileEntity = {
 		path,
+		pathAuthority: "actual_resolved",
 		isDirectory: false,
 		size: buf.byteLength,
 		mtime,

--- a/src/__mocks__/sync-test-helpers.ts
+++ b/src/__mocks__/sync-test-helpers.ts
@@ -181,6 +181,9 @@ export function createMockFs(name: string): IFileSystem & {
 					modified: [] as string[],
 					deleted: [] as string[],
 				}),
+			listCurrentSnapshot: () => Promise.resolve(
+				Array.from(files.values()).map((entry) => ({ ...entry.entity })),
+			),
 			// Load-bearing default: true ⇒ orchestrator's `checkpoint ? !hasCheckpoint() : false`
 			// is false ⇒ no forced cold scan, so default tests stay WARM/COLD (mirroring the
 			// pre-capability mock, which had no hasCheckpoint and short-circuited to false).

--- a/src/__mocks__/sync-test-helpers.ts
+++ b/src/__mocks__/sync-test-helpers.ts
@@ -17,12 +17,14 @@ import { normalizeSyncPath, validateRename } from "../utils/path";
  * when an accurate hash is needed). The `.files` map is exposed so tests can
  * seed/inspect state directly (e.g. attach a `remoteChecksum`).
  */
+export type MockFileSystem = IFileSystem & {
+	files: Map<string, { content: ArrayBuffer; entity: FileEntity }>;
+};
+
 export function createMockFs(
 	name: string,
-	mutationPathAuthority: PathAuthority = "actual_resolved",
-): IFileSystem & {
-	files: Map<string, { content: ArrayBuffer; entity: FileEntity }>;
-} {
+	mutationPathAuthority: PathAuthority,
+): MockFileSystem {
 	const files = new Map<
 		string,
 		{ content: ArrayBuffer; entity: FileEntity }
@@ -197,6 +199,27 @@ export function createMockFs(
 			commitCheckpoint: () => Promise.resolve(),
 		},
 	};
+}
+
+/** Local mutations are observed from the authoritative vault adapter. */
+export function createMockLocalFs(): MockFileSystem {
+	return createMockFs("local", "actual_resolved");
+}
+
+/** Remote mutations remain request echoes until a test models provider confirmation. */
+export function createMockRemoteFs(): MockFileSystem {
+	return createMockFs("remote", "requested_echo");
+}
+
+/** Model a provider observation that confirms one remote path and its descendants. */
+export function confirmMockPath(fs: MockFileSystem, path: string): void {
+	path = normalizeSyncPath(path);
+	const prefix = path + "/";
+	for (const [candidate, entry] of fs.files) {
+		if (candidate === path || candidate.startsWith(prefix)) {
+			entry.entity.pathAuthority = "actual_resolved";
+		}
+	}
 }
 
 /** In-memory mock SyncStateStore for unit tests */

--- a/src/fs/backend-error-log.test.ts
+++ b/src/fs/backend-error-log.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logging/logger";
+import { describeErrorBody, logBackendErrorResponse, MAX_LOGGED_BODY_CHARS } from "./backend-error-log";
+
+function fakeLogger(): { logger: Logger; error: ReturnType<typeof vi.fn> } {
+	const error = vi.fn();
+	return { logger: { error } as unknown as Logger, error };
+}
+
+describe("describeErrorBody", () => {
+	it("serializes the whole JSON body including nested innerError", () => {
+		// The live issue-#42 shape: the outer code is generic, the inner one names the cause.
+		const body = describeErrorBody({
+			status: 403,
+			json: { error: { code: "accessDenied", message: "Access denied", innerError: { code: "serviceReadOnly" } } },
+		});
+		expect(body).toContain("accessDenied");
+		expect(body).toContain("Access denied");
+		expect(body).toContain("serviceReadOnly");
+	});
+
+	it("falls back to raw text when the body is not JSON", () => {
+		expect(describeErrorBody({ status: 502, text: "<html>proxy blocked</html>" })).toBe("<html>proxy blocked</html>");
+	});
+
+	it("reports an empty body rather than returning an empty string", () => {
+		expect(describeErrorBody({ status: 500 })).toBe("(empty body)");
+	});
+
+	it("announces truncation instead of silently clipping", () => {
+		const huge = "x".repeat(MAX_LOGGED_BODY_CHARS + 500);
+		const body = describeErrorBody({ status: 500, text: huge });
+		expect(body).toContain("[truncated 500 more chars]");
+		expect(body.length).toBeLessThan(huge.length);
+	});
+
+	it("still describes a body that cannot be serialized", () => {
+		const cyclic: Record<string, unknown> = {};
+		cyclic.self = cyclic;
+		expect(describeErrorBody({ status: 500, json: cyclic, text: "fallback" })).toBe("fallback");
+	});
+});
+
+describe("logBackendErrorResponse", () => {
+	it("logs status, operation, and the full body at error level", () => {
+		const { logger, error } = fakeLogger();
+		logBackendErrorResponse(logger, "OneDrive", "getAppRoot", {
+			status: 403,
+			json: { error: { code: "accessDenied", innerError: { code: "serviceReadOnly" } } },
+		});
+		expect(error).toHaveBeenCalledTimes(1);
+		const [message, context] = error.mock.calls[0] as [string, Record<string, unknown>];
+		expect(message).toContain("OneDrive");
+		expect(context).toMatchObject({ operation: "getAppRoot", status: 403 });
+		expect(context.body).toContain("serviceReadOnly");
+	});
+
+	it("keeps response headers but drops set-cookie", () => {
+		const { logger, error } = fakeLogger();
+		logBackendErrorResponse(logger, "Dropbox", "listFolder", {
+			status: 429,
+			json: {},
+			headers: { "retry-after": "30", "Set-Cookie": "session=secret" },
+		});
+		const [, context] = error.mock.calls[0] as [string, Record<string, unknown>];
+		expect(context.headers).toEqual({ "retry-after": "30" });
+	});
+
+	it("is a no-op without a logger", () => {
+		expect(() => logBackendErrorResponse(undefined, "OneDrive", "op", { status: 500 })).not.toThrow();
+	});
+});

--- a/src/fs/backend-error-log.ts
+++ b/src/fs/backend-error-log.ts
@@ -21,7 +21,7 @@ import type { Logger } from "../logging/logger";
  * `status` is optional because some call sites (a rejected request whose status the
  * caller already put in the message, an OAuth helper) only hold the body.
  */
-export interface BackendErrorResponse {
+interface BackendErrorResponse {
 	status?: number;
 	json?: unknown;
 	text?: string;

--- a/src/fs/backend-error-log.ts
+++ b/src/fs/backend-error-log.ts
@@ -1,0 +1,98 @@
+import type { Logger } from "../logging/logger";
+
+/**
+ * Lossless logging of an irregular (non-2xx) backend response.
+ *
+ * Why this exists: each backend's `assertOk` used to distil a failure down to a
+ * short thrown message and nothing else — no log line at all. When a backend
+ * reports something the plugin has no branch for, that distillation is exactly
+ * what destroys the evidence. The live case: Microsoft Graph answered every App
+ * Folder call with `403 accessDenied` whose *inner* code was `serviceReadOnly` (a
+ * service-side incident). The plugin surfaced `403 accessDenied` and dropped the
+ * rest, so the cause was invisible for days; another OneDrive client identified it
+ * immediately because its log carried the whole error body.
+ *
+ * So: log the ENTIRE body (and the response headers) verbatim before throwing, and
+ * make any truncation explicit rather than silent.
+ */
+
+/**
+ * Response shape shared by every backend's `requestUrl({ throw: false })` result.
+ * `status` is optional because some call sites (a rejected request whose status the
+ * caller already put in the message, an OAuth helper) only hold the body.
+ */
+export interface BackendErrorResponse {
+	status?: number;
+	json?: unknown;
+	text?: string;
+	headers?: Record<string, string>;
+}
+
+/**
+ * Cap for a single logged body. Generous — an error body is small, and the point of
+ * this module is to keep evidence — but bounded so a backend that answers an error
+ * with a whole HTML page (a captive portal, a proxy block page) cannot flood the log.
+ */
+export const MAX_LOGGED_BODY_CHARS = 8000;
+
+/**
+ * Cap for the body embedded in a thrown error's message. Shorter than the log cap
+ * because that message reaches a Notice, and the log already holds the full body.
+ */
+export const MAX_MESSAGE_BODY_CHARS = 600;
+
+/** Response headers that are never useful here and may carry session state. */
+const SKIPPED_HEADERS = new Set(["set-cookie"]);
+
+/**
+ * Render the response body as a string without losing structure: JSON is serialized
+ * whole (nested `innerError` included), a non-JSON body falls back to its raw text.
+ * Truncation is announced inline so a reader can never mistake a clipped body for a
+ * complete one.
+ */
+export function describeErrorBody(res: BackendErrorResponse, maxChars = MAX_LOGGED_BODY_CHARS): string {
+	let rendered: string;
+	try {
+		rendered = res.json === undefined || res.json === null ? "" : JSON.stringify(res.json);
+	} catch {
+		// A body that cannot be serialized (cycles, exotic values) must still leave a trace.
+		rendered = "";
+	}
+	if (!rendered) rendered = typeof res.text === "string" ? res.text : "";
+	if (!rendered) return "(empty body)";
+	return rendered.length > maxChars
+		? `${rendered.slice(0, maxChars)}…[truncated ${rendered.length - maxChars} more chars]`
+		: rendered;
+}
+
+/** Response headers, minus the ones deliberately skipped. Absent headers ⇒ undefined. */
+function describeHeaders(res: BackendErrorResponse): Record<string, string> | undefined {
+	if (!res.headers) return undefined;
+	const kept: Record<string, string> = {};
+	for (const [key, value] of Object.entries(res.headers)) {
+		if (!SKIPPED_HEADERS.has(key.toLowerCase())) kept[key] = value;
+	}
+	return Object.keys(kept).length > 0 ? kept : undefined;
+}
+
+/**
+ * Log one irregular backend response in full, at `error` level. Called by each
+ * backend's `assertOk` BEFORE it throws, so the evidence survives regardless of how
+ * the thrown error is later classified, retried, or swallowed by a caller.
+ *
+ * Never pass a token-endpoint response here: those bodies carry access/refresh
+ * tokens. Only API responses (which do not) belong in the log.
+ */
+export function logBackendErrorResponse(
+	logger: Logger | undefined,
+	backend: string,
+	operation: string,
+	res: BackendErrorResponse,
+): void {
+	logger?.error(`${backend} API returned an error response`, {
+		operation,
+		status: res.status,
+		body: describeErrorBody(res),
+		headers: describeHeaders(res),
+	});
+}

--- a/src/fs/caching/metadata-cache.ts
+++ b/src/fs/caching/metadata-cache.ts
@@ -1,6 +1,7 @@
-import type { FileEntity } from "../types";
+import type { FileEntity, PathAuthority } from "../types";
 import type { Logger } from "../../logging/logger";
 import { INTERNAL_METADATA_PATH } from "../remote-vault-contract";
+import { resolvePathAuthority } from "./path-authority";
 
 export interface FileChangeResult {
 	oldPath: string | undefined;
@@ -30,6 +31,8 @@ export abstract class AbstractMetadataCache<TFile> {
 	private folders = new Set<string>();
 	/** Parent path → set of direct child paths (for O(k) child lookups) */
 	private children = new Map<string, Set<string>>();
+	/** Producer-qualified authority for each cached path spelling. */
+	private pathAuthorities = new Map<string, PathAuthority>();
 
 	private rootFolderId: string;
 	protected logger?: Logger;
@@ -63,6 +66,9 @@ export abstract class AbstractMetadataCache<TFile> {
 	getPathById(id: string): string | undefined { return this.idToPath.get(id); }
 	hasId(id: string): boolean { return this.idToPath.has(id); }
 	getChildren(path: string): ReadonlySet<string> | undefined { return this.children.get(path); }
+	getPathAuthority(path: string): PathAuthority {
+		return this.pathAuthorities.get(path) ?? "requested_echo";
+	}
 	get size(): number { return this.pathToFile.size; }
 	entries(): IterableIterator<[string, TFile]> { return this.pathToFile.entries(); }
 
@@ -91,10 +97,11 @@ export abstract class AbstractMetadataCache<TFile> {
 	}
 
 	/** Add or update a file in the cache with full index maintenance */
-	setFile(path: string, file: TFile): void {
+	setFile(path: string, file: TFile, pathAuthority: PathAuthority = "requested_echo"): void {
 		if (this.isReserved(path)) return;
 		const isNew = !this.pathToFile.has(path);
 		this.pathToFile.set(path, file);
+		this.pathAuthorities.set(path, pathAuthority);
 		this.idToPath.set(this.extractId(file), path);
 		if (this.isFolderEntry(file)) {
 			this.folders.add(path);
@@ -108,14 +115,16 @@ export abstract class AbstractMetadataCache<TFile> {
 		if (file) this.idToPath.delete(this.extractId(file));
 		this.removeFromIndex(path);
 		this.pathToFile.delete(path);
+		this.pathAuthorities.delete(path);
 		this.folders.delete(path);
 	}
 
 	/** Bulk-load files into the cache. Does NOT clear — callers clear() first when rebuilding. */
-	bulkLoad(items: Iterable<[string, TFile]>): void {
-		for (const [path, file] of items) {
+	bulkLoad(items: Iterable<[string, TFile, PathAuthority?]>): void {
+		for (const [path, file, pathAuthority = "requested_echo"] of items) {
 			if (this.isReserved(path)) continue;
 			this.pathToFile.set(path, file);
+			this.pathAuthorities.set(path, pathAuthority);
 			this.idToPath.set(this.extractId(file), path);
 			if (this.isFolderEntry(file)) {
 				this.folders.add(path);
@@ -127,11 +136,12 @@ export abstract class AbstractMetadataCache<TFile> {
 	}
 
 	/** Return a snapshot of all records for persistence */
-	exportRecords(): { path: string; file: TFile; isFolder: boolean }[] {
+	exportRecords(): { path: string; file: TFile; isFolder: boolean; pathAuthority: PathAuthority }[] {
 		return [...this.pathToFile.entries()].map(([path, file]) => ({
 			path,
 			file,
 			isFolder: this.folders.has(path),
+			pathAuthority: this.getPathAuthority(path),
 		}));
 	}
 
@@ -147,6 +157,7 @@ export abstract class AbstractMetadataCache<TFile> {
 		this.idToPath.clear();
 		this.folders.clear();
 		this.children.clear();
+		this.pathAuthorities.clear();
 	}
 
 	/** Add a path to the children index */
@@ -202,30 +213,51 @@ export abstract class AbstractMetadataCache<TFile> {
 		}
 
 		const resolvedPaths = new Map<string, string>();
+		const resolvedAuthorities = new Map<string, PathAuthority>();
 		const resolved: [string, TFile][] = [];
 		for (const file of files) {
 			const path = this.resolveFilePathCached(file, byId, resolvedPaths, new Set());
 			resolved.push([path, file]);
+			resolvePathAuthority(file, {
+				rootFolderId: this.rootFolderId,
+				byId,
+				extractId: (entry) => this.extractId(entry),
+				extractParentIds: (entry) => this.extractParentIds(entry),
+				resolved: resolvedAuthorities,
+			}, new Set());
 		}
 
-		this.bulkLoad(resolved);
+		this.bulkLoad(resolved.map(([path, file]): [string, TFile, PathAuthority] => [
+			path,
+			file,
+			resolvedAuthorities.get(this.extractId(file)) ?? "requested_echo",
+		]));
 	}
 
 	/** Resolve a file's relative path using the existing cache */
 	resolvePathFromCache(file: TFile): string | null {
+		return this.resolvePathObservationFromCache(file)?.path ?? null;
+	}
+
+	private resolvePathObservationFromCache(
+		file: TFile,
+	): { path: string; pathAuthority: PathAuthority } | null {
 		const parents = this.extractParentIds(file);
 		if (parents.length === 0) return null;
 
 		const parentId = this.findRelevantParentId(parents, this.idToPath);
 		if (!parentId) return null;
 		if (parentId === this.rootFolderId) {
-			return this.extractName(file);
+			return { path: this.extractName(file), pathAuthority: "actual_resolved" };
 		}
 
 		const parentPath = this.idToPath.get(parentId);
 		if (!parentPath) return null;
 
-		return `${parentPath}/${this.extractName(file)}`;
+		return {
+			path: `${parentPath}/${this.extractName(file)}`,
+			pathAuthority: this.getPathAuthority(parentPath),
+		};
 	}
 
 	/**
@@ -280,16 +312,19 @@ export abstract class AbstractMetadataCache<TFile> {
 	}
 
 	/** Rewrite all cached child paths when a folder is renamed/moved */
-	rewriteChildPaths(oldPath: string, newPath: string): void {
+	rewriteChildPaths(oldPath: string, newPath: string, pathAuthority?: PathAuthority): void {
 		const oldPrefix = oldPath + "/";
 		const descendants = this.collectDescendants(oldPath);
 		for (const childPath of descendants) {
 			const childFile = this.pathToFile.get(childPath);
 			if (!childFile) continue;
+			const childAuthority = pathAuthority ?? this.getPathAuthority(childPath);
 			const newChildPath = newPath + "/" + childPath.substring(oldPrefix.length);
 			this.removeFromIndex(childPath);
 			this.pathToFile.delete(childPath);
+			this.pathAuthorities.delete(childPath);
 			this.pathToFile.set(newChildPath, childFile);
+			this.pathAuthorities.set(newChildPath, childAuthority);
 			this.idToPath.set(this.extractId(childFile), newChildPath);
 			this.addToIndex(newChildPath);
 			if (this.folders.delete(childPath)) {
@@ -329,7 +364,8 @@ export abstract class AbstractMetadataCache<TFile> {
 	/** Apply a single file change to the metadata cache */
 	applyFileChange(file: TFile): void {
 		const id = this.extractId(file);
-		const path = this.resolvePathFromCache(file);
+		const observation = this.resolvePathObservationFromCache(file);
+		const path = observation?.path ?? null;
 		const oldPath = this.idToPath.get(id);
 
 		if (!path) {
@@ -363,6 +399,7 @@ export abstract class AbstractMetadataCache<TFile> {
 			const wasFolder = this.folders.has(oldPath);
 			this.removeFromIndex(oldPath);
 			this.pathToFile.delete(oldPath);
+			this.pathAuthorities.delete(oldPath);
 			this.idToPath.delete(id);
 			this.folders.delete(oldPath);
 			if (wasFolder) {
@@ -371,6 +408,7 @@ export abstract class AbstractMetadataCache<TFile> {
 		}
 
 		this.pathToFile.set(path, file);
+		this.pathAuthorities.set(path, observation?.pathAuthority ?? "requested_echo");
 		this.idToPath.set(id, path);
 		this.addToIndex(path);
 		if (this.isFolderEntry(file)) {

--- a/src/fs/caching/metadata-cache.ts
+++ b/src/fs/caching/metadata-cache.ts
@@ -1,7 +1,7 @@
 import type { FileEntity, PathAuthority } from "../types";
 import type { Logger } from "../../logging/logger";
 import { INTERNAL_METADATA_PATH } from "../remote-vault-contract";
-import { resolvePathAuthority } from "./path-authority";
+import { resolveCachedPathAuthority, resolvePathAuthority, resolveStoredPathAuthority } from "./path-authority";
 
 export interface FileChangeResult {
 	oldPath: string | undefined;
@@ -67,7 +67,7 @@ export abstract class AbstractMetadataCache<TFile> {
 	hasId(id: string): boolean { return this.idToPath.has(id); }
 	getChildren(path: string): ReadonlySet<string> | undefined { return this.children.get(path); }
 	getPathAuthority(path: string): PathAuthority {
-		return this.pathAuthorities.get(path) ?? "requested_echo";
+		return resolveCachedPathAuthority(path, this.pathToFile, this.pathAuthorities);
 	}
 	get size(): number { return this.pathToFile.size; }
 	entries(): IterableIterator<[string, TFile]> { return this.pathToFile.entries(); }
@@ -173,7 +173,7 @@ export abstract class AbstractMetadataCache<TFile> {
 			path,
 			file,
 			isFolder: this.folders.has(path),
-			pathAuthority: this.getPathAuthority(path),
+			pathAuthority: resolveStoredPathAuthority(path, this.pathAuthorities),
 		}));
 	}
 
@@ -344,13 +344,13 @@ export abstract class AbstractMetadataCache<TFile> {
 	}
 
 	/** Rewrite all cached child paths when a folder is renamed/moved */
-	rewriteChildPaths(oldPath: string, newPath: string, pathAuthority?: PathAuthority): void {
+	rewriteChildPaths(oldPath: string, newPath: string): void {
 		const oldPrefix = oldPath + "/";
 		const descendants = this.collectDescendants(oldPath);
 		for (const childPath of descendants) {
 			const childFile = this.pathToFile.get(childPath);
 			if (!childFile) continue;
-			const childAuthority = pathAuthority ?? this.getPathAuthority(childPath);
+			const childAuthority = resolveStoredPathAuthority(childPath, this.pathAuthorities);
 			const newChildPath = newPath + "/" + childPath.substring(oldPrefix.length);
 			this.removeFromIndex(childPath);
 			this.pathToFile.delete(childPath);

--- a/src/fs/caching/metadata-cache.ts
+++ b/src/fs/caching/metadata-cache.ts
@@ -66,9 +66,8 @@ export abstract class AbstractMetadataCache<TFile> {
 	getPathById(id: string): string | undefined { return this.idToPath.get(id); }
 	hasId(id: string): boolean { return this.idToPath.has(id); }
 	getChildren(path: string): ReadonlySet<string> | undefined { return this.children.get(path); }
-	getPathAuthority(path: string): PathAuthority {
-		return resolveCachedPathAuthority(path, this.pathToFile, this.pathAuthorities);
-	}
+	getPathAuthority(path: string): PathAuthority { return resolveCachedPathAuthority(path, this.pathToFile, this.pathAuthorities); }
+	getStoredPathAuthority(path: string): PathAuthority { return resolveStoredPathAuthority(path, this.pathAuthorities); }
 	get size(): number { return this.pathToFile.size; }
 	entries(): IterableIterator<[string, TFile]> { return this.pathToFile.entries(); }
 
@@ -173,7 +172,7 @@ export abstract class AbstractMetadataCache<TFile> {
 			path,
 			file,
 			isFolder: this.folders.has(path),
-			pathAuthority: resolveStoredPathAuthority(path, this.pathAuthorities),
+			pathAuthority: this.getStoredPathAuthority(path),
 		}));
 	}
 
@@ -268,28 +267,16 @@ export abstract class AbstractMetadataCache<TFile> {
 
 	/** Resolve a file's relative path using the existing cache */
 	resolvePathFromCache(file: TFile): string | null {
-		return this.resolvePathObservationFromCache(file)?.path ?? null;
-	}
-
-	private resolvePathObservationFromCache(
-		file: TFile,
-	): { path: string; pathAuthority: PathAuthority } | null {
 		const parents = this.extractParentIds(file);
 		if (parents.length === 0) return null;
 
 		const parentId = this.findRelevantParentId(parents, this.idToPath);
 		if (!parentId) return null;
-		if (parentId === this.rootFolderId) {
-			return { path: this.extractName(file), pathAuthority: "actual_resolved" };
-		}
+		if (parentId === this.rootFolderId) return this.extractName(file);
 
 		const parentPath = this.idToPath.get(parentId);
 		if (!parentPath) return null;
-
-		return {
-			path: `${parentPath}/${this.extractName(file)}`,
-			pathAuthority: this.getPathAuthority(parentPath),
-		};
+		return `${parentPath}/${this.extractName(file)}`;
 	}
 
 	/**
@@ -396,8 +383,7 @@ export abstract class AbstractMetadataCache<TFile> {
 	/** Apply a single file change to the metadata cache */
 	applyFileChange(file: TFile): void {
 		const id = this.extractId(file);
-		const observation = this.resolvePathObservationFromCache(file);
-		const path = observation?.path ?? null;
+		const path = this.resolvePathFromCache(file);
 		const oldPath = this.idToPath.get(id);
 
 		if (!path) {
@@ -416,6 +402,9 @@ export abstract class AbstractMetadataCache<TFile> {
 			return;
 		}
 
-		this.setFile(path, file, observation?.pathAuthority ?? "requested_echo");
+		// The delta names this entry and its parent id directly, so the entry's own
+		// spelling is provider-resolved. getPathAuthority() still projects any
+		// unresolved ancestor over it until that ancestor is confirmed.
+		this.setFile(path, file, "actual_resolved");
 	}
 }

--- a/src/fs/caching/metadata-cache.ts
+++ b/src/fs/caching/metadata-cache.ts
@@ -99,14 +99,42 @@ export abstract class AbstractMetadataCache<TFile> {
 	/** Add or update a file in the cache with full index maintenance */
 	setFile(path: string, file: TFile, pathAuthority: PathAuthority = "requested_echo"): void {
 		if (this.isReserved(path)) return;
-		const isNew = !this.pathToFile.has(path);
+		const id = this.extractId(file);
+		const incomingIsFolder = this.isFolderEntry(file);
+		const oldPath = this.idToPath.get(id);
+		const occupant = this.pathToFile.get(path);
+
+		// Provider upserts may re-key a stable id without a preceding tombstone.
+		// Keep the path and identity indexes bijective at their single mutation seam.
+		if (occupant && this.extractId(occupant) !== id) {
+			this.removeTree(path);
+		}
+
+		if (oldPath && oldPath !== path) {
+			const wasFolder = this.folders.has(oldPath);
+			if (wasFolder && !incomingIsFolder) {
+				this.removeTree(oldPath);
+			} else {
+				this.removeFromIndex(oldPath);
+				this.pathToFile.delete(oldPath);
+				this.pathAuthorities.delete(oldPath);
+				this.idToPath.delete(id);
+				this.folders.delete(oldPath);
+				if (wasFolder) this.rewriteChildPaths(oldPath, path);
+			}
+		} else if (oldPath === path && this.folders.has(path) && !incomingIsFolder) {
+			this.removeTree(path);
+		}
+
 		this.pathToFile.set(path, file);
 		this.pathAuthorities.set(path, pathAuthority);
-		this.idToPath.set(this.extractId(file), path);
-		if (this.isFolderEntry(file)) {
+		this.idToPath.set(id, path);
+		if (incomingIsFolder) {
 			this.folders.add(path);
+		} else {
+			this.folders.delete(path);
 		}
-		if (isNew) this.addToIndex(path);
+		this.addToIndex(path);
 	}
 
 	/** Remove a single entry from pathToFile/idToPath/folders and the children index */
@@ -121,17 +149,21 @@ export abstract class AbstractMetadataCache<TFile> {
 
 	/** Bulk-load files into the cache. Does NOT clear — callers clear() first when rebuilding. */
 	bulkLoad(items: Iterable<[string, TFile, PathAuthority?]>): void {
-		for (const [path, file, pathAuthority = "requested_echo"] of items) {
+		const records = [...items];
+		const seenIds = new Map<string, string>();
+		for (const [path, file] of records) {
 			if (this.isReserved(path)) continue;
-			this.pathToFile.set(path, file);
-			this.pathAuthorities.set(path, pathAuthority);
-			this.idToPath.set(this.extractId(file), path);
-			if (this.isFolderEntry(file)) {
-				this.folders.add(path);
+			const id = this.extractId(file);
+			const priorPath = seenIds.get(id);
+			if (priorPath !== undefined) {
+				throw new Error(
+					`Metadata cache contains duplicate stable id "${id}" at "${priorPath}" and "${path}"`,
+				);
 			}
+			seenIds.set(id, path);
 		}
-		for (const path of this.pathToFile.keys()) {
-			this.addToIndex(path);
+		for (const [path, file, pathAuthority = "requested_echo"] of records) {
+			this.setFile(path, file, pathAuthority);
 		}
 	}
 
@@ -384,37 +416,6 @@ export abstract class AbstractMetadataCache<TFile> {
 			return;
 		}
 
-		// A different entry already occupies this path with no preceding `deleted`
-		// tombstone (the provider didn't emit the delete first, or batched them out
-		// of order). Evict it — and, if it was a folder, its whole cached subtree —
-		// so stale descendants don't linger as phantom paths, and idToPath doesn't
-		// keep pointing the displaced id at this path.
-		const occupant = this.pathToFile.get(path);
-		if (occupant && this.extractId(occupant) !== id) {
-			this.removeTree(path);
-		}
-
-		// Remove old mapping if ID was at a different path (rename/move)
-		if (oldPath && oldPath !== path) {
-			const wasFolder = this.folders.has(oldPath);
-			this.removeFromIndex(oldPath);
-			this.pathToFile.delete(oldPath);
-			this.pathAuthorities.delete(oldPath);
-			this.idToPath.delete(id);
-			this.folders.delete(oldPath);
-			if (wasFolder) {
-				this.rewriteChildPaths(oldPath, path);
-			}
-		}
-
-		this.pathToFile.set(path, file);
-		this.pathAuthorities.set(path, observation?.pathAuthority ?? "requested_echo");
-		this.idToPath.set(id, path);
-		this.addToIndex(path);
-		if (this.isFolderEntry(file)) {
-			this.folders.add(path);
-		} else {
-			this.folders.delete(path);
-		}
+		this.setFile(path, file, observation?.pathAuthority ?? "requested_echo");
 	}
 }

--- a/src/fs/caching/path-authority.ts
+++ b/src/fs/caching/path-authority.ts
@@ -1,0 +1,44 @@
+import type { PathAuthority } from "../types";
+
+interface PathAuthorityContext<TFile> {
+	rootFolderId: string;
+	byId: ReadonlyMap<string, TFile>;
+	extractId: (file: TFile) => string;
+	extractParentIds: (file: TFile) => string[];
+	resolved: Map<string, PathAuthority>;
+}
+
+/** Resolve whether a backend parent chain reaches the configured sync root. */
+export function resolvePathAuthority<TFile>(
+	file: TFile,
+	context: PathAuthorityContext<TFile>,
+	visiting: Set<string>,
+): PathAuthority {
+	const id = context.extractId(file);
+	const cached = context.resolved.get(id);
+	if (cached !== undefined) return cached;
+	if (visiting.has(id)) return "requested_echo";
+
+	const parents = context.extractParentIds(file);
+	const parentId = parents.includes(context.rootFolderId)
+		? context.rootFolderId
+		: parents.find((candidate) => context.byId.has(candidate));
+	if (!parentId || parentId === id) return remember(context.resolved, id, "requested_echo");
+	if (parentId === context.rootFolderId) return remember(context.resolved, id, "actual_resolved");
+
+	const parent = context.byId.get(parentId);
+	if (!parent) return remember(context.resolved, id, "requested_echo");
+	visiting.add(id);
+	const authority = resolvePathAuthority(parent, context, visiting);
+	visiting.delete(id);
+	return remember(context.resolved, id, authority);
+}
+
+function remember(
+	resolved: Map<string, PathAuthority>,
+	id: string,
+	authority: PathAuthority,
+): PathAuthority {
+	resolved.set(id, authority);
+	return authority;
+}

--- a/src/fs/caching/path-authority.ts
+++ b/src/fs/caching/path-authority.ts
@@ -49,6 +49,7 @@ export function resolveCachedPathAuthority(
 	entries: ReadonlyMap<string, unknown>,
 	authorities: ReadonlyMap<string, PathAuthority>,
 ): PathAuthority {
+	if (!entries.has(path)) return "requested_echo";
 	let current = path;
 	while (current) {
 		if (entries.has(current) && resolveStoredPathAuthority(current, authorities) === "requested_echo") {

--- a/src/fs/caching/path-authority.ts
+++ b/src/fs/caching/path-authority.ts
@@ -42,3 +42,26 @@ function remember(
 	resolved.set(id, authority);
 	return authority;
 }
+
+/** Project stored entry authority through any unresolved cached ancestor. */
+export function resolveCachedPathAuthority(
+	path: string,
+	entries: ReadonlyMap<string, unknown>,
+	authorities: ReadonlyMap<string, PathAuthority>,
+): PathAuthority {
+	let current = path;
+	while (current) {
+		if (entries.has(current) && resolveStoredPathAuthority(current, authorities) === "requested_echo") {
+			return "requested_echo";
+		}
+		const separator = current.lastIndexOf("/");
+		current = separator === -1 ? "" : current.substring(0, separator);
+	}
+	return "actual_resolved";
+}
+
+export function resolveStoredPathAuthority(
+	path: string, authorities: ReadonlyMap<string, PathAuthority>,
+): PathAuthority {
+	return authorities.get(path) ?? "requested_echo";
+}

--- a/src/fs/caching/remote-fs-contract.test.ts
+++ b/src/fs/caching/remote-fs-contract.test.ts
@@ -261,5 +261,31 @@ export function runCachingRemoteFsContract<TFile>(
 			expect(await fs.stat("dir/b.md")).toBeNull();
 			await store.close();
 		});
+
+		it("reads the post-delta snapshot without consuming the next delta", async () => {
+			const h = makeHarness();
+			h.seedFolderWithChild("dir", "b.md");
+			const store = h.makeStore("contract-snapshot-no-replay");
+			const fs = h.makeFs(store);
+			await fs.list();
+			await fs.commitCheckpoint();
+
+			h.stageRemoteRename("dir", "papers", { isFolder: true });
+			const first = await fs.getChangedPaths();
+			expect(first?.renamed).toContainEqual({
+				oldPath: "dir", newPath: "papers", isFolder: true,
+			});
+
+			h.stageRemoteRename("papers", "archive", { isFolder: true });
+			const snapshot = await fs.listCurrentSnapshot();
+			expect(snapshot.some((entry) => entry.path === "papers/b.md")).toBe(true);
+			expect(snapshot.some((entry) => entry.path === "archive/b.md")).toBe(false);
+
+			const second = await fs.getChangedPaths();
+			expect(second?.renamed).toContainEqual({
+				oldPath: "papers", newPath: "archive", isFolder: true,
+			});
+			await store.close();
+		});
 	});
 }

--- a/src/fs/caching/remote-fs.contract.test.ts
+++ b/src/fs/caching/remote-fs.contract.test.ts
@@ -1,4 +1,5 @@
 import "fake-indexeddb/auto";
+import { describe, expect, it } from "vitest";
 import type { FileEntity } from "../types";
 import type { RenamePair } from "../types";
 import { MetadataStore } from "../../store/metadata-store";
@@ -31,8 +32,9 @@ class MockCache extends AbstractMetadataCache<MockFile> {
 	protected extractName(f: MockFile): string { return f.name; }
 	protected isFolderEntry(f: MockFile): boolean { return !!f.isFolder; }
 	toEntity(path: string, f: MockFile): FileEntity {
-		if (f.isFolder) return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
-		return { path, isDirectory: false, size: 0, mtime: 0, hash: "", remoteChecksum: { algo: "opaque", value: f.checksum } };
+		const pathAuthority = this.getPathAuthority(path);
+		if (f.isFolder) return { path, pathAuthority, isDirectory: true, size: 0, mtime: 0, hash: "" };
+		return { path, pathAuthority, isDirectory: false, size: 0, mtime: 0, hash: "", remoteChecksum: { algo: "opaque", value: f.checksum } };
 	}
 }
 
@@ -146,3 +148,33 @@ function makeMockHarness(): CachingRemoteFsHarness<MockFile> {
 }
 
 runCachingRemoteFsContract("MockRemoteFs", makeMockHarness);
+
+describe("MockRemoteFs incremental authority persistence", () => {
+	it("restores a child's own authority after its unresolved parent is confirmed", async () => {
+		const remote = new FakeRemote();
+		remote.seedFolderWithChild("Docs", "a.md");
+		const [folder, child] = remote.list();
+		const store = new MetadataStore<MockFile>("authority-restart", {
+			dbNamePrefix: "air-sync-mock", version: 1,
+		});
+		await store.open();
+		await store.saveAll([
+			{ path: "Docs", file: folder!, isFolder: true, pathAuthority: "requested_echo" },
+			{ path: "Docs/a.md", file: child!, isFolder: false, pathAuthority: "actual_resolved" },
+		], new Map([["changesStartPageToken", "c0"]]));
+
+		remote.stageRename("a.md", "a.md");
+		const first = new MockRemoteFs(remote, store);
+		await first.getChangedPaths();
+		expect((await first.stat("Docs/a.md"))?.pathAuthority).toBe("requested_echo");
+		await first.commitCheckpoint();
+		await first.close();
+
+		remote.stageRename("Docs", "Docs", { isFolder: true });
+		const restarted = new MockRemoteFs(remote, store);
+		await restarted.getChangedPaths();
+
+		expect((await restarted.stat("Docs/a.md"))?.pathAuthority).toBe("actual_resolved");
+		await restarted.close();
+	});
+});

--- a/src/fs/caching/remote-fs.contract.test.ts
+++ b/src/fs/caching/remote-fs.contract.test.ts
@@ -150,6 +150,31 @@ function makeMockHarness(): CachingRemoteFsHarness<MockFile> {
 runCachingRemoteFsContract("MockRemoteFs", makeMockHarness);
 
 describe("MockRemoteFs incremental authority persistence", () => {
+	it("rejects a duplicate-identity checkpoint before sync chooses WARM", async () => {
+		const remote = new FakeRemote();
+		remote.seed("c.md");
+		const [file] = remote.list();
+		const store = new MetadataStore<MockFile>("duplicate-identity-checkpoint", {
+			dbNamePrefix: "air-sync-mock",
+			version: 1,
+		});
+		await store.open();
+		await store.saveAll([
+			{ path: "C.md", file: file!, isFolder: false },
+			{ path: "c.md", file: file!, isFolder: false },
+		], new Map([["changesStartPageToken", "c0"]]));
+
+		const fs = new MockRemoteFs(remote, store);
+
+		// A cursor cannot make a malformed file map a usable checkpoint. Returning
+		// true here makes the orchestrator choose WARM; the later recovery scan then
+		// looks like an empty delta and a pending case-only rename is silently skipped.
+		expect(await fs.hasCheckpoint()).toBe(false);
+		expect((await fs.list()).map((entry) => entry.path)).toEqual(["c.md"]);
+
+		await fs.close();
+	});
+
 	it("restores a child's own authority after its unresolved parent is confirmed", async () => {
 		const remote = new FakeRemote();
 		remote.seedFolderWithChild("Docs", "a.md");

--- a/src/fs/caching/remote-fs.ts
+++ b/src/fs/caching/remote-fs.ts
@@ -330,7 +330,7 @@ export abstract class CachingRemoteFs<TFile> implements IFileSystem {
 	 * is co-located with the cache, so its presence is the checkpoint.
 	 */
 	async hasCheckpoint(): Promise<boolean> {
-		return (await this.peekMeta(CURSOR_META_KEY, this._changesPageToken)) !== null;
+		return this.cacheMutex.run(() => this.initialized ? Promise.resolve(this._changesPageToken !== null) : this.loadFromCache());
 	}
 
 	/**

--- a/src/fs/caching/remote-fs.ts
+++ b/src/fs/caching/remote-fs.ts
@@ -1,6 +1,5 @@
 import type { IFileSystem, IncrementalCheckpoint } from "../interface";
-import type { FileEntity } from "../types";
-import type { RenamePair } from "../types";
+import type { FileEntity, PathAuthority, RenamePair } from "../types";
 import type { MetadataStore } from "../../store/metadata-store";
 import type { Logger } from "../../logging/logger";
 import { AsyncMutex } from "../../queue/async-queue";
@@ -227,7 +226,8 @@ export abstract class CachingRemoteFs<TFile> implements IFileSystem {
 			if (!cursor) return false;
 
 			this.cache.clear();
-			this.cache.bulkLoad(files.map((r): [string, TFile] => [r.path, r.file]));
+			this.cache.bulkLoad(files.map((r): [string, TFile, PathAuthority?] =>
+				[r.path, r.file, r.pathAuthority]));
 			this._changesPageToken = cursor;
 			this._scopeFingerprint = meta.get(SCOPE_FINGERPRINT_META_KEY) ?? null;
 			this.initialized = true;
@@ -292,11 +292,12 @@ export abstract class CachingRemoteFs<TFile> implements IFileSystem {
 			await store.saveAll(this.cache.exportRecords(), meta);
 			return;
 		}
-		const updated: { path: string; file: TFile; isFolder: boolean }[] = [];
+		const updated: { path: string; file: TFile; isFolder: boolean; pathAuthority: PathAuthority }[] = [];
 		const deleted: string[] = [];
 		for (const path of this.touchedPaths) {
 			const file = this.cache.getFile(path);
-			if (file) updated.push({ path, file, isFolder: this.cache.isFolder(path) });
+			if (file) updated.push({ path, file, isFolder: this.cache.isFolder(path),
+				pathAuthority: this.cache.getPathAuthority(path) });
 			else deleted.push(path);
 		}
 		await store.commitIncremental(updated, deleted, meta);

--- a/src/fs/caching/remote-fs.ts
+++ b/src/fs/caching/remote-fs.ts
@@ -297,7 +297,7 @@ export abstract class CachingRemoteFs<TFile> implements IFileSystem {
 		for (const path of this.touchedPaths) {
 			const file = this.cache.getFile(path);
 			if (file) updated.push({ path, file, isFolder: this.cache.isFolder(path),
-				pathAuthority: this.cache.getPathAuthority(path) });
+				pathAuthority: this.cache.getStoredPathAuthority(path) });
 			else deleted.push(path);
 		}
 		await store.commitIncremental(updated, deleted, meta);

--- a/src/fs/caching/remote-fs.ts
+++ b/src/fs/caching/remote-fs.ts
@@ -461,6 +461,13 @@ export abstract class CachingRemoteFs<TFile> implements IFileSystem {
 		});
 	}
 
+	async listCurrentSnapshot(): Promise<FileEntity[]> {
+		return this.cacheMutex.run(async () => {
+			await this.ensureInitialized();
+			return this.snapshotEntities();
+		});
+	}
+
 	// ── Read-only ops (walk the cache) ──
 
 	async list(): Promise<FileEntity[]> {
@@ -469,10 +476,14 @@ export abstract class CachingRemoteFs<TFile> implements IFileSystem {
 			if (await this.ensureInitialized()) {
 				await this._applyIncrementalChanges();
 			}
-			return Array.from(this.cache.entries(), ([path, file]) =>
-				this.cache.toEntity(path, file),
-			);
+			return this.snapshotEntities();
 		});
+	}
+
+	private snapshotEntities(): FileEntity[] {
+		return Array.from(this.cache.entries(), ([path, file]) =>
+			this.cache.toEntity(path, file),
+		);
 	}
 
 	/**

--- a/src/fs/dropbox/auth.ts
+++ b/src/fs/dropbox/auth.ts
@@ -2,6 +2,7 @@ import { requestUrl } from "../../platform/obsidian";
 import type { ISecretStore } from "../secret-store";
 import type { Logger } from "../../logging/logger";
 import { AuthError } from "../errors";
+import { logBackendErrorResponse } from "../backend-error-log";
 import { BaseOAuthTokenManager, extractTokenErrorDetail } from "../oauth-pkce";
 import { PkceAuthProvider } from "../pkce-auth-provider";
 import { DROPBOX_AUTH } from "../auth-config";
@@ -82,6 +83,7 @@ export class DropboxAuth extends BaseOAuthTokenManager {
 			}).toString(),
 		});
 		if (res.status < 200 || res.status >= 300) {
+			logBackendErrorResponse(this.logger, "Dropbox token", "exchangeCode", res);
 			throw new Error(`Token exchange failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertDropboxTokenResponse(res.json);
@@ -108,10 +110,12 @@ export class DropboxAuth extends BaseOAuthTokenManager {
 			throw err;
 		}
 		if (res.status === 400 || res.status === 401) {
+			logBackendErrorResponse(this.logger, "Dropbox token", "performRefresh", res);
 			this.authFailedAt = Date.now();
 			throw new AuthError(`Token refresh failed: ${res.status} ${extractTokenErrorDetail(res)}`, res.status);
 		}
 		if (res.status < 200 || res.status >= 300) {
+			logBackendErrorResponse(this.logger, "Dropbox token", "performRefresh", res);
 			throw new Error(`Token refresh failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertDropboxTokenResponse(res.json);

--- a/src/fs/dropbox/client.ts
+++ b/src/fs/dropbox/client.ts
@@ -136,7 +136,7 @@ export class DropboxClient {
 			await this.sleep(delay);
 			return this.request(op, opts, { ...state, rateLimitRetries: state.rateLimitRetries + 1 });
 		}
-		assertOk(res, op);
+		assertOk(res, op, this.logger);
 		return res;
 	}
 

--- a/src/fs/dropbox/ifilesystem-contract.test.ts
+++ b/src/fs/dropbox/ifilesystem-contract.test.ts
@@ -152,4 +152,5 @@ function makeFakeDropboxClient(): DropboxClient {
 // cache work; the checkpoint machinery has its own contract.
 runIFileSystemContract("DropboxFs", () => new DropboxFs(makeFakeDropboxClient(), ROOT_ID), {
 	computesHashOnStat: false,
+	stableIdentity: true,
 });

--- a/src/fs/dropbox/incremental-sync.ts
+++ b/src/fs/dropbox/incremental-sync.ts
@@ -169,7 +169,7 @@ function applyUpsertEntry(ctx: DropboxSyncContext, acc: DeltaAccumulator, entry:
 	if (oldPath === undefined) {
 		for (const d of cache.collectDescendants(path!)) acc.changedPaths.add(d);
 	}
-	cache.setEntry(path!, entry);
+	cache.setEntry(path!, entry, "actual_resolved");
 	acc.changedPaths.add(path!);
 }
 
@@ -216,7 +216,7 @@ function applyRename(
 	const displaced = cache.hasFile(newPath) ? cache.collectDescendants(newPath) : [];
 
 	cache.removeEntry(oldPath);
-	cache.setEntry(newPath, entry);
+	cache.setEntry(newPath, entry, "actual_resolved");
 	if (wasFolder) cache.rewriteChildPaths(oldPath, newPath);
 
 	acc.renamedPaths.push({ oldPath, newPath, isFolder: wasFolder || undefined });

--- a/src/fs/dropbox/index.test.ts
+++ b/src/fs/dropbox/index.test.ts
@@ -232,6 +232,112 @@ describe("DropboxFs stale-cache guards (CAS mechanism)", () => {
 });
 
 describe("DropboxFs.rename", () => {
+	type CacheView = {
+		setEntry(path: string, entry: DropboxEntry): void;
+		getFile(path: string): DropboxEntry | undefined;
+	};
+
+	async function caseRenameFs() {
+		const fs = await makeFs();
+		(fs as unknown as DropboxFsInternal).initialized = true;
+		const cache = (fs as unknown as { cache: CacheView }).cache;
+		cache.setEntry("Case.md", dbxFile("case", "/root/Case.md"));
+		return { fs, cache };
+	}
+
+	function notFound() {
+		return mockRes({ error_summary: "path/not_found/", error: { ".tag": "path" } }, { status: 409 });
+	}
+
+	it("performs a case-only rename through a deterministic intermediate path", async () => {
+		const { fs } = await caseRenameFs();
+		const moves: Array<{ from_path: string; to_path: string }> = [];
+		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
+			const request = opts as RequestUrlParam;
+			if (request.url.includes("get_metadata")) return Promise.resolve(notFound());
+			if (request.url.includes("move_v2")) {
+				const body = JSON.parse(request.body as string) as { from_path: string; to_path: string };
+				moves.push(body);
+				const path = moves.length === 1 ? "/root/.airsync-case-rename" : "/root/case.md";
+				return Promise.resolve(mockRes({ metadata: untagged(dbxFile("case", path)) }));
+			}
+			return Promise.resolve(mockRes({}));
+		});
+
+		await fs.rename("Case.md", "case.md");
+
+		expect(moves).toHaveLength(2);
+		expect(moves[0]!.from_path).toBe("id:root/Case.md");
+		expect(moves[0]!.to_path).toMatch(/^id:root\/\.airsync-case-rename-[0-9a-f]{8}$/);
+		expect(moves[1]).toMatchObject({ from_path: moves[0]!.to_path, to_path: "id:root/case.md" });
+		expect((await fs.stat("case.md"))?.identityKey).toBe("id:case");
+	});
+
+	it("resumes the second leg when the deterministic intermediate already holds the source id", async () => {
+		const { fs } = await caseRenameFs();
+		const moves: Array<{ from_path: string; to_path: string }> = [];
+		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
+			const request = opts as RequestUrlParam;
+			if (request.url.includes("get_metadata")) {
+				return Promise.resolve(mockRes(dbxFile("case", "/root/.airsync-case-rename-existing")));
+			}
+			if (request.url.includes("move_v2")) {
+				moves.push(JSON.parse(request.body as string) as { from_path: string; to_path: string });
+				return Promise.resolve(mockRes({ metadata: untagged(dbxFile("case", "/root/case.md")) }));
+			}
+			return Promise.resolve(mockRes({}));
+		});
+
+		await fs.rename("Case.md", "case.md");
+
+		expect(moves).toHaveLength(1);
+		expect(moves[0]!.from_path).toMatch(/^id:root\/\.airsync-case-rename-[0-9a-f]{8}$/);
+		expect(moves[0]!.to_path).toBe("id:root/case.md");
+	});
+
+	it("fails before moving when the deterministic intermediate is occupied by another id", async () => {
+		const { fs } = await caseRenameFs();
+		const move = vi.fn();
+		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
+			const request = opts as RequestUrlParam;
+			if (request.url.includes("get_metadata")) {
+				return Promise.resolve(mockRes(dbxFile("foreign", "/root/.airsync-case-rename-occupied")));
+			}
+			if (request.url.includes("move_v2")) move();
+			return Promise.resolve(mockRes({}));
+		});
+
+		await expect(fs.rename("Case.md", "case.md")).rejects.toThrow("temporary path is occupied");
+		expect(move).not.toHaveBeenCalled();
+	});
+
+	it("rolls the first leg back when the final move fails", async () => {
+		const { fs, cache } = await caseRenameFs();
+		const moves: Array<{ from_path: string; to_path: string }> = [];
+		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
+			const request = opts as RequestUrlParam;
+			if (request.url.includes("get_metadata")) return Promise.resolve(notFound());
+			if (request.url.includes("move_v2")) {
+				moves.push(JSON.parse(request.body as string) as { from_path: string; to_path: string });
+				if (moves.length === 2) {
+					return Promise.resolve(mockRes(
+						{ error_summary: "to/conflict/file/", error: { ".tag": "to" } },
+						{ status: 409 },
+					));
+				}
+				return Promise.resolve(mockRes({ metadata: untagged(dbxFile("case", "/root/Case.md")) }));
+			}
+			return Promise.resolve(mockRes({}));
+		});
+
+		await expect(fs.rename("Case.md", "case.md")).rejects.toThrow("Dropbox API move failed");
+
+		expect(moves).toHaveLength(3);
+		expect(moves[2]).toMatchObject({ from_path: moves[0]!.to_path, to_path: "id:root/Case.md" });
+		expect(cache.getFile("Case.md")?.id).toBe("id:case");
+		expect(cache.getFile("case.md")).toBeUndefined();
+	});
+
 	it("keeps a moved folder classified as a folder even when move_v2 returns it untagged", async () => {
 		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
 			const url = typeof opts === "string" ? opts : opts.url;

--- a/src/fs/dropbox/index.test.ts
+++ b/src/fs/dropbox/index.test.ts
@@ -102,6 +102,8 @@ describe("DropboxFs.write", () => {
 
 		const entity = await fs.write("sub/x.md", bytes("hi"), 1_700_000_000_000);
 		expect(entity.path).toBe("sub/x.md");
+		expect(entity.pathAuthority).toBe("requested_echo");
+		expect(entity.identityKey).toBe("id:x");
 		expect(entity.remoteChecksum).toEqual({ algo: "dropbox", value: "hashx" });
 		expect(entity.hash).not.toBe(""); // sha256 of content is computed on write
 
@@ -244,7 +246,12 @@ describe("DropboxFs.rename", () => {
 		const fs = await makeFs();
 		(fs as unknown as DropboxFsInternal).initialized = true;
 		// Seed a folder "docs" in the cache (as a full scan would).
-		await fs.mkdir("docs");
+		const folder = await fs.mkdir("docs");
+		expect(folder).toMatchObject({
+			path: "docs",
+			pathAuthority: "requested_echo",
+			identityKey: "id:d",
+		});
 
 		await fs.rename("docs", "papers");
 		expect((await fs.stat("papers"))?.isDirectory).toBe(true);

--- a/src/fs/dropbox/index.test.ts
+++ b/src/fs/dropbox/index.test.ts
@@ -3,7 +3,8 @@ import type { RequestUrlParam } from "obsidian";
 import { spyRequestUrl, mockRes, dbxFile, dbxFolder, untagged } from "./test-helpers";
 import type { DropboxFsInternal } from "./test-helpers";
 import type { DropboxEntry } from "./types";
-import type { MetadataStore } from "../../store/metadata-store";
+import "fake-indexeddb/auto";
+import { METADATA_CACHE_VERSION, MetadataStore } from "../../store/metadata-store";
 
 vi.mock("obsidian");
 
@@ -273,6 +274,37 @@ describe("DropboxFs.rename", () => {
 		expect((await fs.stat("case.md"))?.identityKey).toBe("id:case");
 	});
 
+	it("persists case-only rename intent before the first remote move", async () => {
+		const events: string[] = [];
+		const store = {
+			getMeta: () => Promise.resolve(undefined),
+			setMeta: () => { events.push("persist"); return Promise.resolve(); },
+			deleteMeta: () => Promise.resolve(),
+		} as unknown as MetadataStore<DropboxEntry>;
+		const { DropboxFs } = await import("./index");
+		const { DropboxClient } = await import("./client");
+		const fs = new DropboxFs(
+			new DropboxClient(() => Promise.resolve("AT")), "id:root", undefined, store,
+		);
+		(fs as unknown as DropboxFsInternal).initialized = true;
+		(fs as unknown as { cache: CacheView }).cache.setEntry(
+			"Case.md", dbxFile("case", "/root/Case.md"),
+		);
+		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
+			const request = opts as RequestUrlParam;
+			if (request.url.includes("get_metadata")) return Promise.resolve(notFound());
+			if (request.url.includes("move_v2")) {
+				events.push("move");
+				return Promise.resolve(mockRes({ metadata: untagged(dbxFile("case", "/root/case.md")) }));
+			}
+			return Promise.resolve(mockRes({}));
+		});
+
+		await fs.rename("Case.md", "case.md");
+
+		expect(events).toEqual(["persist", "move", "move"]);
+	});
+
 	it("resumes the second leg when the deterministic intermediate already holds the source id", async () => {
 		const { fs } = await caseRenameFs();
 		const moves: Array<{ from_path: string; to_path: string }> = [];
@@ -338,6 +370,59 @@ describe("DropboxFs.rename", () => {
 		expect(cache.getFile("case.md")).toBeUndefined();
 	});
 
+	it("recovers a persisted case-only rename from its temporary path after restart", async () => {
+		const store = new MetadataStore<DropboxEntry>(crypto.randomUUID(), {
+			dbNamePrefix: "air-sync-dropbox-case-rename", version: METADATA_CACHE_VERSION,
+		});
+		await store.setMeta("dropboxCaseRenamePending", JSON.stringify({
+			oldPath: "Case.md",
+			newPath: "case.md",
+			tempPath: ".airsync-case-rename-35544a52",
+			expectedId: "id:case",
+		}));
+		let moved = false;
+		const moves: Array<{ from_path: string; to_path: string }> = [];
+		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
+			const request = opts as RequestUrlParam;
+			if (request.url.includes("get_metadata")) {
+				const path = (JSON.parse(request.body as string) as { path: string }).path;
+				if (path === "id:root") return Promise.resolve(metaRes());
+				if (path.endsWith("/.airsync-case-rename-35544a52") && !moved) {
+					return Promise.resolve(mockRes(dbxFile("case", "/root/.airsync-case-rename-35544a52")));
+				}
+				if (path.endsWith("/case.md") && moved) {
+					return Promise.resolve(mockRes(dbxFile("case", "/root/case.md")));
+				}
+				return Promise.resolve(notFound());
+			}
+			if (request.url.includes("move_v2")) {
+				moves.push(JSON.parse(request.body as string) as { from_path: string; to_path: string });
+				moved = true;
+				return Promise.resolve(mockRes({ metadata: untagged(dbxFile("case", "/root/case.md")) }));
+			}
+			if (request.url.includes("get_latest_cursor")) return Promise.resolve(mockRes({ cursor: "C0" }));
+			if (request.url.endsWith(PLAIN_LIST)) {
+				const entries = moved ? [dbxFile("case", "/root/case.md")] : [];
+				return Promise.resolve(mockRes({ entries, cursor: "C1", has_more: false }));
+			}
+			return Promise.resolve(mockRes({}));
+		});
+		const { DropboxFs } = await import("./index");
+		const { DropboxClient } = await import("./client");
+		const fs = new DropboxFs(
+			new DropboxClient(() => Promise.resolve("AT")), "id:root", undefined, store,
+		);
+
+		expect((await fs.list()).map((item) => item.path)).toEqual(["case.md"]);
+		expect(moves).toHaveLength(1);
+		expect(moves[0]).toMatchObject({
+			from_path: "id:root/.airsync-case-rename-35544a52",
+			to_path: "id:root/case.md",
+		});
+		expect(await store.getMeta("dropboxCaseRenamePending")).toBeUndefined();
+		await store.close();
+	});
+
 	it("keeps a moved folder classified as a folder even when move_v2 returns it untagged", async () => {
 		(await spyRequestUrl()).mockImplementation((opts: string | RequestUrlParam) => {
 			const url = typeof opts === "string" ? opts : opts.url;
@@ -394,6 +479,7 @@ describe("DropboxFs id-based addressing", () => {
 		// (CURSOR_META_KEY), so its presence is what makes loadFromCache replay.
 		const fakeStore = {
 			open: () => Promise.resolve(),
+			getMeta: () => Promise.resolve(undefined),
 			loadAll: () => Promise.resolve({
 				files: [{ path: "a.md", file: dbxFile("1", "/root/a.md") }],
 				meta: new Map<string, string>([["changesStartPageToken", "C1"]]),

--- a/src/fs/dropbox/index.ts
+++ b/src/fs/dropbox/index.ts
@@ -234,7 +234,7 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 				// from the known prior type so the cache keeps classifying a moved folder
 				// as a folder (else a later write into it fails with "is a file").
 				this.cache.setEntry(newPath, { ...result, ".tag": r.wasFolder ? "folder" : "file" });
-				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
+				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath);
 			},
 		});
 	}

--- a/src/fs/dropbox/index.ts
+++ b/src/fs/dropbox/index.ts
@@ -127,6 +127,8 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 		const hash = await sha256(content);
 		return {
 			path,
+			pathAuthority: "requested_echo",
+			identityKey: entry.id,
 			isDirectory: false,
 			size: content.byteLength,
 			mtime: parseDropboxTime(entry.server_modified ?? entry.client_modified),
@@ -142,7 +144,16 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 			await this.ensureInitialized();
 			await this.ensureFolder(path);
 			const entry = this.cache.getFile(path);
-			return { path, isDirectory: true, size: 0, mtime: 0, hash: "", backendMeta: { dropboxId: entry?.id } };
+			return {
+				path,
+				pathAuthority: "requested_echo",
+				identityKey: entry?.id,
+				isDirectory: true,
+				size: 0,
+				mtime: 0,
+				hash: "",
+				backendMeta: { dropboxId: entry?.id },
+			};
 		});
 	}
 
@@ -180,7 +191,7 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 				// from the known prior type so the cache keeps classifying a moved folder
 				// as a folder (else a later write into it fails with "is a file").
 				this.cache.setEntry(newPath, { ...result, ".tag": r.wasFolder ? "folder" : "file" });
-				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath);
+				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
 			},
 		});
 	}

--- a/src/fs/dropbox/index.ts
+++ b/src/fs/dropbox/index.ts
@@ -1,6 +1,6 @@
 import type { FileEntity } from "../types";
 import type { DropboxEntry } from "./types";
-import { parseDropboxTime } from "./types";
+import { DropboxApiError, parseDropboxTime } from "./types";
 import type { DropboxClient } from "./client";
 import type { MetadataStore } from "../../store/metadata-store";
 import type { Logger } from "../../logging/logger";
@@ -11,6 +11,22 @@ import { sha256 } from "../../utils/hash";
 import { normalizeSyncPath, validateRename } from "../../utils/path";
 import { CachingRemoteFs } from "../caching/remote-fs";
 import type { IncrementalChangesResult } from "../caching/remote-fs";
+
+function isCaseOnlyRename(oldPath: string, newPath: string): boolean {
+	return oldPath !== newPath && oldPath.toLowerCase() === newPath.toLowerCase();
+}
+
+/** Deterministic so a retry can resume a move interrupted after its first leg. */
+function caseRenameTempPath(path: string, identity: string): string {
+	let hash = 0x811c9dc5;
+	for (const char of identity) {
+		hash ^= char.charCodeAt(0);
+		hash = Math.imul(hash, 0x01000193);
+	}
+	const parent = DropboxMetadataCache.parentPath(path);
+	const name = `.airsync-case-rename-${(hash >>> 0).toString(16).padStart(8, "0")}`;
+	return parent ? `${parent}/${name}` : name;
+}
 
 /**
  * IFileSystem implementation backed by Dropbox (App Folder scope).
@@ -168,9 +184,18 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 				if (!entry) throw new Error(`File not found: ${oldPath}`);
 				if (this.cache.hasFile(newPath)) throw new Error(`Destination already exists: ${newPath}`);
 				await this.ensureFolder(DropboxMetadataCache.parentPath(newPath));
-				return { expectedId: this.cache.idAt(oldPath), wasFolder: this.cache.isFolder(oldPath) };
+				const expectedId = this.cache.idAt(oldPath);
+				return {
+					expectedId,
+					wasFolder: this.cache.isFolder(oldPath),
+					caseOnlyTempPath: expectedId && isCaseOnlyRename(oldPath, newPath)
+						? caseRenameTempPath(oldPath, expectedId)
+						: undefined,
+				};
 			},
-			execute: () => this.client.move(this.addr(oldPath), this.addr(newPath)),
+			execute: (r) => r.caseOnlyTempPath
+				? this.moveCaseOnly(oldPath, newPath, r.caseOnlyTempPath, r.expectedId!)
+				: this.client.move(this.addr(oldPath), this.addr(newPath)),
 			staleGuard: (r) => ({ path: oldPath, expectedId: r.expectedId }),
 			update: (r, result) => {
 				// The shared staleGuard only validates the SOURCE (oldPath still resolves to
@@ -194,6 +219,52 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
 			},
 		});
+	}
+
+	/**
+	 * Dropbox move_v2 explicitly does not support case-only renames. Use a
+	 * deterministic intermediate path so a retry can resume after a crash between
+	 * the two moves. A foreign occupant at that path fails before touching source.
+	 */
+	private async moveCaseOnly(
+		oldPath: string,
+		newPath: string,
+		tempPath: string,
+		expectedId: string,
+	): Promise<DropboxEntry> {
+		const oldAddress = this.addr(oldPath);
+		const newAddress = this.addr(newPath);
+		const tempAddress = this.addr(tempPath);
+		const existingTemp = await this.getOptionalMetadata(tempAddress);
+		if (existingTemp && existingTemp.id !== expectedId) {
+			throw new Error(`Dropbox case-only rename temporary path is occupied: ${tempPath}`);
+		}
+		if (!existingTemp) {
+			await this.client.move(oldAddress, tempAddress);
+		}
+		try {
+			return await this.client.move(tempAddress, newAddress);
+		} catch (err) {
+			try {
+				await this.client.move(tempAddress, oldAddress);
+			} catch (rollbackErr) {
+				throw new Error(
+					`Dropbox case-only rename failed and rollback failed; retry will resume from ${tempPath}: ` +
+					`${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+					{ cause: err },
+				);
+			}
+			throw err;
+		}
+	}
+
+	private async getOptionalMetadata(path: string): Promise<DropboxEntry | null> {
+		try {
+			return await this.client.getMetadata(path);
+		} catch (err) {
+			if (err instanceof DropboxApiError && err.summary.includes("not_found")) return null;
+			throw err;
+		}
 	}
 
 	/** Ensure a folder exists by path, creating parents as needed (idempotent). */

--- a/src/fs/dropbox/index.ts
+++ b/src/fs/dropbox/index.ts
@@ -16,6 +16,15 @@ function isCaseOnlyRename(oldPath: string, newPath: string): boolean {
 	return oldPath !== newPath && oldPath.toLowerCase() === newPath.toLowerCase();
 }
 
+const CASE_RENAME_PENDING_META_KEY = "dropboxCaseRenamePending";
+
+interface PendingCaseRename {
+	oldPath: string;
+	newPath: string;
+	tempPath: string;
+	expectedId: string;
+}
+
 /** Deterministic so a retry can resume a move interrupted after its first leg. */
 function caseRenameTempPath(path: string, identity: string): string {
 	let hash = 0x811c9dc5;
@@ -42,6 +51,7 @@ function caseRenameTempPath(path: string, identity: string): string {
 export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 	readonly name = "dropbox";
 	private client: DropboxClient;
+	private pendingCaseRenameSettled = false;
 	// The base stores the cache as AbstractMetadataCache; narrow it so the
 	// Dropbox-specific seams (relativize/setRootPath/setEntry) are visible. The
 	// runtime value IS a DropboxMetadataCache (passed to super below).
@@ -77,6 +87,14 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 			throw new Error(`Dropbox vault folder ${this.rootFolderId} has no path (deleted?)`);
 		}
 		this.cache.setRootPath(meta.path_display);
+	}
+
+	protected async ensureInitialized(): Promise<boolean> {
+		if (!this.pendingCaseRenameSettled) {
+			await this.recoverPendingCaseRename();
+			this.pendingCaseRenameSettled = true;
+		}
+		return super.ensureInitialized();
 	}
 
 	// ── Dropbox-specific seams ──
@@ -223,8 +241,9 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 
 	/**
 	 * Dropbox move_v2 explicitly does not support case-only renames. Use a
-	 * deterministic intermediate path so a retry can resume after a crash between
-	 * the two moves. A foreign occupant at that path fails before touching source.
+	 * deterministic intermediate path and persist the intent before the first move,
+	 * so a fresh process can resume after a crash between the two moves. A foreign
+	 * occupant at that path fails before touching source.
 	 */
 	private async moveCaseOnly(
 		oldPath: string,
@@ -232,30 +251,87 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 		tempPath: string,
 		expectedId: string,
 	): Promise<DropboxEntry> {
-		const oldAddress = this.addr(oldPath);
-		const newAddress = this.addr(newPath);
-		const tempAddress = this.addr(tempPath);
-		const existingTemp = await this.getOptionalMetadata(tempAddress);
-		if (existingTemp && existingTemp.id !== expectedId) {
-			throw new Error(`Dropbox case-only rename temporary path is occupied: ${tempPath}`);
+		const pending = { oldPath, newPath, tempPath, expectedId };
+		await this.savePendingCaseRename(pending);
+		return this.resumeCaseOnlyRename(pending, true);
+	}
+
+	private async recoverPendingCaseRename(): Promise<void> {
+		const raw = await this.metadataStore?.getMeta(CASE_RENAME_PENDING_META_KEY);
+		if (!raw) return;
+		await this.resumeCaseOnlyRename(parsePendingCaseRename(raw), false);
+	}
+
+	private async savePendingCaseRename(pending: PendingCaseRename): Promise<void> {
+		await this.metadataStore?.setMeta(CASE_RENAME_PENDING_META_KEY, JSON.stringify(pending));
+		this.pendingCaseRenameSettled = false;
+	}
+
+	private async clearPendingCaseRename(): Promise<void> {
+		await this.metadataStore?.deleteMeta(CASE_RENAME_PENDING_META_KEY);
+		this.pendingCaseRenameSettled = true;
+	}
+
+	private async resumeCaseOnlyRename(
+		pending: PendingCaseRename,
+		sourceKnown: boolean,
+	): Promise<DropboxEntry> {
+		const existingTemp = await this.getOptionalMetadata(this.addr(pending.tempPath));
+		if (existingTemp && existingTemp.id !== pending.expectedId) {
+			if (sourceKnown || (await this.getOptionalMetadata(this.addr(pending.oldPath)))?.id === pending.expectedId) {
+				await this.clearPendingCaseRename();
+			}
+			throw new Error(`Dropbox case-only rename temporary path is occupied: ${pending.tempPath}`);
 		}
-		if (!existingTemp) {
-			await this.client.move(oldAddress, tempAddress);
+		if (existingTemp) return this.finishCaseOnlyRename(pending);
+
+		const destination = await this.getOptionalMetadata(this.addr(pending.newPath));
+		if (destination?.id === pending.expectedId) {
+			await this.clearPendingCaseRename();
+			return destination;
 		}
+		if (destination) {
+			if (sourceKnown || (await this.getOptionalMetadata(this.addr(pending.oldPath)))?.id === pending.expectedId) {
+				await this.clearPendingCaseRename();
+			}
+			throw new Error(`Dropbox case-only rename destination is occupied: ${pending.newPath}`);
+		}
+		if (!sourceKnown) {
+			const source = await this.getOptionalMetadata(this.addr(pending.oldPath));
+			if (source?.id !== pending.expectedId) {
+				throw new Error(`Dropbox case-only rename source is missing: ${pending.oldPath}`);
+			}
+		}
+		await this.client.move(this.addr(pending.oldPath), this.addr(pending.tempPath));
+		return this.finishCaseOnlyRename(pending);
+	}
+
+	private async finishCaseOnlyRename(pending: PendingCaseRename): Promise<DropboxEntry> {
+		let result: DropboxEntry;
 		try {
-			return await this.client.move(tempAddress, newAddress);
+			result = await this.client.move(this.addr(pending.tempPath), this.addr(pending.newPath));
 		} catch (err) {
+			const source = await this.getOptionalMetadata(this.addr(pending.oldPath));
+			if (source) {
+				throw new Error(
+					`Dropbox case-only rename failed and source path is occupied; retry will resume from ${pending.tempPath}`,
+					{ cause: err },
+				);
+			}
 			try {
-				await this.client.move(tempAddress, oldAddress);
+				await this.client.move(this.addr(pending.tempPath), this.addr(pending.oldPath));
+				await this.clearPendingCaseRename();
 			} catch (rollbackErr) {
 				throw new Error(
-					`Dropbox case-only rename failed and rollback failed; retry will resume from ${tempPath}: ` +
+					`Dropbox case-only rename failed and rollback failed; retry will resume from ${pending.tempPath}: ` +
 					`${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
 					{ cause: err },
 				);
 			}
 			throw err;
 		}
+		await this.clearPendingCaseRename();
+		return result;
 	}
 
 	private async getOptionalMetadata(path: string): Promise<DropboxEntry | null> {
@@ -282,4 +358,24 @@ export class DropboxFs extends CachingRemoteFs<DropboxEntry> {
 			this.cache.setEntry(currentPath, folder);
 		}
 	}
+}
+
+function parsePendingCaseRename(raw: string): PendingCaseRename {
+	let value: unknown;
+	try {
+		value = JSON.parse(raw);
+	} catch {
+		throw new Error("Invalid persisted Dropbox case-only rename operation");
+	}
+	if (!value || typeof value !== "object") {
+		throw new Error("Invalid persisted Dropbox case-only rename operation");
+	}
+	const pending = value as Partial<PendingCaseRename>;
+	if (typeof pending.oldPath !== "string" || typeof pending.newPath !== "string" ||
+		typeof pending.tempPath !== "string" || typeof pending.expectedId !== "string" ||
+		!isCaseOnlyRename(pending.oldPath, pending.newPath) ||
+		pending.tempPath !== caseRenameTempPath(pending.oldPath, pending.expectedId)) {
+		throw new Error("Invalid persisted Dropbox case-only rename operation");
+	}
+	return pending as PendingCaseRename;
 }

--- a/src/fs/dropbox/metadata-cache.test.ts
+++ b/src/fs/dropbox/metadata-cache.test.ts
@@ -71,16 +71,20 @@ describe("DropboxMetadataCache.removeTree / rewriteChildPaths", () => {
 		expect(cache.getPathById("id:3")).toBe("renamed/b.md");
 	});
 
-	it("degrades descendant authority when a requested folder rename supplies the new prefix", () => {
+	it("restores resolved descendants after a requested folder prefix is confirmed", () => {
 		const cache = makeCache();
 		cache.buildFromFiles([dbxFolder("2", "/root/dir"), dbxFile("3", "/root/dir/b.md")]);
 
 		cache.removeEntry("dir");
 		cache.setEntry("Renamed", dbxFolder("2", "/root/Renamed"));
-		cache.rewriteChildPaths("dir", "Renamed", "requested_echo");
+		cache.rewriteChildPaths("dir", "Renamed");
 
 		const child = cache.getFile("Renamed/b.md")!;
 		expect(cache.toEntity("Renamed/b.md", child).pathAuthority).toBe("requested_echo");
+
+		cache.setEntry("Renamed", dbxFolder("2", "/root/Renamed"), "actual_resolved");
+
+		expect(cache.toEntity("Renamed/b.md", child).pathAuthority).toBe("actual_resolved");
 	});
 });
 

--- a/src/fs/dropbox/metadata-cache.test.ts
+++ b/src/fs/dropbox/metadata-cache.test.ts
@@ -70,6 +70,18 @@ describe("DropboxMetadataCache.removeTree / rewriteChildPaths", () => {
 		expect(cache.hasFile("dir/b.md")).toBe(false);
 		expect(cache.getPathById("id:3")).toBe("renamed/b.md");
 	});
+
+	it("degrades descendant authority when a requested folder rename supplies the new prefix", () => {
+		const cache = makeCache();
+		cache.buildFromFiles([dbxFolder("2", "/root/dir"), dbxFile("3", "/root/dir/b.md")]);
+
+		cache.removeEntry("dir");
+		cache.setEntry("Renamed", dbxFolder("2", "/root/Renamed"));
+		cache.rewriteChildPaths("dir", "Renamed", "requested_echo");
+
+		const child = cache.getFile("Renamed/b.md")!;
+		expect(cache.toEntity("Renamed/b.md", child).pathAuthority).toBe("requested_echo");
+	});
 });
 
 describe("DropboxMetadataCache.setEntry id eviction", () => {

--- a/src/fs/dropbox/metadata-cache.ts
+++ b/src/fs/dropbox/metadata-cache.ts
@@ -1,4 +1,4 @@
-import type { FileEntity } from "../types";
+import type { FileEntity, PathAuthority } from "../types";
 import type { DropboxEntry } from "./types";
 import { dropboxEntryToEntity } from "./types";
 import type { Logger } from "../../logging/logger";
@@ -67,7 +67,7 @@ export class DropboxMetadataCache extends AbstractMetadataCache<DropboxEntry> {
 	}
 
 	toEntity(path: string, entry: DropboxEntry): FileEntity {
-		return dropboxEntryToEntity(path, entry);
+		return { ...dropboxEntryToEntity(path, entry), pathAuthority: this.getPathAuthority(path) };
 	}
 
 	// ── Dropbox-specific path resolution ──
@@ -109,13 +109,13 @@ export class DropboxMetadataCache extends AbstractMetadataCache<DropboxEntry> {
 	 * folder, and its stale id mapping either way, so phantom descendants don't linger
 	 * and the displaced id stops reverse-resolving to this live path.
 	 */
-	setEntry(path: string, entry: DropboxEntry): void {
+	setEntry(path: string, entry: DropboxEntry, pathAuthority: PathAuthority = "requested_echo"): void {
 		const prev = this.getFile(path);
 		if (prev && this.extractId(prev) !== this.extractId(entry)) {
 			if (this.isFolder(path)) this.removeTree(path);
 			else this.removeEntry(path);
 		}
-		this.setFile(path, entry);
+		this.setFile(path, entry, pathAuthority);
 	}
 
 	/**
@@ -131,7 +131,7 @@ export class DropboxMetadataCache extends AbstractMetadataCache<DropboxEntry> {
 			if (entry[".tag"] === "deleted") continue;
 			const path = this.relativize(entry);
 			if (path === null || path === "") continue;
-			this.setEntry(path, entry);
+			this.setEntry(path, entry, "actual_resolved");
 		}
 	}
 }

--- a/src/fs/dropbox/types.test.ts
+++ b/src/fs/dropbox/types.test.ts
@@ -132,6 +132,8 @@ describe("dropboxEntryToEntity", () => {
 		const entity = dropboxEntryToEntity("notes/a.md", dbxFile("1", "/root/notes/a.md", { content_hash: "abc", size: 7, server_modified: "2024-02-02T00:00:00Z" }));
 		expect(entity).toMatchObject({
 			path: "notes/a.md",
+			pathAuthority: "requested_echo",
+			identityKey: "id:1",
 			isDirectory: false,
 			size: 7,
 			hash: "",
@@ -143,7 +145,29 @@ describe("dropboxEntryToEntity", () => {
 
 	it("maps a folder to a directory entity with no checksum", () => {
 		const entity = dropboxEntryToEntity("notes", dbxFolder("9", "/root/notes"));
-		expect(entity).toMatchObject({ path: "notes", isDirectory: true, size: 0, mtime: 0, hash: "" });
+		expect(entity).toMatchObject({
+			path: "notes",
+			pathAuthority: "requested_echo",
+			identityKey: "id:9",
+			isDirectory: true,
+			size: 0,
+			mtime: 0,
+			hash: "",
+		});
 		expect(entity.remoteChecksum).toBeUndefined();
+	});
+
+	it("keeps identity absent when Dropbox omits the stable id", () => {
+		const file = dropboxEntryToEntity(
+			"notes/a.md",
+			{ ...dbxFile("1", "/root/notes/a.md"), id: undefined },
+		);
+		const folder = dropboxEntryToEntity(
+			"notes",
+			{ ...dbxFolder("9", "/root/notes"), id: undefined },
+		);
+
+		expect(file.identityKey).toBeUndefined();
+		expect(folder.identityKey).toBeUndefined();
 	});
 });

--- a/src/fs/dropbox/types.test.ts
+++ b/src/fs/dropbox/types.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { Logger } from "../../logging/logger";
 import {
 	assertOk,
 	assertDropboxTokenResponse,
@@ -25,6 +26,45 @@ describe("assertOk", () => {
 		expect(() =>
 			assertOk({ status: 409, json: { error_summary: "invalid_access_token/..", error: { ".tag": "invalid_access_token" } } }, "op"),
 		).toThrow(AuthError);
+	});
+
+	// Dropbox puts a display string in `user_message` and may add fields this
+	// codebase does not model; distilling to `error_summary` used to drop both.
+	it("carries the whole Dropbox error body, unmodelled fields included", () => {
+		let thrown: unknown;
+		try {
+			assertOk(
+				{
+					status: 409,
+					json: {
+						error_summary: "path/conflict/file/.",
+						error: { ".tag": "path" },
+						user_message: { text: "A file already exists there.", locale: "en" },
+					},
+				},
+				"createFolder",
+			);
+		} catch (err) {
+			thrown = err;
+		}
+		const message = (thrown as Error).message;
+		expect(message).toContain("409");
+		expect(message).toContain("path/conflict/file/.");
+		expect(message).toContain("A file already exists there.");
+		// `summary` stays exposed for callers that branch on it (reset, path/conflict).
+		expect((thrown as DropboxApiError).summary).toBe("path/conflict/file/.");
+	});
+
+	it("logs the whole error response before throwing", () => {
+		const error = vi.fn();
+		const logger = { error } as unknown as Logger;
+		expect(() =>
+			assertOk({ status: 429, json: { error_summary: "too_many_requests/." } }, "listFolder", logger),
+		).toThrow(DropboxApiError);
+		expect(error).toHaveBeenCalledTimes(1);
+		const [, context] = error.mock.calls[0] as [string, Record<string, unknown>];
+		expect(context).toMatchObject({ operation: "listFolder", status: 429 });
+		expect(context.body).toContain("too_many_requests");
 	});
 
 	it("throws a DropboxApiError carrying status + summary for a 409", () => {

--- a/src/fs/dropbox/types.ts
+++ b/src/fs/dropbox/types.ts
@@ -1,5 +1,7 @@
 import type { FileEntity } from "../types";
+import type { Logger } from "../../logging/logger";
 import { AuthError } from "../errors";
+import { describeErrorBody, logBackendErrorResponse, MAX_MESSAGE_BODY_CHARS } from "../backend-error-log";
 
 /**
  * A Dropbox file/folder metadata entry (the subset Air Sync uses).
@@ -116,20 +118,27 @@ const AUTH_ERROR_TAGS = new Set([
  * @throws {DropboxApiError} for any other non-2xx (409 endpoint errors, 429
  *   rate limits, 5xx), preserving the status and `error_summary`.
  */
-export function assertOk(res: { status: number; json?: unknown; text?: string }, op: string): void {
+export function assertOk(
+	res: { status: number; json?: unknown; text?: string; headers?: Record<string, string> },
+	op: string,
+	logger?: Logger,
+): void {
 	if (res.status >= 200 && res.status < 300) return;
+	// Log the whole response first — `error_summary` is a distillation, and a
+	// `user_message` or an unrecognised `.tag` shape would otherwise be lost.
+	logBackendErrorResponse(logger, "Dropbox", op, res);
 	let body: DropboxErrorBody | undefined;
 	try {
 		body = res.json as DropboxErrorBody | undefined;
 	} catch {
 		body = undefined;
 	}
+	// `summary`/`tag` are still read — but ONLY for branching (auth class, and the
+	// `summary` carried on DropboxApiError for `path/conflict` / `reset` callers).
+	// The message itself carries the body verbatim rather than a distillation.
 	const summary = body?.error_summary ?? (typeof res.text === "string" ? res.text : "");
 	const tag = body?.error?.[".tag"] ?? summary.split("/")[0] ?? "";
-	const detail = summary || tag;
-	const message = detail
-		? `Dropbox API ${op} failed: ${res.status} ${detail}`
-		: `Dropbox API ${op} failed: ${res.status}`;
+	const message = `Dropbox API ${op} failed: ${res.status} ${describeErrorBody(res, MAX_MESSAGE_BODY_CHARS)}`;
 	if (res.status === 401 || AUTH_ERROR_TAGS.has(tag)) {
 		throw new AuthError(message, 401);
 	}

--- a/src/fs/dropbox/types.ts
+++ b/src/fs/dropbox/types.ts
@@ -172,10 +172,20 @@ export function parseDropboxTime(value: string | undefined): number {
  */
 export function dropboxEntryToEntity(path: string, entry: DropboxEntry): FileEntity {
 	if (isFolderEntry(entry)) {
-		return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+		return {
+			path,
+			pathAuthority: "requested_echo",
+			identityKey: entry.id,
+			isDirectory: true,
+			size: 0,
+			mtime: 0,
+			hash: "",
+		};
 	}
 	return {
 		path,
+		pathAuthority: "requested_echo",
+		identityKey: entry.id,
 		isDirectory: false,
 		size: entry.size ?? 0,
 		mtime: parseDropboxTime(entry.server_modified ?? entry.client_modified),

--- a/src/fs/googledrive/auth.test.ts
+++ b/src/fs/googledrive/auth.test.ts
@@ -497,11 +497,17 @@ describe("GoogleAuthDirect.handleAuthCallback", () => {
 		).rejects.toThrow("PKCE code verifier is missing");
 	});
 
-	it("includes Google error detail when token exchange fails", async () => {
+	it("carries the whole Google error body when token exchange fails", async () => {
 		const err = new Error("Request failed, status 400");
 		Object.assign(err, {
 			status: 400,
-			json: { error: "redirect_uri_mismatch", error_description: "Bad Request" },
+			// `error_uri` stands in for the fields a picked `error: error_description`
+			// pair used to drop: the body must reach the message intact.
+			json: {
+				error: "redirect_uri_mismatch",
+				error_description: "Bad Request",
+				error_uri: "https://developers.google.com/identity/protocols/oauth2",
+			},
 		});
 		const mockRequestUrl = (await spyRequestUrl()).mockRejectedValue(err);
 
@@ -510,9 +516,11 @@ describe("GoogleAuthDirect.handleAuthCallback", () => {
 		auth.setAuthState("state");
 		auth.setCodeVerifier("verifier");
 
-		await expect(
-			auth.handleAuthCallback({ code: "code", state: "state" })
-		).rejects.toThrow("Token exchange failed: redirect_uri_mismatch: Bad Request");
+		const thrown = auth.handleAuthCallback({ code: "code", state: "state" });
+		await expect(thrown).rejects.toThrow("Token exchange failed");
+		await expect(thrown).rejects.toThrow("redirect_uri_mismatch");
+		await expect(thrown).rejects.toThrow("Bad Request");
+		await expect(thrown).rejects.toThrow("developers.google.com");
 
 		mockRequestUrl.mockRestore();
 	});

--- a/src/fs/googledrive/auth.ts
+++ b/src/fs/googledrive/auth.ts
@@ -3,6 +3,7 @@ import type { Logger } from "../../logging/logger";
 import { assertTokenResponse } from "./types";
 import { BaseOAuthTokenManager, buildOAuthState, computeS256Challenge, generateRandomString } from "../oauth-pkce";
 import { GOOGLE_DRIVE_AUTH, DEFAULT_CUSTOM_REDIRECT_URI } from "../auth-config";
+import { describeErrorBody, MAX_MESSAGE_BODY_CHARS } from "../backend-error-log";
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -323,15 +324,20 @@ export class GoogleAuthDirect extends GoogleAuthBase {
 	}
 }
 
-/** Extract error detail from a Google OAuth error response */
+/**
+ * Render a Google OAuth error response for a thrown message. The body goes through
+ * verbatim rather than being reduced to `error: error_description` — Google also
+ * returns fields that rule out whole causes (`error_uri`, `error_subtype`, and the
+ * nested `error.errors[].reason` shape), and a picked pair discards them.
+ * Falls back to the Error's own message when there is no response body at all.
+ */
 function extractGoogleErrorDetail(err: unknown): string {
-	const json = (err as { json?: unknown }).json;
-	if (json && typeof json === "object") {
-		const obj = json as Record<string, unknown>;
-		if (typeof obj.error === "string") {
-			const desc = typeof obj.error_description === "string" ? obj.error_description : "";
-			return desc ? `${obj.error}: ${desc}` : obj.error;
-		}
+	const src = (err ?? {}) as { json?: unknown; text?: unknown };
+	if (src.json !== undefined || typeof src.text === "string") {
+		return describeErrorBody(
+			{ status: 0, json: src.json, text: typeof src.text === "string" ? src.text : undefined },
+			MAX_MESSAGE_BODY_CHARS,
+		);
 	}
 	return err instanceof Error ? err.message : String(err);
 }

--- a/src/fs/googledrive/client.test.ts
+++ b/src/fs/googledrive/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { spyRequestUrl, mockRes } from "./test-helpers.test";
+import type { Logger } from "../../logging/logger";
 
 vi.mock("obsidian");
 
@@ -39,6 +40,42 @@ describe("GoogleDriveClient error wrapping", () => {
 			expect(errObj.status).toBe(403);
 			expect(errObj.headers).toEqual({ "retry-after": "30" });
 		}
+
+		mockRequestUrl.mockRestore();
+	});
+
+	// Drive keeps the actionable reason in `error.errors[].reason`, which `err.message`
+	// alone never contains — the wrapped message must carry the response body verbatim.
+	it("carries the whole Drive error body in the message and logs it", async () => {
+		const error = vi.fn();
+		const logger = { error } as unknown as Logger;
+		const originalError = Object.assign(new Error("Request failed, status 403"), {
+			status: 403,
+			json: {
+				error: {
+					code: 403,
+					message: "Rate Limit Exceeded",
+					errors: [{ domain: "usageLimits", reason: "rateLimitExceeded", message: "Rate Limit Exceeded" }],
+				},
+			},
+		});
+		const mockRequestUrl = (await spyRequestUrl()).mockRejectedValue(originalError);
+
+		const { GoogleDriveClient } = await import("./client");
+		const client = new GoogleDriveClient(() => Promise.resolve("access"), logger);
+		try {
+			await client.listFiles("folder-id");
+			expect.fail("should have thrown");
+		} catch (err) {
+			const message = (err as Error).message;
+			expect(message).toContain("Google Drive API listFiles failed");
+			expect(message).toContain("rateLimitExceeded");
+			expect(message).toContain("usageLimits");
+		}
+		expect(error).toHaveBeenCalled();
+		const [, context] = error.mock.calls[0] as [string, Record<string, unknown>];
+		expect(context).toMatchObject({ operation: "listFiles", status: 403 });
+		expect(context.body).toContain("rateLimitExceeded");
 
 		mockRequestUrl.mockRestore();
 	});

--- a/src/fs/googledrive/client.ts
+++ b/src/fs/googledrive/client.ts
@@ -1,6 +1,7 @@
 import { requestUrl } from "../../platform/obsidian";
 import type { RequestUrlParam } from "../../platform/obsidian";
 import type { Logger } from "../../logging/logger";
+import { describeErrorBody, logBackendErrorResponse, MAX_MESSAGE_BODY_CHARS } from "../backend-error-log";
 import type { GoogleDriveFile, GoogleDriveFileList, GoogleDriveChangeList } from "./types";
 import {
 	FOLDER_MIME,
@@ -63,19 +64,31 @@ export class GoogleDriveClient {
 			}
 
 			const msg = err instanceof Error ? err.message : String(err);
-			const wrapped = new Error(`Google Drive API ${operation} failed: ${msg}`);
 			if (err && typeof err === "object") {
 				const src = err as Record<string, unknown>;
-				this.logger?.error("Google Drive API request failed", { operation, status: src.status, error: msg });
+				const res = {
+					status: typeof src.status === "number" ? src.status : 0,
+					json: src.json,
+					text: typeof src.text === "string" ? src.text : undefined,
+					headers: src.headers as Record<string, string> | undefined,
+				};
+				// Log the whole response, and carry it verbatim in the message. Drive puts
+				// the actionable reason in `error.errors[].reason` (rateLimitExceeded,
+				// storageQuotaExceeded, …), which `err.message` alone does not contain.
+				logBackendErrorResponse(this.logger, "Google Drive", operation, res);
+				const detail = src.json !== undefined || res.text !== undefined
+					? describeErrorBody(res, MAX_MESSAGE_BODY_CHARS)
+					: msg;
+				const wrapped = new Error(`Google Drive API ${operation} failed: ${detail}`);
 				for (const key of ["status", "headers", "json"] as const) {
 					if (key in src) {
 						(wrapped as unknown as Record<string, unknown>)[key] = src[key];
 					}
 				}
-			} else {
-				this.logger?.error("Google Drive API request failed", { operation, error: msg });
+				throw wrapped;
 			}
-			throw wrapped;
+			this.logger?.error("Google Drive API request failed", { operation, error: msg });
+			throw new Error(`Google Drive API ${operation} failed: ${msg}`);
 		}
 	}
 

--- a/src/fs/googledrive/ifilesystem-contract.test.ts
+++ b/src/fs/googledrive/ifilesystem-contract.test.ts
@@ -165,5 +165,5 @@ function makeFakeGoogleDriveClient(): GoogleDriveClient {
 runIFileSystemContract(
 	"GoogleDriveFs",
 	() => new GoogleDriveFs(makeFakeGoogleDriveClient(), "root"),
-	{ computesHashOnStat: false },
+	{ computesHashOnStat: false, stableIdentity: true },
 );

--- a/src/fs/googledrive/index.test.ts
+++ b/src/fs/googledrive/index.test.ts
@@ -735,6 +735,54 @@ describe("GoogleDriveFs cache persistence", () => {
 		await store.close();
 	});
 
+	it("rejects duplicate-id persisted cache and replaces its checkpoint from an authoritative full scan", async () => {
+		const { GoogleDriveFs } = await import("./index");
+		const { MetadataStore } = await import("../../store/metadata-store");
+		const store = new MetadataStore<GoogleDriveFile>("persist-duplicate-id", {
+			dbNamePrefix: "air-sync-googledrive",
+			version: 1,
+		});
+		await store.open();
+		await store.saveAll([
+			{
+				path: "a-new.txt",
+				file: { id: "f1", name: "a-new.txt", mimeType: "text/plain", parents: ["root"] },
+				isFolder: false,
+			},
+			{
+				path: "z-old.txt",
+				file: { id: "f1", name: "z-old.txt", mimeType: "text/plain", parents: ["root"] },
+				isFolder: false,
+			},
+		], new Map([["changesStartPageToken", "stale-token"]]));
+
+		const listAllFiles = vi.fn().mockResolvedValue([
+			{ id: "f1", name: "a-new.txt", mimeType: "text/plain", parents: ["root"] },
+		]);
+		const getChangesStartToken = vi.fn().mockResolvedValue("fresh-token");
+		const listChanges = vi.fn();
+		const fs = new GoogleDriveFs({
+			listAllFiles,
+			getChangesStartToken,
+			listChanges,
+		} as never, "root", undefined, store);
+
+		const files = await fs.list();
+
+		expect(files.map((file) => file.path)).toEqual(["a-new.txt"]);
+		expect(listAllFiles).toHaveBeenCalledOnce();
+		expect(getChangesStartToken).toHaveBeenCalledOnce();
+		expect(listChanges).not.toHaveBeenCalled();
+		expect(fs.changesPageToken).toBe("fresh-token");
+
+		await fs.commitCheckpoint();
+		const persisted = await store.loadAll();
+		expect(persisted.files.map((record) => record.path)).toEqual(["a-new.txt"]);
+		expect(persisted.meta.get("changesStartPageToken")).toBe("fresh-token");
+
+		await store.close();
+	});
+
 
 });
 

--- a/src/fs/googledrive/index.test.ts
+++ b/src/fs/googledrive/index.test.ts
@@ -151,6 +151,8 @@ describe("GoogleDriveFs.write remoteChecksum", () => {
 		const content = new TextEncoder().encode("hello").buffer.slice(0);
 		const result = await fs.write("test.md", content, Date.now());
 
+		expect(result.pathAuthority).toBe("requested_echo");
+		expect(result.identityKey).toBe("file1");
 		expect(result.remoteChecksum).toEqual({ algo: "md5", value: "abc123hash" });
 		expect(result.backendMeta?.googleDriveId).toBe("file1");
 
@@ -186,6 +188,31 @@ describe("GoogleDriveFs.write remoteChecksum", () => {
 		expect(result.backendMeta?.googleDriveId).toBe("doc1");
 
 		mockRequestUrl.mockRestore();
+	});
+});
+
+describe("GoogleDriveFs mutation provenance", () => {
+	it("returns the native folder identity without claiming requested casing was resolved", async () => {
+		const { GoogleDriveFs } = await import("./index");
+		const mockClient = {
+			findChildByName: vi.fn().mockResolvedValue(null),
+			createFolder: vi.fn().mockResolvedValue({
+				id: "folder1",
+				name: "Docs",
+				mimeType: "application/vnd.google-apps.folder",
+				parents: ["root"],
+			}),
+		} as never;
+		const fs = new GoogleDriveFs(mockClient, "root");
+		(fs as unknown as GoogleDriveFsInternal).initialized = true;
+
+		const entity = await fs.mkdir("Docs");
+
+		expect(entity).toMatchObject({
+			path: "Docs",
+			pathAuthority: "requested_echo",
+			identityKey: "folder1",
+		});
 	});
 });
 
@@ -699,6 +726,7 @@ describe("GoogleDriveFs cache persistence", () => {
 
 		expect(files2).toHaveLength(2);
 		expect(files2.map((f) => f.path).sort()).toEqual(["docs", "docs/note.md"]);
+		expect(files2.every((file) => file.pathAuthority === "actual_resolved")).toBe(true);
 		// listAllFiles should NOT have been called (loaded from cache)
 		expect(listAllFilesSpy).not.toHaveBeenCalled();
 		// The #3 cursor is the single source of truth — never clobbered by #2.

--- a/src/fs/googledrive/index.ts
+++ b/src/fs/googledrive/index.ts
@@ -205,7 +205,7 @@ export class GoogleDriveFs extends CachingRemoteFs<GoogleDriveFile> {
 				this.cache.removeEntry(oldPath);
 				this.cache.setFile(newPath, result);
 				if (r.wasFolder) {
-					this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
+					this.cache.rewriteChildPaths(oldPath, newPath);
 				}
 			},
 		});

--- a/src/fs/googledrive/index.ts
+++ b/src/fs/googledrive/index.ts
@@ -108,6 +108,8 @@ export class GoogleDriveFs extends CachingRemoteFs<GoogleDriveFile> {
 		const hash = await sha256(content);
 		return {
 			path,
+			pathAuthority: "requested_echo",
+			identityKey: googleDriveFile.id,
 			isDirectory: false,
 			size: content.byteLength,
 			mtime: googleDriveFile.modifiedTime
@@ -126,6 +128,8 @@ export class GoogleDriveFs extends CachingRemoteFs<GoogleDriveFile> {
 			const folderId = await this.ensureFolder(path);
 			return {
 				path,
+				pathAuthority: "requested_echo",
+				identityKey: folderId,
 				isDirectory: true,
 				size: 0,
 				mtime: 0,
@@ -201,7 +205,7 @@ export class GoogleDriveFs extends CachingRemoteFs<GoogleDriveFile> {
 				this.cache.removeEntry(oldPath);
 				this.cache.setFile(newPath, result);
 				if (r.wasFolder) {
-					this.cache.rewriteChildPaths(oldPath, newPath);
+					this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
 				}
 			},
 		});

--- a/src/fs/googledrive/metadata-cache.test.ts
+++ b/src/fs/googledrive/metadata-cache.test.ts
@@ -46,6 +46,12 @@ describe("empty cache queries", () => {
 		expect(cache.size).toBe(0);
 		expect([...cache.entries()]).toEqual([]);
 	});
+
+	it("does not treat an absent cache path as producer-resolved", () => {
+		const cache = makeCache();
+
+		expect(cache.getPathAuthority("missing.md")).toBe("requested_echo");
+	});
 });
 
 // ── setFile ──
@@ -546,6 +552,12 @@ describe("applyFileChange", () => {
 		cache.applyFileChange(child);
 
 		expect(cache.toEntity("Docs/a.md", child).pathAuthority).toBe("requested_echo");
+		expect(cache.exportRecords().find((record) => record.path === "Docs/a.md")?.pathAuthority)
+			.toBe("actual_resolved");
+
+		cache.setFile("Docs", requestedParent, "actual_resolved");
+
+		expect(cache.toEntity("Docs/a.md", child).pathAuthority).toBe("actual_resolved");
 	});
 
 	it("adds new file", () => {

--- a/src/fs/googledrive/metadata-cache.test.ts
+++ b/src/fs/googledrive/metadata-cache.test.ts
@@ -138,6 +138,12 @@ describe("setFile", () => {
 		expect(cache.hasFile("new")).toBe(true);
 		expect(cache.hasFile("new/child.txt")).toBe(true);
 		expect(cache.getPathById("c1")).toBe("new/child.txt");
+		expect(cache.getPathAuthority("new/child.txt")).toBe("requested_echo");
+		expect(cache.exportRecords().find((record) => record.path === "new/child.txt")?.pathAuthority)
+			.toBe("actual_resolved");
+
+		cache.setFile("new", makeFolder({ id: "d1", name: "new" }), "actual_resolved");
+
 		expect(cache.getPathAuthority("new/child.txt")).toBe("actual_resolved");
 	});
 

--- a/src/fs/googledrive/metadata-cache.test.ts
+++ b/src/fs/googledrive/metadata-cache.test.ts
@@ -76,7 +76,69 @@ describe("setFile", () => {
 
 		expect(cache.getFile("a.txt")).toBe(updated);
 		expect(cache.getPathById("f2")).toBe("a.txt");
+		expect(cache.getPathById("f1")).toBeUndefined();
 		expect(cache.size).toBe(1);
+	});
+
+	it("re-keys the same stable id to one path", () => {
+		const cache = makeCache();
+		cache.setFile("old.txt", makeGoogleDriveFile({ id: "f1", name: "old.txt" }));
+
+		cache.setFile(
+			"new.txt",
+			makeGoogleDriveFile({ id: "f1", name: "new.txt" }),
+			"actual_resolved",
+		);
+
+		expect(cache.hasFile("old.txt")).toBe(false);
+		expect(cache.getPathById("f1")).toBe("new.txt");
+		expect(cache.getPathAuthority("new.txt")).toBe("actual_resolved");
+		expect(cache.size).toBe(1);
+		expect(cache.exportRecords().map((record) => record.path)).toEqual(["new.txt"]);
+	});
+
+	it("evicts a destination folder occupant and its subtree when re-keying", () => {
+		const cache = makeCache();
+		cache.setFile("old.txt", makeGoogleDriveFile({ id: "f1", name: "old.txt" }));
+		cache.setFile("occupied", makeFolder({ id: "d1", name: "occupied" }));
+		cache.setFile(
+			"occupied/child.txt",
+			makeGoogleDriveFile({ id: "c1", name: "child.txt" }),
+		);
+
+		const moved = makeGoogleDriveFile({ id: "f1", name: "occupied" });
+		cache.setFile("occupied", moved);
+
+		expect(cache.getFile("occupied")).toBe(moved);
+		expect(cache.hasFile("old.txt")).toBe(false);
+		expect(cache.hasFile("occupied/child.txt")).toBe(false);
+		expect(cache.getPathById("d1")).toBeUndefined();
+		expect(cache.getPathById("c1")).toBeUndefined();
+		expect(cache.exportRecords()).toEqual([{
+			path: "occupied",
+			file: moved,
+			isFolder: false,
+			pathAuthority: "requested_echo",
+		}]);
+	});
+
+	it("rewrites descendants when a folder stable id is re-keyed", () => {
+		const cache = makeCache();
+		cache.setFile("old", makeFolder({ id: "d1", name: "old" }));
+		cache.setFile(
+			"old/child.txt",
+			makeGoogleDriveFile({ id: "c1", name: "child.txt" }),
+			"actual_resolved",
+		);
+
+		cache.setFile("new", makeFolder({ id: "d1", name: "new" }));
+
+		expect(cache.hasFile("old")).toBe(false);
+		expect(cache.hasFile("old/child.txt")).toBe(false);
+		expect(cache.hasFile("new")).toBe(true);
+		expect(cache.hasFile("new/child.txt")).toBe(true);
+		expect(cache.getPathById("c1")).toBe("new/child.txt");
+		expect(cache.getPathAuthority("new/child.txt")).toBe("actual_resolved");
 	});
 
 	it("maintains children index", () => {
@@ -131,6 +193,15 @@ describe("bulkLoad", () => {
 		expect(cache.size).toBe(3);
 		expect(cache.isFolder("docs")).toBe(true);
 		expect(cache.getChildren("docs")?.has("docs/b.txt")).toBe(true);
+	});
+
+	it("rejects persisted duplicate stable ids instead of selecting by path order", () => {
+		const cache = makeCache();
+		expect(() => cache.bulkLoad([
+			["a-new.txt", makeGoogleDriveFile({ id: "f1", name: "a-new.txt" })],
+			["z-old.txt", makeGoogleDriveFile({ id: "f1", name: "z-old.txt" })],
+		])).toThrow(/duplicate stable id/i);
+		expect(cache.size).toBe(0);
 	});
 });
 
@@ -559,6 +630,42 @@ describe("applyFileChange", () => {
 		expect(cache.hasFile("data/child.txt")).toBe(false);
 		// The displaced folder's id no longer points anywhere.
 		expect(cache.getPathById("d1")).toBeUndefined();
+		expect(cache.getPathById("c1")).toBeUndefined();
+	});
+
+	it("evicts descendants when the same stable id changes from folder to file in place", () => {
+		const cache = makeCache();
+		cache.setFile("data", makeFolder({ id: "same", name: "data", parents: [ROOT] }));
+		cache.setFile(
+			"data/child.txt",
+			makeGoogleDriveFile({ id: "c1", name: "child.txt", parents: ["same"] }),
+		);
+
+		const replacement = makeGoogleDriveFile({ id: "same", name: "data", parents: [ROOT] });
+		cache.applyFileChange(replacement);
+
+		expect(cache.getFile("data")).toBe(replacement);
+		expect(cache.isFolder("data")).toBe(false);
+		expect(cache.hasFile("data/child.txt")).toBe(false);
+		expect(cache.getPathById("c1")).toBeUndefined();
+	});
+
+	it("evicts old descendants when a folder stable id re-keys as a file", () => {
+		const cache = makeCache();
+		cache.setFile("old", makeFolder({ id: "same", name: "old", parents: [ROOT] }));
+		cache.setFile(
+			"old/child.txt",
+			makeGoogleDriveFile({ id: "c1", name: "child.txt", parents: ["same"] }),
+		);
+
+		const replacement = makeGoogleDriveFile({ id: "same", name: "new", parents: [ROOT] });
+		cache.applyFileChange(replacement);
+
+		expect(cache.getFile("new")).toBe(replacement);
+		expect(cache.isFolder("new")).toBe(false);
+		expect(cache.hasFile("old")).toBe(false);
+		expect(cache.hasFile("old/child.txt")).toBe(false);
+		expect(cache.hasFile("new/child.txt")).toBe(false);
 		expect(cache.getPathById("c1")).toBeUndefined();
 	});
 

--- a/src/fs/googledrive/metadata-cache.test.ts
+++ b/src/fs/googledrive/metadata-cache.test.ts
@@ -139,12 +139,15 @@ describe("bulkLoad", () => {
 describe("clear", () => {
 	it("empties all data structures", () => {
 		const cache = makeCache();
-		cache.setFile("a.txt", makeGoogleDriveFile({ id: "f1", name: "a.txt" }));
+		const file = makeGoogleDriveFile({ id: "f1", name: "a.txt" });
+		cache.setFile("a.txt", file, "actual_resolved");
 		cache.clear();
 
 		expect(cache.size).toBe(0);
 		expect(cache.hasFile("a.txt")).toBe(false);
 		expect(cache.getPathById("f1")).toBeUndefined();
+		cache.setFile("a.txt", file);
+		expect(cache.toEntity("a.txt", file).pathAuthority).toBe("requested_echo");
 	});
 });
 
@@ -162,6 +165,8 @@ describe("exportRecords", () => {
 		const file = records.find((r) => r.path === "a.txt");
 		expect(folder?.isFolder).toBe(true);
 		expect(file?.isFolder).toBe(false);
+		expect(folder?.pathAuthority).toBe("requested_echo");
+		expect(file?.pathAuthority).toBe("requested_echo");
 	});
 });
 
@@ -305,6 +310,19 @@ describe("buildFromFiles", () => {
 		expect(cache.isFolder("docs")).toBe(true);
 	});
 
+	it("does not promote missing-parent or cyclic fallback paths to resolved authority", () => {
+		const cache = makeCache();
+		const orphan = makeGoogleDriveFile({ id: "orphan", name: "orphan.md", parents: ["missing"] });
+		const a = makeFolder({ id: "a", name: "A", parents: ["b"] });
+		const b = makeFolder({ id: "b", name: "B", parents: ["a"] });
+
+		cache.buildFromFiles([orphan, a, b]);
+
+		expect(cache.toEntity("orphan.md", orphan).pathAuthority).toBe("requested_echo");
+		const cyclicPath = cache.getPathById("a")!;
+		expect(cache.toEntity(cyclicPath, a).pathAuthority).toBe("requested_echo");
+	});
+
 	it("handles circular references gracefully", () => {
 		const logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() };
 		const cache = new GoogleDriveMetadataCache(ROOT, logger as never);
@@ -384,6 +402,21 @@ describe("removeTree", () => {
 // ── toEntity ──
 
 describe("toEntity", () => {
+	it("distinguishes backend-resolved paths from requested mutation paths", () => {
+		const scanned = makeGoogleDriveFile({ id: "f1", name: "Scanned.md", parents: [ROOT] });
+		const changed = makeGoogleDriveFile({ id: "f2", name: "Changed.md", parents: [ROOT] });
+		const requested = makeGoogleDriveFile({ id: "f3", name: "Written.md", parents: [ROOT] });
+		const cache = makeCache();
+
+		cache.buildFromFiles([scanned]);
+		cache.applyFileChange(changed);
+		cache.setFile("Written.md", requested);
+
+		expect(cache.toEntity("Scanned.md", scanned).pathAuthority).toBe("actual_resolved");
+		expect(cache.toEntity("Changed.md", changed).pathAuthority).toBe("actual_resolved");
+		expect(cache.toEntity("Written.md", requested).pathAuthority).toBe("requested_echo");
+	});
+
 	it("converts file to entity", () => {
 		const cache = makeCache();
 		const file = makeGoogleDriveFile({ id: "f1", name: "a.txt", modifiedTime: "2024-01-01T00:00:00.000Z", size: "100", md5Checksum: "abc" });
@@ -391,6 +424,8 @@ describe("toEntity", () => {
 
 		const entity = cache.toEntity("a.txt", file);
 		expect(entity.path).toBe("a.txt");
+		expect(entity.pathAuthority).toBe("requested_echo");
+		expect(entity.identityKey).toBe("f1");
 		expect(entity.isDirectory).toBe(false);
 		expect(entity.size).toBe(100);
 		expect(entity.mtime).toBe(new Date("2024-01-01T00:00:00.000Z").getTime());
@@ -405,6 +440,8 @@ describe("toEntity", () => {
 		cache.setFile("docs", folder);
 
 		const entity = cache.toEntity("docs", folder);
+		expect(entity.pathAuthority).toBe("requested_echo");
+		expect(entity.identityKey).toBe("d1");
 		expect(entity.isDirectory).toBe(true);
 		expect(entity.size).toBe(0);
 	});
@@ -423,6 +460,17 @@ describe("toEntity", () => {
 // ── applyFileChange ──
 
 describe("applyFileChange", () => {
+	it("inherits a cached parent's authority when resolving a child delta", () => {
+		const requestedParent = makeFolder({ id: "d1", name: "Docs", parents: [ROOT] });
+		const child = makeGoogleDriveFile({ id: "f1", name: "a.md", parents: ["d1"] });
+		const cache = makeCache();
+		cache.bulkLoad([["Docs", requestedParent]]);
+
+		cache.applyFileChange(child);
+
+		expect(cache.toEntity("Docs/a.md", child).pathAuthority).toBe("requested_echo");
+	});
+
 	it("adds new file", () => {
 		const cache = makeCache();
 		cache.setFile("docs", makeFolder({ id: "d1", name: "docs", parents: [ROOT] }));

--- a/src/fs/googledrive/metadata-cache.ts
+++ b/src/fs/googledrive/metadata-cache.ts
@@ -35,13 +35,23 @@ export class GoogleDriveMetadataCache extends AbstractMetadataCache<GoogleDriveF
 	 */
 	toEntity(path: string, googleDriveFile: GoogleDriveFile): FileEntity {
 		if (this.isFolder(path)) {
-			return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+			return {
+				path,
+				pathAuthority: this.getPathAuthority(path),
+				identityKey: googleDriveFile.id,
+				isDirectory: true,
+				size: 0,
+				mtime: 0,
+				hash: "",
+			};
 		}
 		const parsedMtime = googleDriveFile.modifiedTime
 			? new Date(googleDriveFile.modifiedTime).getTime()
 			: 0;
 		return {
 			path,
+			pathAuthority: this.getPathAuthority(path),
+			identityKey: googleDriveFile.id,
 			isDirectory: false,
 			size: parseInt(googleDriveFile.size || "0", 10),
 			mtime: Number.isNaN(parsedMtime) ? 0 : parsedMtime,

--- a/src/fs/googledrive/provider-base.ts
+++ b/src/fs/googledrive/provider-base.ts
@@ -8,7 +8,7 @@ import type { RemoteVaultResolution } from "../remote-vault-contract";
 import type { IGoogleAuth } from "./auth";
 import { GoogleDriveClient } from "./client";
 import { GoogleDriveFs } from "./index";
-import { MetadataStore } from "../../store/metadata-store";
+import { METADATA_CACHE_VERSION, MetadataStore } from "../../store/metadata-store";
 import { resolveGoogleDriveRemoteVault } from "./remote-vault";
 import { resolveFolderPath } from "./folder-path";
 import { isHttpError } from "./incremental-sync";
@@ -69,7 +69,7 @@ export abstract class GoogleDriveProviderBase implements IBackendProvider {
 		if (!data.remoteVaultFolderId) return null;
 		return new MetadataStore<GoogleDriveFile>(`${settings.vaultId}-${data.remoteVaultFolderId}`, {
 			dbNamePrefix: "air-sync-googledrive",
-			version: 1,
+			version: METADATA_CACHE_VERSION,
 		});
 	}
 

--- a/src/fs/ifilesystem-contract.test.ts
+++ b/src/fs/ifilesystem-contract.test.ts
@@ -20,11 +20,12 @@ import { registerWriteContract } from "./ifilesystem-contract-writes.test";
  * orchestrator-level in-session convergence (state C) is pinned in
  * `orchestrator.test.ts`. A new remote backend runs all three.
  *
- * `opts.computesHashOnStat` is the only backend-class difference here, and it is
- * intrinsic, not a weakness: local-storage backends (mock, LocalFs) compute a
+ * The opt-in capability flags are intrinsic backend-class differences, not
+ * weaknesses: local-storage backends (mock, LocalFs) compute a
  * content hash on `stat()`, while remote backends return `hash: ""` and carry a
- * `remoteChecksum` instead (see {@link IFileSystem.stat}). Everything else is a
- * universal invariant the engine depends on — including type-collision errors
+ * `remoteChecksum` instead (see {@link IFileSystem.stat}); native remote backends
+ * expose a same-root stable identity while local storage does not promise one.
+ * Everything else is a universal invariant the engine depends on — including type-collision errors
  * and exact messages, which a backend that omits them must FIX rather than
  * opt out of.
  *
@@ -34,6 +35,11 @@ import { registerWriteContract } from "./ifilesystem-contract-writes.test";
  * `describe` via the shared {@link IFileSystemContractCtx}.
  */
 export interface IFileSystemContractOpts {
+	/**
+	 * Whether the backend exposes an opaque native identity that survives rename
+	 * within this configured root and changes when a path is replaced.
+	 */
+	stableIdentity?: boolean;
 	/**
 	 * Whether `stat()` fills `FileEntity.hash` with a real content hash for files.
 	 * True for local-storage backends (mock, LocalFs); false for remote backends
@@ -148,7 +154,41 @@ export function runIFileSystemContract(
 		};
 
 		registerRenameAndReadContract(ctx);
+		if (opts.stableIdentity) registerStableIdentityContract(ctx);
 		registerWriteContract(ctx);
+	});
+}
+
+function registerStableIdentityContract(ctx: IFileSystemContractCtx): void {
+	describe("stable identity", () => {
+		it("survives rename and distinguishes replacement at the same path", async () => {
+			await ctx.seed("identity-old.txt", "first");
+			const echoed = await ctx.fs().stat("identity-old.txt");
+			// Mutation-backed cache paths echo the requested spelling. A backend must
+			// expose that limitation instead of upgrading it to resolved-path proof.
+			expect(echoed?.pathAuthority).toBe("requested_echo");
+			expect(echoed?.identityKey).toBeTruthy();
+
+			// A replay-free full observation is producer-resolved and must retain the
+			// same opaque identity. Missing checkpoint capability is not guessed.
+			expect(ctx.fs().checkpoint).toBeDefined();
+			await ctx.fs().checkpoint!.resetCheckpoint();
+			const before = (await ctx.fs().list()).find((item) => item.path === "identity-old.txt");
+			expect(before?.pathAuthority).toBe("actual_resolved");
+			expect(before?.identityKey).toBeTruthy();
+			expect(before?.identityKey).toBe(echoed?.identityKey);
+
+			await ctx.fs().rename("identity-old.txt", "identity-new.txt");
+			const moved = await ctx.fs().stat("identity-new.txt");
+			expect(moved?.pathAuthority).toBe("requested_echo");
+			expect(moved?.identityKey).toBe(before?.identityKey);
+
+			await ctx.fs().delete("identity-new.txt");
+			await ctx.seed("identity-new.txt", "replacement");
+			const replacement = await ctx.fs().stat("identity-new.txt");
+			expect(replacement?.identityKey).toBeTruthy();
+			expect(replacement?.identityKey).not.toBe(before?.identityKey);
+		});
 	});
 }
 

--- a/src/fs/interface.ts
+++ b/src/fs/interface.ts
@@ -133,6 +133,15 @@ export interface IncrementalCheckpoint {
 	} | null>;
 
 	/**
+	 * Return the cache state produced by the most recent `getChangedPaths()` call
+	 * without fetching or applying another delta page. Folder-rename recovery uses
+	 * this to inspect the whole moved subtree while keeping one cursor/evidence
+	 * boundary. Optional for non-caching/test implementations; callers that require
+	 * it must fail closed rather than fall back to `IFileSystem.list()`.
+	 */
+	listCurrentSnapshot?(): Promise<FileEntity[]>;
+
+	/**
 	 * Whether a committed incremental checkpoint (delta cursor) exists. When false,
 	 * the sync engine cannot trust delta-based remote detection — the last sync never
 	 * completed, or was reset — so it forces a full cold reconcile. The cursor is

--- a/src/fs/local/dot-path-adapter.test.ts
+++ b/src/fs/local/dot-path-adapter.test.ts
@@ -17,7 +17,39 @@ function createAdapter(dotRoots: string[] = [".airsync"]): {
 }
 
 describe("DotPathAdapter", () => {
+	describe("stat", () => {
+		it("marks the requested spelling as an echo because the raw adapter cannot resolve casing", async () => {
+			const { vault, adapter } = createAdapter();
+			await vault.adapter.writeBinary(".airsync/a.md", new Uint8Array([1]).buffer);
+
+			const entity = await adapter.stat(".airsync/a.md");
+
+			expect(entity).toMatchObject({
+				path: ".airsync/a.md",
+				pathAuthority: "requested_echo",
+			});
+		});
+	});
+
 	describe("listAll", () => {
+		it("marks raw adapter listings as requested echoes", async () => {
+			const { vault, adapter } = createAdapter();
+			const vaultInternal = vault as unknown as { files: Map<string, unknown> };
+			vaultInternal.files.set(".airsync", { type: "folder" });
+			vaultInternal.files.set(".airsync/sub", { type: "folder" });
+			vaultInternal.files.set(".airsync/a.md", {
+				type: "file",
+				content: new ArrayBuffer(1),
+				mtime: 100,
+			});
+
+			const entities: Array<{ pathAuthority?: string }> = [];
+			await adapter.listAll(entities as never);
+
+			expect(entities).not.toHaveLength(0);
+			expect(entities.every((entity) => entity.pathAuthority === "requested_echo")).toBe(true);
+		});
+
 		it("lists files from all dot roots", async () => {
 			const { vault, adapter } = createAdapter([".airsync", ".templates"]);
 			const vaultInternal = vault as unknown as { files: Map<string, unknown> };
@@ -51,6 +83,23 @@ describe("DotPathAdapter", () => {
 	});
 
 	describe("listDir", () => {
+		it("marks direct raw adapter listings as requested echoes", async () => {
+			const { vault, adapter } = createAdapter([".templates"]);
+			const vaultInternal = vault as unknown as { files: Map<string, unknown> };
+			vaultInternal.files.set(".templates", { type: "folder" });
+			vaultInternal.files.set(".templates/sub", { type: "folder" });
+			vaultInternal.files.set(".templates/daily.md", {
+				type: "file",
+				content: new ArrayBuffer(5),
+				mtime: 100,
+			});
+
+			const entities = await adapter.listDir(".templates");
+
+			expect(entities).not.toHaveLength(0);
+			expect(entities.every((entity) => entity.pathAuthority === "requested_echo")).toBe(true);
+		});
+
 		it("lists direct children of a dot path", async () => {
 			const { vault, adapter } = createAdapter([".templates"]);
 			const vaultInternal = vault as unknown as { files: Map<string, unknown> };

--- a/src/fs/local/dot-path-adapter.test.ts
+++ b/src/fs/local/dot-path-adapter.test.ts
@@ -18,7 +18,7 @@ function createAdapter(dotRoots: string[] = [".airsync"]): {
 
 describe("DotPathAdapter", () => {
 	describe("stat", () => {
-		it("marks the requested spelling as an echo because the raw adapter cannot resolve casing", async () => {
+		it("resolves the actual spelling from the parent listing", async () => {
 			const { vault, adapter } = createAdapter();
 			await vault.adapter.writeBinary(".airsync/a.md", new Uint8Array([1]).buffer);
 
@@ -26,13 +26,13 @@ describe("DotPathAdapter", () => {
 
 			expect(entity).toMatchObject({
 				path: ".airsync/a.md",
-				pathAuthority: "requested_echo",
+				pathAuthority: "actual_resolved",
 			});
 		});
 	});
 
 	describe("listAll", () => {
-		it("marks raw adapter listings as requested echoes", async () => {
+		it("marks raw adapter listings as resolved provider paths", async () => {
 			const { vault, adapter } = createAdapter();
 			const vaultInternal = vault as unknown as { files: Map<string, unknown> };
 			vaultInternal.files.set(".airsync", { type: "folder" });
@@ -47,7 +47,7 @@ describe("DotPathAdapter", () => {
 			await adapter.listAll(entities as never);
 
 			expect(entities).not.toHaveLength(0);
-			expect(entities.every((entity) => entity.pathAuthority === "requested_echo")).toBe(true);
+			expect(entities.every((entity) => entity.pathAuthority === "actual_resolved")).toBe(true);
 		});
 
 		it("lists files from all dot roots", async () => {
@@ -83,7 +83,7 @@ describe("DotPathAdapter", () => {
 	});
 
 	describe("listDir", () => {
-		it("marks direct raw adapter listings as requested echoes", async () => {
+		it("marks direct raw adapter listings as resolved provider paths", async () => {
 			const { vault, adapter } = createAdapter([".templates"]);
 			const vaultInternal = vault as unknown as { files: Map<string, unknown> };
 			vaultInternal.files.set(".templates", { type: "folder" });
@@ -97,7 +97,7 @@ describe("DotPathAdapter", () => {
 			const entities = await adapter.listDir(".templates");
 
 			expect(entities).not.toHaveLength(0);
-			expect(entities.every((entity) => entity.pathAuthority === "requested_echo")).toBe(true);
+			expect(entities.every((entity) => entity.pathAuthority === "actual_resolved")).toBe(true);
 		});
 
 		it("lists direct children of a dot path", async () => {

--- a/src/fs/local/dot-path-adapter.ts
+++ b/src/fs/local/dot-path-adapter.ts
@@ -23,13 +23,14 @@ export class DotPathAdapter {
 		if (!(await this.vault.adapter.exists(dir))) return;
 		const listed = await this.vault.adapter.list(dir);
 		for (const folder of listed.folders) {
-			entities.push({ path: folder, isDirectory: true, size: 0, mtime: 0, hash: "" });
+			entities.push({ path: folder, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" });
 			await this.list(folder, entities);
 		}
 		for (const file of listed.files) {
 			const s = await this.vault.adapter.stat(file);
 			entities.push({
 				path: file,
+				pathAuthority: "requested_echo",
 				isDirectory: false,
 				size: s?.size ?? 0,
 				mtime: s?.mtime ?? 0,
@@ -42,11 +43,11 @@ export class DotPathAdapter {
 		const s = await this.vault.adapter.stat(path);
 		if (!s) return null;
 		if (s.type === "folder") {
-			return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+			return { path, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" };
 		}
 		const content = await this.vault.adapter.readBinary(path);
 		const hash = await sha256(content);
-		return { path, isDirectory: false, size: s.size, mtime: s.mtime, hash };
+		return { path, pathAuthority: "requested_echo", isDirectory: false, size: s.size, mtime: s.mtime, hash };
 	}
 
 	async read(path: string): Promise<ArrayBuffer> {
@@ -63,7 +64,7 @@ export class DotPathAdapter {
 		}
 		await this.vault.adapter.writeBinary(path, content, { mtime });
 		const hash = await sha256(content);
-		return { path, isDirectory: false, size: content.byteLength, mtime, hash };
+		return { path, pathAuthority: "requested_echo", isDirectory: false, size: content.byteLength, mtime, hash };
 	}
 
 	async delete(path: string): Promise<void> {
@@ -82,12 +83,13 @@ export class DotPathAdapter {
 		if (!(await this.vault.adapter.exists(dir))) return entities;
 		const listed = await this.vault.adapter.list(dir);
 		for (const folder of listed.folders) {
-			entities.push({ path: folder, isDirectory: true, size: 0, mtime: 0, hash: "" });
+			entities.push({ path: folder, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" });
 		}
 		for (const file of listed.files) {
 			const s = await this.vault.adapter.stat(file);
 			entities.push({
 				path: file,
+				pathAuthority: "requested_echo",
 				isDirectory: false,
 				size: s?.size ?? 0,
 				mtime: s?.mtime ?? 0,

--- a/src/fs/local/dot-path-adapter.ts
+++ b/src/fs/local/dot-path-adapter.ts
@@ -23,14 +23,14 @@ export class DotPathAdapter {
 		if (!(await this.vault.adapter.exists(dir))) return;
 		const listed = await this.vault.adapter.list(dir);
 		for (const folder of listed.folders) {
-			entities.push({ path: folder, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" });
+			entities.push({ path: folder, pathAuthority: "actual_resolved", isDirectory: true, size: 0, mtime: 0, hash: "" });
 			await this.list(folder, entities);
 		}
 		for (const file of listed.files) {
 			const s = await this.vault.adapter.stat(file);
 			entities.push({
 				path: file,
-				pathAuthority: "requested_echo",
+				pathAuthority: "actual_resolved",
 				isDirectory: false,
 				size: s?.size ?? 0,
 				mtime: s?.mtime ?? 0,
@@ -42,12 +42,25 @@ export class DotPathAdapter {
 	async stat(path: string): Promise<FileEntity | null> {
 		const s = await this.vault.adapter.stat(path);
 		if (!s) return null;
+		const actualPath = await this.resolveActualPath(path);
+		const pathAuthority = actualPath ? "actual_resolved" : "requested_echo";
+		const resolvedPath = actualPath ?? path;
 		if (s.type === "folder") {
-			return { path, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" };
+			return { path: resolvedPath, pathAuthority, isDirectory: true, size: 0, mtime: 0, hash: "" };
 		}
 		const content = await this.vault.adapter.readBinary(path);
 		const hash = await sha256(content);
-		return { path, pathAuthority: "requested_echo", isDirectory: false, size: s.size, mtime: s.mtime, hash };
+		return { path: resolvedPath, pathAuthority, isDirectory: false, size: s.size, mtime: s.mtime, hash };
+	}
+
+	private async resolveActualPath(path: string): Promise<string | null> {
+		const separator = path.lastIndexOf("/");
+		const parent = separator === -1 ? "" : path.substring(0, separator);
+		const listed = await this.vault.adapter.list(parent);
+		const candidates = [...listed.folders, ...listed.files];
+		if (candidates.includes(path)) return path;
+		const aliases = candidates.filter((candidate) => candidate.toLowerCase() === path.toLowerCase());
+		return aliases.length === 1 ? aliases[0]! : null;
 	}
 
 	async read(path: string): Promise<ArrayBuffer> {
@@ -83,13 +96,13 @@ export class DotPathAdapter {
 		if (!(await this.vault.adapter.exists(dir))) return entities;
 		const listed = await this.vault.adapter.list(dir);
 		for (const folder of listed.folders) {
-			entities.push({ path: folder, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" });
+			entities.push({ path: folder, pathAuthority: "actual_resolved", isDirectory: true, size: 0, mtime: 0, hash: "" });
 		}
 		for (const file of listed.files) {
 			const s = await this.vault.adapter.stat(file);
 			entities.push({
 				path: file,
-				pathAuthority: "requested_echo",
+				pathAuthority: "actual_resolved",
 				isDirectory: false,
 				size: s?.size ?? 0,
 				mtime: s?.mtime ?? 0,

--- a/src/fs/local/index.ts
+++ b/src/fs/local/index.ts
@@ -45,6 +45,7 @@ export class LocalFs implements IFileSystem {
 			if (file instanceof TFile) {
 				entities.push({
 					path: file.path,
+					pathAuthority: "actual_resolved",
 					isDirectory: false,
 					size: file.stat.size,
 					mtime: file.stat.mtime,
@@ -56,6 +57,7 @@ export class LocalFs implements IFileSystem {
 			} else if (file instanceof TFolder) {
 				entities.push({
 					path: file.path,
+					pathAuthority: "actual_resolved",
 					isDirectory: true,
 					size: 0,
 					mtime: 0,
@@ -93,6 +95,7 @@ export class LocalFs implements IFileSystem {
 			const hash = await sha256(content);
 			return {
 				path: file.path,
+				pathAuthority: "actual_resolved",
 				isDirectory: false,
 				size: file.stat.size,
 				mtime: file.stat.mtime,
@@ -101,6 +104,7 @@ export class LocalFs implements IFileSystem {
 		} else if (file instanceof TFolder) {
 			return {
 				path: file.path,
+				pathAuthority: "actual_resolved",
 				isDirectory: true,
 				size: 0,
 				mtime: 0,
@@ -149,6 +153,7 @@ export class LocalFs implements IFileSystem {
 		const hash = await sha256(content);
 		return {
 			path,
+			pathAuthority: "requested_echo",
 			isDirectory: false,
 			size: written.stat.size,
 			mtime: written.stat.mtime,
@@ -159,7 +164,7 @@ export class LocalFs implements IFileSystem {
 	async mkdir(path: string): Promise<FileEntity> {
 		path = normalizeSyncPath(path);
 		await this.mkdirRecursive(path);
-		return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+		return { path, pathAuthority: "requested_echo", isDirectory: true, size: 0, mtime: 0, hash: "" };
 	}
 
 	async listDir(path: string): Promise<FileEntity[]> {
@@ -173,13 +178,14 @@ export class LocalFs implements IFileSystem {
 			if (child instanceof TFile) {
 				return {
 					path: child.path,
+					pathAuthority: "actual_resolved",
 					isDirectory: false,
 					size: child.stat.size,
 					mtime: child.stat.mtime,
 					hash: "",
 				};
 			}
-			return { path: child.path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+			return { path: child.path, pathAuthority: "actual_resolved", isDirectory: true, size: 0, mtime: 0, hash: "" };
 		});
 	}
 

--- a/src/fs/local/local-fs.test.ts
+++ b/src/fs/local/local-fs.test.ts
@@ -116,6 +116,7 @@ describe("LocalFs", () => {
 			expect(entity!.isDirectory).toBe(false);
 			expect(entity!.hash).not.toBe("");
 			expect(entity!.path).toBe(".airsync/logs/test.log");
+			expect(entity!.pathAuthority).toBe("requested_echo");
 		});
 
 		it("returns FileEntity for a .airsync directory", async () => {
@@ -150,6 +151,24 @@ describe("LocalFs", () => {
 			expect(entity!.isDirectory).toBe(false);
 			expect(entity!.size).toBe(2);
 			expect(entity!.hash).not.toBe("");
+			expect(entity!.pathAuthority).toBe("requested_echo");
+		});
+
+		it("marks an indexed stat as resolved and preserves the index's actual spelling", async () => {
+			const { vault, fs } = createLocalFs();
+			const resolved = new TFile();
+			resolved.path = "notes/a.md";
+			resolved.stat = { size: 1, mtime: 1, ctime: 1 };
+			vi.spyOn(vault, "getAbstractFileByPath").mockReturnValue(resolved);
+			vi.spyOn(vault, "readBinary").mockResolvedValue(new Uint8Array([1]).buffer);
+
+			const entity = await fs.stat("notes/A.md");
+
+			expect(entity).toMatchObject({
+				path: "notes/a.md",
+				pathAuthority: "actual_resolved",
+			});
+			expect(entity?.identityKey).toBeUndefined();
 		});
 
 		it("returns null for a path absent from both the index and disk", async () => {

--- a/src/fs/local/local-fs.test.ts
+++ b/src/fs/local/local-fs.test.ts
@@ -116,7 +116,7 @@ describe("LocalFs", () => {
 			expect(entity!.isDirectory).toBe(false);
 			expect(entity!.hash).not.toBe("");
 			expect(entity!.path).toBe(".airsync/logs/test.log");
-			expect(entity!.pathAuthority).toBe("requested_echo");
+			expect(entity!.pathAuthority).toBe("actual_resolved");
 		});
 
 		it("returns FileEntity for a .airsync directory", async () => {
@@ -151,7 +151,7 @@ describe("LocalFs", () => {
 			expect(entity!.isDirectory).toBe(false);
 			expect(entity!.size).toBe(2);
 			expect(entity!.hash).not.toBe("");
-			expect(entity!.pathAuthority).toBe("requested_echo");
+			expect(entity!.pathAuthority).toBe("actual_resolved");
 		});
 
 		it("marks an indexed stat as resolved and preserves the index's actual spelling", async () => {

--- a/src/fs/oauth-pkce.test.ts
+++ b/src/fs/oauth-pkce.test.ts
@@ -5,6 +5,7 @@ import {
 	computeS256Challenge,
 	buildOAuthState,
 	BaseOAuthTokenManager,
+	extractTokenErrorDetail,
 	type OAuthTokenResponse,
 } from "./oauth-pkce";
 import { AuthError } from "./errors";
@@ -164,5 +165,36 @@ describe("BaseOAuthTokenManager", () => {
 		await m.getAccessToken(true);
 		expect(rotated).toEqual(["RT2"]);
 		expect(m.getTokenState().refreshToken).toBe("RT2");
+	});
+});
+
+describe("extractTokenErrorDetail", () => {
+	// Microsoft's RFC 6749 error body carries the fields its support actually needs
+	// (`error_codes`, `trace_id`, `correlation_id`, `suberror`). Picking
+	// `error_description` used to drop every one of them.
+	it("returns the whole body, not a picked field", () => {
+		const detail = extractTokenErrorDetail({
+			json: {
+				error: "invalid_grant",
+				error_description: "AADSTS7000012: The grant was obtained for a different tenant.",
+				error_codes: [7000012],
+				trace_id: "f34ffa47-bccd-443f-8180-358bbe594b01",
+				correlation_id: "27981afe-82ba-4811-9a2c-f6771159458a",
+				suberror: "consent_required",
+			},
+		});
+		expect(detail).toContain("invalid_grant");
+		expect(detail).toContain("AADSTS7000012");
+		expect(detail).toContain("7000012");
+		expect(detail).toContain("f34ffa47-bccd-443f-8180-358bbe594b01");
+		expect(detail).toContain("consent_required");
+	});
+
+	it("falls back to the raw text for a non-JSON body", () => {
+		expect(extractTokenErrorDetail({ text: "Bad Gateway" })).toBe("Bad Gateway");
+	});
+
+	it("reports an empty body rather than an empty string", () => {
+		expect(extractTokenErrorDetail({})).toBe("(empty body)");
 	});
 });

--- a/src/fs/oauth-pkce.ts
+++ b/src/fs/oauth-pkce.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "../logging/logger";
 import { AuthError } from "./errors";
+import { describeErrorBody, MAX_MESSAGE_BODY_CHARS } from "./backend-error-log";
 
 /**
  * Shared OAuth/PKCE primitives used by every cloud backend that speaks OAuth 2.0
@@ -105,20 +106,20 @@ export interface OAuthTokenResponse {
 }
 
 /**
- * Extract a readable error detail from an OAuth token-endpoint error response,
- * preferring `error_description`, then `error`, then the raw text. Shared by the
- * worker-less PKCE backends (Dropbox, OneDrive) whose token endpoints return the
+ * Render an OAuth token-endpoint ERROR response for a thrown message. Shared by the
+ * worker-less PKCE backends (Dropbox, OneDrive), whose token endpoints return the
  * same RFC 6749 error shape, so the message format can't drift between them.
+ *
+ * It used to pick `error_description`, else `error`, else the text — which dropped
+ * everything else the provider sent (`error_codes`, `trace_id`, `correlation_id`,
+ * `suberror`, `timestamp`). Those are precisely the fields a provider's support
+ * needs, so the body now goes through verbatim, like every other backend response.
+ *
+ * Safe for these responses specifically: a token endpoint only returns tokens on
+ * SUCCESS, and this is reached only for a non-2xx.
  */
 export function extractTokenErrorDetail(res: { json?: unknown; text?: string }): string {
-	try {
-		const json = res.json as { error_description?: string; error?: string } | undefined;
-		if (json?.error_description) return json.error_description;
-		if (json?.error) return json.error;
-	} catch {
-		// fall through to text
-	}
-	return typeof res.text === "string" ? res.text : "";
+	return describeErrorBody(res, MAX_MESSAGE_BODY_CHARS);
 }
 
 /**

--- a/src/fs/onedrive/auth.ts
+++ b/src/fs/onedrive/auth.ts
@@ -2,6 +2,7 @@ import { requestUrl } from "../../platform/obsidian";
 import type { ISecretStore } from "../secret-store";
 import type { Logger } from "../../logging/logger";
 import { AuthError } from "../errors";
+import { logBackendErrorResponse } from "../backend-error-log";
 import { BaseOAuthTokenManager, extractTokenErrorDetail } from "../oauth-pkce";
 import { PkceAuthProvider } from "../pkce-auth-provider";
 import { ONEDRIVE_AUTH } from "../auth-config";
@@ -100,6 +101,7 @@ export class OneDriveAuth extends BaseOAuthTokenManager {
 			}).toString(),
 		});
 		if (res.status < 200 || res.status >= 300) {
+			logBackendErrorResponse(this.logger, "OneDrive token", "exchangeCode", res);
 			throw new Error(`Token exchange failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertMicrosoftTokenResponse(res.json);
@@ -127,10 +129,12 @@ export class OneDriveAuth extends BaseOAuthTokenManager {
 			throw err;
 		}
 		if (res.status === 400 || res.status === 401) {
+			logBackendErrorResponse(this.logger, "OneDrive token", "performRefresh", res);
 			this.authFailedAt = Date.now();
 			throw new AuthError(`Token refresh failed: ${res.status} ${extractTokenErrorDetail(res)}`, res.status);
 		}
 		if (res.status < 200 || res.status >= 300) {
+			logBackendErrorResponse(this.logger, "OneDrive token", "performRefresh", res);
 			throw new Error(`Token refresh failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertMicrosoftTokenResponse(res.json);

--- a/src/fs/onedrive/client.ts
+++ b/src/fs/onedrive/client.ts
@@ -100,7 +100,7 @@ export class OneDriveClient {
 			await this.sleep(delay);
 			return this.request(op, opts, { ...state, rateLimitRetries: state.rateLimitRetries + 1 }, skipAuth);
 		}
-		assertOk(res, op);
+		assertOk(res, op, this.logger);
 		return res;
 	};
 

--- a/src/fs/onedrive/ifilesystem-contract.test.ts
+++ b/src/fs/onedrive/ifilesystem-contract.test.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OneDriveClient } from "./client";
 import type { OneDriveItem, OneDriveDeltaResponse } from "./types";
 import { OneDriveFs } from "./index";
@@ -131,4 +131,25 @@ function makeFakeOneDriveClient(): OneDriveClient {
 // cache work; the checkpoint machinery has its own contract.
 runIFileSystemContract("OneDriveFs", () => new OneDriveFs(makeFakeOneDriveClient(), ROOT_ID), {
 	computesHashOnStat: false,
+});
+
+describe("OneDriveFs mutation provenance", () => {
+	it("returns stable native identities without claiming requested casing was resolved", async () => {
+		const fs = new OneDriveFs(makeFakeOneDriveClient(), ROOT_ID);
+
+		const folder = await fs.mkdir("Docs");
+		const file = await fs.write("Docs/a.md", new Uint8Array([1]).buffer, 1000);
+
+		expect(folder).toMatchObject({
+			path: "Docs",
+			pathAuthority: "requested_echo",
+		});
+		expect(file).toMatchObject({
+			path: "Docs/a.md",
+			pathAuthority: "requested_echo",
+		});
+		expect(folder.identityKey).toMatch(/^id/);
+		expect(file.identityKey).toMatch(/^id/);
+		expect(file.identityKey).not.toBe(folder.identityKey);
+	});
 });

--- a/src/fs/onedrive/ifilesystem-contract.test.ts
+++ b/src/fs/onedrive/ifilesystem-contract.test.ts
@@ -131,6 +131,7 @@ function makeFakeOneDriveClient(): OneDriveClient {
 // cache work; the checkpoint machinery has its own contract.
 runIFileSystemContract("OneDriveFs", () => new OneDriveFs(makeFakeOneDriveClient(), ROOT_ID), {
 	computesHashOnStat: false,
+	stableIdentity: true,
 });
 
 describe("OneDriveFs mutation provenance", () => {

--- a/src/fs/onedrive/incremental-sync.test.ts
+++ b/src/fs/onedrive/incremental-sync.test.ts
@@ -5,6 +5,12 @@ import type { OneDriveClient } from "./client";
 import type { OneDriveDeltaResponse } from "./types";
 import { GraphApiError } from "./types";
 import { odFile, odFolder, odDeleted, deltaPage } from "./test-helpers";
+import { collectRemoteRenameEvidence } from "../../sync/identity-evidence";
+import {
+	admitDestructivePlan,
+	captureCycleAdmissionSnapshot,
+} from "../../sync/plan-admission";
+import type { PathObservation, SyncAction } from "../../sync/types";
 
 vi.mock("obsidian");
 
@@ -84,6 +90,53 @@ describe("applyOneDriveDelta", () => {
 		expect(cache.hasFile("a.md")).toBe(false);
 		expect(cache.getPathById("f1")).toBe("renamed.md");
 		expect(result.renamedPaths).toEqual([{ oldPath: "a.md", newPath: "renamed.md", isFolder: undefined }]);
+	});
+
+	it("emits a rename edge for a same-id casing-only rename", async () => {
+		const cache = new OneDriveMetadataCache(ROOT);
+		cache.buildFromFiles([odFile("f1", "A.md", ROOT)]);
+		const client = fakeClient([deltaPage([odFile("f1", "a.md", ROOT)], "tok2")]);
+
+		const result = await applyOneDriveDelta(ctx(cache, client), "tok1");
+		if (result.needsFullScan) throw new Error("unexpected resync");
+
+		expect(result.renamedPaths).toEqual([
+			{ oldPath: "A.md", newPath: "a.md", isFolder: undefined },
+		]);
+		expect(cache.getPathById("f1")).toBe("a.md");
+	});
+
+	it("proves the casing edge, not Admission policy, changes destructive authorization", async () => {
+		const cache = new OneDriveMetadataCache(ROOT);
+		cache.buildFromFiles([odFile("f1", "A.md", ROOT)]);
+		const client = fakeClient([deltaPage([odFile("f1", "a.md", ROOT)], "tok2")]);
+		const delta = await applyOneDriveDelta(ctx(cache, client), "tok1");
+		if (delta.needsFullScan) throw new Error("unexpected resync");
+		const emittedEvidence = collectRemoteRenameEvidence(delta.renamedPaths);
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "delete_local" },
+			{ path: "a.md", action: "delete_remote" },
+		];
+		const observations: PathObservation[] = [
+			{ kind: "absent", side: "remote", requestedPath: "A.md", authority: "checkpoint_deleted" },
+			{ kind: "absent", side: "local", requestedPath: "a.md", authority: "stat" },
+		];
+		const scope = { byEndpoint: new Map([
+			["A.md", "included" as const], ["a.md", "included" as const],
+		]) };
+		const admit = (identityEvidence: typeof emittedEvidence) => admitDestructivePlan(
+			captureCycleAdmissionSnapshot(
+				{ actions }, identityEvidence, observations, scope, "onedrive:root",
+			),
+		);
+
+		const withProducerEdge = admit(emittedEvidence);
+		const withoutProducerEdge = admit([]);
+
+		expect(withProducerEdge.executable.actions).toEqual([]);
+		expect(withProducerEdge.deferred[0]?.reasons).toEqual(["opposing_deletes"]);
+		expect(withoutProducerEdge.executable.actions).toEqual(actions);
+		expect(withoutProducerEdge.deferred).toEqual([]);
 	});
 
 	it("rewrites child paths when a folder is renamed via the same id", async () => {

--- a/src/fs/onedrive/index.ts
+++ b/src/fs/onedrive/index.ts
@@ -101,6 +101,8 @@ export class OneDriveFs extends CachingRemoteFs<OneDriveItem> {
 		const hash = await sha256(content);
 		return {
 			path,
+			pathAuthority: "requested_echo",
+			identityKey: item.id,
 			isDirectory: false,
 			size: content.byteLength,
 			mtime: itemMtime(item),
@@ -115,7 +117,16 @@ export class OneDriveFs extends CachingRemoteFs<OneDriveItem> {
 		return this.cacheMutex.run(async () => {
 			await this.ensureInitialized();
 			const folderId = await this.ensureFolder(path);
-			return { path, isDirectory: true, size: 0, mtime: 0, hash: "", backendMeta: { oneDriveId: folderId } };
+			return {
+				path,
+				pathAuthority: "requested_echo",
+				identityKey: folderId,
+				isDirectory: true,
+				size: 0,
+				mtime: 0,
+				hash: "",
+				backendMeta: { oneDriveId: folderId },
+			};
 		});
 	}
 
@@ -156,7 +167,7 @@ export class OneDriveFs extends CachingRemoteFs<OneDriveItem> {
 				}
 				this.cache.removeEntry(oldPath);
 				this.cache.setFile(newPath, result);
-				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath);
+				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
 			},
 		});
 	}

--- a/src/fs/onedrive/index.ts
+++ b/src/fs/onedrive/index.ts
@@ -167,7 +167,7 @@ export class OneDriveFs extends CachingRemoteFs<OneDriveItem> {
 				}
 				this.cache.removeEntry(oldPath);
 				this.cache.setFile(newPath, result);
-				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath, "requested_echo");
+				if (r.wasFolder) this.cache.rewriteChildPaths(oldPath, newPath);
 			},
 		});
 	}

--- a/src/fs/onedrive/metadata-cache.test.ts
+++ b/src/fs/onedrive/metadata-cache.test.ts
@@ -32,7 +32,14 @@ describe("OneDriveMetadataCache.buildFromFiles (id-chain resolution)", () => {
 		expect(file.backendMeta).toMatchObject({ oneDriveId: "f1" });
 
 		cache.buildFromFiles([odFolder("d1", "dir", ROOT)]);
-		expect(cache.toEntity("dir", cache.getFile("dir")!)).toMatchObject({ isDirectory: true, size: 0, mtime: 0, hash: "" });
+		expect(cache.toEntity("dir", cache.getFile("dir")!)).toMatchObject({
+			pathAuthority: "actual_resolved",
+			identityKey: "d1",
+			isDirectory: true,
+			size: 0,
+			mtime: 0,
+			hash: "",
+		});
 	});
 });
 

--- a/src/fs/onedrive/metadata-cache.ts
+++ b/src/fs/onedrive/metadata-cache.ts
@@ -36,9 +36,6 @@ export class OneDriveMetadataCache extends AbstractMetadataCache<OneDriveItem> {
 	 * uses remoteChecksum (the locally-reproducible quickXorHash) instead.
 	 */
 	toEntity(path: string, item: OneDriveItem): FileEntity {
-		if (this.isFolder(path)) {
-			return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
-		}
-		return oneDriveItemToEntity(path, item);
+		return { ...oneDriveItemToEntity(path, item), pathAuthority: this.getPathAuthority(path) };
 	}
 }

--- a/src/fs/onedrive/types.test.ts
+++ b/src/fs/onedrive/types.test.ts
@@ -203,6 +203,8 @@ describe("oneDriveItemToEntity", () => {
 		}));
 		expect(entity).toMatchObject({
 			path: "notes/a.md",
+			pathAuthority: "requested_echo",
+			identityKey: "1",
 			isDirectory: false,
 			size: 7,
 			hash: "",
@@ -214,7 +216,15 @@ describe("oneDriveItemToEntity", () => {
 
 	it("maps a folder to a directory entity with no checksum", () => {
 		const entity = oneDriveItemToEntity("notes", odFolder("9", "notes", "p"));
-		expect(entity).toMatchObject({ path: "notes", isDirectory: true, size: 0, mtime: 0, hash: "" });
+		expect(entity).toMatchObject({
+			path: "notes",
+			pathAuthority: "requested_echo",
+			identityKey: "9",
+			isDirectory: true,
+			size: 0,
+			mtime: 0,
+			hash: "",
+		});
 		expect(entity.remoteChecksum).toBeUndefined();
 	});
 });

--- a/src/fs/onedrive/types.test.ts
+++ b/src/fs/onedrive/types.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { Logger } from "../../logging/logger";
 import {
 	assertOk,
 	assertMicrosoftTokenResponse,
@@ -38,6 +39,77 @@ describe("assertOk", () => {
 			expect((err as GraphApiError).status).toBe(409);
 			expect((err as GraphApiError).code).toBe("nameAlreadyExists");
 		}
+	});
+
+	// RED (issue #42): Graph's `error.message` is the only field that distinguishes a
+	// missing App Folder from an insufficient grant, and `suffix = code || detail`
+	// (types.ts:134) drops it whenever a code is present — which it always is for 403.
+	it("keeps the Graph error.message alongside the code for a 403 accessDenied", () => {
+		expect(() =>
+			assertOk(
+				{
+					status: 403,
+					json: {
+						error: {
+							code: "accessDenied",
+							message: "Access denied. You do not have permission to perform this action or access this resource.",
+						},
+					},
+				},
+				"getAppRoot",
+			),
+		).toThrow(/Access denied\. You do not have permission/);
+	});
+
+	// The live issue-#42 shape: Graph kept the actionable condition in `innerError.code`
+	// while the outer code stayed the generic `accessDenied`. Nothing the backend sent
+	// may be dropped — including fields this codebase does not model.
+	it("carries the whole Graph error body, innerError and unmodelled fields included", () => {
+		let thrown: unknown;
+		try {
+			assertOk(
+				{
+					status: 403,
+					json: {
+						error: {
+							code: "accessDenied",
+							message: "Access denied",
+							innerError: { code: "serviceReadOnly", "request-id": "33575d37", date: "2026-08-20T02:16:12" },
+							suberror: "a_field_this_codebase_does_not_model",
+						},
+					},
+				},
+				"getAppRoot",
+			);
+		} catch (err) {
+			thrown = err;
+		}
+		const message = (thrown as Error).message;
+		expect(message).toContain("403");
+		expect(message).toContain("accessDenied");
+		expect(message).toContain("serviceReadOnly");
+		expect(message).toContain("33575d37");
+		expect(message).toContain("a_field_this_codebase_does_not_model");
+		// `code` is still exposed for callers that branch on it.
+		expect((thrown as GraphApiError).code).toBe("accessDenied");
+	});
+
+	it("logs the whole error response before throwing", () => {
+		const error = vi.fn();
+		const logger = { error } as unknown as Logger;
+		expect(() =>
+			assertOk({ status: 500, json: { error: { code: "internalError" } } }, "fullList", logger),
+		).toThrow(GraphApiError);
+		expect(error).toHaveBeenCalledTimes(1);
+		const [, context] = error.mock.calls[0] as [string, Record<string, unknown>];
+		expect(context).toMatchObject({ operation: "fullList", status: 500 });
+		expect(context.body).toContain("internalError");
+	});
+
+	it("still reports a non-JSON error body verbatim", () => {
+		expect(() => assertOk({ status: 502, text: "<html>proxy blocked</html>" }, "download")).toThrow(
+			/<html>proxy blocked<\/html>/,
+		);
 	});
 
 	it("throws a GraphApiError for a 410 resync", () => {

--- a/src/fs/onedrive/types.ts
+++ b/src/fs/onedrive/types.ts
@@ -212,10 +212,20 @@ export function itemMtime(item: OneDriveItem): number {
  */
 export function oneDriveItemToEntity(path: string, item: OneDriveItem): FileEntity {
 	if (isFolderEntry(item)) {
-		return { path, isDirectory: true, size: 0, mtime: 0, hash: "" };
+		return {
+			path,
+			pathAuthority: "requested_echo",
+			identityKey: item.id,
+			isDirectory: true,
+			size: 0,
+			mtime: 0,
+			hash: "",
+		};
 	}
 	return {
 		path,
+		pathAuthority: "requested_echo",
+		identityKey: item.id,
 		isDirectory: false,
 		size: item.size ?? 0,
 		mtime: itemMtime(item),

--- a/src/fs/onedrive/types.ts
+++ b/src/fs/onedrive/types.ts
@@ -1,5 +1,7 @@
 import type { FileEntity, RemoteChecksum } from "../types";
+import type { Logger } from "../../logging/logger";
 import { AuthError } from "../errors";
+import { describeErrorBody, logBackendErrorResponse, MAX_MESSAGE_BODY_CHARS } from "../backend-error-log";
 
 /**
  * A Microsoft Graph `driveItem` (the subset Air Sync uses).
@@ -78,9 +80,14 @@ export function assertMicrosoftTokenResponse(json: unknown): asserts json is Mic
 	}
 }
 
-/** Shape of a Microsoft Graph JSON error body. */
+/**
+ * Shape of a Microsoft Graph JSON error body. `innerError.code` is the field that
+ * actually names a service-side condition (e.g. `serviceReadOnly` during an App
+ * Folder incident) while the outer `code` stays a generic `accessDenied`, so it is
+ * typed here rather than left as `unknown`.
+ */
 interface GraphErrorBody {
-	error?: { code?: string; message?: string; innerError?: unknown };
+	error?: { code?: string; message?: string; innerError?: { code?: string } & Record<string, unknown> };
 }
 
 /**
@@ -121,20 +128,30 @@ const AUTH_ERROR_CODES = new Set([
  * @throws {GraphApiError} for any other non-2xx (409 conflicts, 410 resync, 429
  *   rate limits, 5xx), preserving the status and error `code`.
  */
-export function assertOk(res: { status: number; json?: unknown; text?: string }, op: string): void {
+export function assertOk(
+	res: { status: number; json?: unknown; text?: string; headers?: Record<string, string> },
+	op: string,
+	logger?: Logger,
+): void {
 	if (res.status >= 200 && res.status < 300) return;
+	// Log the whole response first: whatever this function distils into the thrown
+	// message, the raw body (including `innerError`) stays recoverable from the log.
+	logBackendErrorResponse(logger, "OneDrive", op, res);
 	let body: GraphErrorBody | undefined;
 	try {
 		body = res.json as GraphErrorBody | undefined;
 	} catch {
 		body = undefined;
 	}
+	// `code` is still read — but ONLY for branching (auth class, and the code carried
+	// on GraphApiError for 409/410 callers). It is deliberately not used to build the
+	// message: hand-picking fields is what made the live `serviceReadOnly` incident
+	// invisible, and any field Graph adds later would be dropped the same way.
 	const code = body?.error?.code ?? "";
-	const detail = body?.error?.message ?? (typeof res.text === "string" ? res.text : "");
-	const suffix = code || detail;
-	const message = suffix
-		? `OneDrive API ${op} failed: ${res.status} ${suffix}`
-		: `OneDrive API ${op} failed: ${res.status}`;
+	// The message carries the response body verbatim. Whatever Graph chose to say —
+	// `message`, `innerError.code`, request ids, fields not modelled here — reaches
+	// the user's notice and their bug report intact.
+	const message = `OneDrive API ${op} failed: ${res.status} ${describeErrorBody(res, MAX_MESSAGE_BODY_CHARS)}`;
 	if (res.status === 401 || AUTH_ERROR_CODES.has(code)) {
 		throw new AuthError(message, 401);
 	}

--- a/src/fs/pkce-app-folder-provider.ts
+++ b/src/fs/pkce-app-folder-provider.ts
@@ -7,7 +7,7 @@ import type { IBackendSettingsRenderer } from "./settings-renderer";
 import type { AirSyncSettings } from "../settings";
 import type { Logger } from "../logging/logger";
 import type { RemoteVaultResolution } from "./remote-vault-contract";
-import { MetadataStore } from "../store/metadata-store";
+import { METADATA_CACHE_VERSION, MetadataStore } from "../store/metadata-store";
 import { getBackendSecret, setBackendSecret, hasBackendSecret, clearBackendSecrets } from "./token-store";
 import type { PkceAuthProvider, PkceTokenManager } from "./pkce-auth-provider";
 
@@ -111,7 +111,10 @@ export abstract class PkceAppFolderProvider<
 	protected metadataStoreFor(settings: AirSyncSettings): MetadataStore<TFile> | null {
 		const id = this.getData(settings).remoteVaultFolderId;
 		if (!id) return null;
-		return new MetadataStore<TFile>(`${settings.vaultId}-${id}`, { dbNamePrefix: this.dbNamePrefix, version: 1 });
+		return new MetadataStore<TFile>(`${settings.vaultId}-${id}`, {
+			dbNamePrefix: this.dbNamePrefix,
+			version: METADATA_CACHE_VERSION,
+		});
 	}
 
 	/** A usable token exists if either secret is present (a refresh OR a live access token). */

--- a/src/fs/types.ts
+++ b/src/fs/types.ts
@@ -22,10 +22,17 @@ export interface RemoteChecksum {
 	value: string;
 }
 
+/** Whether an entity path was resolved by the producer or merely echoed from the request. */
+export type PathAuthority = "actual_resolved" | "requested_echo";
+
 /** Represents a file or folder entity from any filesystem */
 export interface FileEntity {
 	/** Relative path from the sync root (e.g. "notes/hello.md") */
 	path: string;
+	/** Producer-qualified authority for `path`; absence is not proof of resolved spelling. */
+	pathAuthority?: PathAuthority;
+	/** Opaque identity stable only within this configured filesystem/root. */
+	identityKey?: string;
 	/** True if this entity is a directory */
 	isDirectory: boolean;
 	/** File size in bytes (0 for directories) */

--- a/src/store/metadata-store.test.ts
+++ b/src/store/metadata-store.test.ts
@@ -1,6 +1,6 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect } from "vitest";
-import { MetadataStore } from "./metadata-store";
+import { METADATA_CACHE_VERSION, MetadataStore } from "./metadata-store";
 
 interface TestFile {
 	id: string;
@@ -92,5 +92,29 @@ describe("MetadataStore", () => {
 		expect(loaded.files).toHaveLength(1);
 
 		await store.close();
+	});
+
+	it("cold-starts when persisted record semantics bump the cache version", async () => {
+		const legacy = new MetadataStore<TestFile>("upgrade-vault", {
+			dbNamePrefix: "test-metadata-upgrade",
+			version: METADATA_CACHE_VERSION - 1,
+		});
+		await legacy.open();
+		await legacy.saveAll(
+			[{ path: "legacy.md", file: { id: "1", name: "legacy.md", mimeType: "text/plain" }, isFolder: false }],
+			new Map([["changesStartPageToken", "legacy-cursor"]]),
+		);
+		await legacy.close();
+
+		const current = new MetadataStore<TestFile>("upgrade-vault", {
+			dbNamePrefix: "test-metadata-upgrade",
+			version: METADATA_CACHE_VERSION,
+		});
+		await current.open();
+		const loaded = await current.loadAll();
+
+		expect(loaded.files).toEqual([]);
+		expect(loaded.meta.size).toBe(0);
+		await current.close();
 	});
 });

--- a/src/store/metadata-store.test.ts
+++ b/src/store/metadata-store.test.ts
@@ -79,6 +79,21 @@ describe("MetadataStore", () => {
 		await store.close();
 	});
 
+	it("sets and deletes one durable operation marker without replacing cache metadata", async () => {
+		const store = new MetadataStore<TestFile>("test-vault-operation", CONFIG);
+		await store.open();
+		await store.saveAll([], new Map([["changesStartPageToken", "cursor"]]));
+
+		await store.setMeta("pendingOperation", "payload");
+		expect(await store.getMeta("pendingOperation")).toBe("payload");
+		expect(await store.getMeta("changesStartPageToken")).toBe("cursor");
+
+		await store.deleteMeta("pendingOperation");
+		expect(await store.getMeta("pendingOperation")).toBeUndefined();
+		expect(await store.getMeta("changesStartPageToken")).toBe("cursor");
+		await store.close();
+	});
+
 	it("uses config for db name prefix", async () => {
 		const store = new MetadataStore<TestFile>("my-vault", { dbNamePrefix: "custom-prefix", version: 1 });
 		await store.open();

--- a/src/store/metadata-store.test.ts
+++ b/src/store/metadata-store.test.ts
@@ -17,7 +17,7 @@ describe("MetadataStore", () => {
 		await store.open();
 
 		const files = [
-			{ path: "notes/a.md", file: { id: "1", name: "a.md", mimeType: "text/plain" }, isFolder: false },
+			{ path: "notes/a.md", file: { id: "1", name: "a.md", mimeType: "text/plain" }, isFolder: false, pathAuthority: "actual_resolved" as const },
 			{ path: "notes", file: { id: "2", name: "notes", mimeType: "application/vnd.google-apps.folder" }, isFolder: true },
 		];
 		const meta = new Map([
@@ -30,6 +30,7 @@ describe("MetadataStore", () => {
 
 		expect(loaded.files).toHaveLength(2);
 		expect(loaded.files.map((f) => f.path).sort()).toEqual(["notes", "notes/a.md"]);
+		expect(loaded.files.find((f) => f.path === "notes/a.md")?.pathAuthority).toBe("actual_resolved");
 		expect(loaded.meta.get("rootFolderId")).toBe("root123");
 		expect(loaded.meta.get("changesStartPageToken")).toBe("token456");
 

--- a/src/store/metadata-store.ts
+++ b/src/store/metadata-store.ts
@@ -1,4 +1,5 @@
 import { IDBHelper, sanitizeDbName } from "./idb-helper";
+import type { PathAuthority } from "../fs/types";
 
 const FILES_STORE = "files";
 const META_STORE = "meta";
@@ -7,6 +8,7 @@ export interface FileRecord<T> {
 	path: string;
 	file: T;
 	isFolder: boolean;
+	pathAuthority?: PathAuthority;
 }
 
 export interface MetadataStoreConfig {

--- a/src/store/metadata-store.ts
+++ b/src/store/metadata-store.ts
@@ -114,6 +114,22 @@ export class MetadataStore<T> {
 		});
 	}
 
+	/** Persist one backend-owned operation marker without replacing cache metadata. */
+	async setMeta(key: string, value: string): Promise<void> {
+		await this.helper.runTransaction(META_STORE, "readwrite", (tx) => {
+			tx.objectStore(META_STORE).put({ key, value });
+			return () => {};
+		});
+	}
+
+	/** Remove one backend-owned operation marker. */
+	async deleteMeta(key: string): Promise<void> {
+		await this.helper.runTransaction(META_STORE, "readwrite", (tx) => {
+			tx.objectStore(META_STORE).delete(key);
+			return () => {};
+		});
+	}
+
 	/** Clear all stores */
 	async clear(): Promise<void> {
 		await this.helper.runTransaction([FILES_STORE, META_STORE], "readwrite", (tx) => {

--- a/src/store/metadata-store.ts
+++ b/src/store/metadata-store.ts
@@ -4,6 +4,9 @@ import type { PathAuthority } from "../fs/types";
 const FILES_STORE = "files";
 const META_STORE = "meta";
 
+/** Bump whenever persisted file-record semantics require a cold cache rebuild. */
+export const METADATA_CACHE_VERSION = 2;
+
 export interface FileRecord<T> {
 	path: string;
 	file: T;

--- a/src/sync/change-detector.test.ts
+++ b/src/sync/change-detector.test.ts
@@ -435,6 +435,61 @@ describe("collectChanges — temperature selection", () => {
 			expect(paths).toContain("old.md");
 		});
 
+		it("hot mode: treats a case-insensitive stat alias as an absent rename source", async () => {
+			await stateStore.put(makeRecord("PRUEBA.md", {
+				hash: "sha256abc",
+				localMtime: 1000,
+				localSize: 7,
+			}));
+			addFile(localFs, "PRUEBa.md", "content", 1000);
+			addFile(remoteFs, "PRUEBA.md", "content", 1000);
+
+			localTracker.acknowledge(localTracker.snapshot());
+			localTracker.markRenamed("PRUEBa.md", "PRUEBA.md");
+
+			const exactStat = localFs.stat.bind(localFs);
+			localFs.stat = async (path: string) => {
+				const exact = await exactStat(path);
+				if (exact) return exact;
+				const alias = [...localFs.files.keys()].find(
+					(candidate) => candidate.toLowerCase() === path.toLowerCase(),
+				);
+				return alias ? exactStat(alias) : null;
+			};
+
+			const result = await collectChanges(makeDeps());
+			const source = result.entries.find((entry) => entry.path === "PRUEBA.md");
+			const destination = result.entries.find((entry) => entry.path === "PRUEBa.md");
+
+			expect(result.temperature).toBe("hot");
+			expect(source).toMatchObject({
+				path: "PRUEBA.md",
+				local: undefined,
+			});
+			expect(source?.remote).toBeDefined();
+			expect(source?.prevSync).toBeDefined();
+			expect(destination?.local?.path).toBe("PRUEBa.md");
+		});
+
+		it("hot mode: preserves a rename source that was recreated before syncing", async () => {
+			await stateStore.put(makeRecord("PRUEBA.md", {
+				hash: "sha256abc",
+				localMtime: 1000,
+				localSize: 7,
+			}));
+			addFile(localFs, "PRUEBA.md", "recreated source", 2000);
+			addFile(localFs, "PRUEBa.md", "content", 1000);
+			addFile(remoteFs, "PRUEBA.md", "content", 1000);
+
+			localTracker.acknowledge(localTracker.snapshot());
+			localTracker.markRenamed("PRUEBa.md", "PRUEBA.md");
+
+			const result = await collectChanges(makeDeps());
+			const source = result.entries.find((entry) => entry.path === "PRUEBA.md");
+
+			expect(source?.local?.path).toBe("PRUEBA.md");
+		});
+
 		it("hot mode: remote rename pairs are included in ChangeSet", async () => {
 			await stateStore.put(makeRecord("a.md"));
 			addFile(localFs, "a.md", "content", 1000);

--- a/src/sync/change-detector.test.ts
+++ b/src/sync/change-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { collectChanges, enrichHashesForRenames } from "./change-detector";
+import { planSync } from "./decision-engine";
 import type { ChangeDetectorDeps } from "./change-detector";
 import { LocalChangeTracker } from "./local-tracker";
 import { createMockFs, createMockStateStore, addFile } from "../__mocks__/sync-test-helpers";
@@ -313,11 +314,19 @@ describe("collectChanges — temperature selection", () => {
 			expect(paths).toContain("remote-only.md");
 		});
 
-		it("includes remote deleted paths from getChangedPaths in hot mode", async () => {
+		it("retains an authoritative remote deletion with an unchanged local file in hot mode", async () => {
 			await stateStore.put(makeRecord("local-dirty.md", { localMtime: 500 }));
-			await stateStore.put(makeRecord("remote-deleted.md"));
 			addFile(localFs, "local-dirty.md", "changed", 2000);
-			// remote-deleted.md is absent from remoteFs (deleted)
+			addFile(localFs, "remote-deleted.md", "unchanged", 1000);
+			const unchanged = await localFs.stat("remote-deleted.md");
+			expect(unchanged).not.toBeNull();
+			await stateStore.put(makeRecord("remote-deleted.md", {
+				hash: unchanged!.hash,
+				localMtime: unchanged!.mtime,
+				localSize: unchanged!.size,
+			}));
+			// The local copy survives unchanged; only the checkpoint authoritatively
+			// reports that the remote copy was deleted.
 
 			remoteFs.checkpoint!.getChangedPaths = () => Promise.resolve({ modified: [], deleted: ["remote-deleted.md"] });
 
@@ -330,7 +339,35 @@ describe("collectChanges — temperature selection", () => {
 			const paths = result.entries.map((e) => e.path);
 			expect(paths).toContain("remote-deleted.md");
 			const deleted = result.entries.find((e) => e.path === "remote-deleted.md");
+			expect(deleted?.local).toBeDefined();
 			expect(deleted?.remote).toBeUndefined();
+			expect(planSync([deleted!]).actions).toMatchObject([
+				{ path: "remote-deleted.md", action: "delete_local" },
+			]);
+		});
+
+		it("keeps an authoritative remote deletion as conflict when the local file changed", async () => {
+			await stateStore.put(makeRecord("local-dirty.md", { localMtime: 500 }));
+			await stateStore.put(makeRecord("remote-deleted.md", {
+				hash: "baseline-hash",
+				localMtime: 1000,
+				localSize: 8,
+			}));
+			addFile(localFs, "local-dirty.md", "changed", 2000);
+			addFile(localFs, "remote-deleted.md", "locally changed", 2000);
+			remoteFs.checkpoint!.getChangedPaths = () => Promise.resolve({
+				modified: [],
+				deleted: ["remote-deleted.md"],
+			});
+			localTracker.acknowledge(localTracker.snapshot());
+			localTracker.markDirty("local-dirty.md");
+
+			const result = await collectChanges(makeDeps());
+			const deleted = result.entries.find((e) => e.path === "remote-deleted.md");
+
+			expect(planSync([deleted!]).actions).toMatchObject([
+				{ path: "remote-deleted.md", action: "conflict" },
+			]);
 		});
 
 		it("includes locally deleted file that still exists on remote", async () => {

--- a/src/sync/change-detector.test.ts
+++ b/src/sync/change-detector.test.ts
@@ -5,7 +5,7 @@ import type { ChangeDetectorDeps } from "./change-detector";
 import { LocalChangeTracker } from "./local-tracker";
 import { createMockFs, createMockStateStore, addFile } from "../__mocks__/sync-test-helpers";
 import type { FileEntity, RemoteChecksum } from "../fs/types";
-import type { MixedEntity, SyncRecord } from "./types";
+import type { MixedEntity, PathObservation, SyncRecord } from "./types";
 import { md5 } from "../utils/md5";
 import { sha256, sha1 } from "../utils/hash";
 
@@ -487,7 +487,34 @@ describe("collectChanges — temperature selection", () => {
 			const result = await collectChanges(makeDeps());
 
 			expect(result.temperature).toBe("hot");
-			expect(result.remoteRenamePairs).toEqual([{ oldPath: "a.md", newPath: "b.md" }]);
+			expect(result.observations).toContainEqual({
+				kind: "absent", side: "remote", requestedPath: "a.md",
+				authority: "checkpoint_deleted",
+			});
+			expect(result.identityEvidence).toContainEqual({
+				kind: "rename", side: "remote", oldPath: "a.md", newPath: "b.md",
+				isFolder: false, authority: "reported",
+			});
+		});
+
+		it("keeps a requested-echo stat result unresolved and out of exact entries", async () => {
+			await stateStore.put(makeRecord("a.md"));
+			addFile(localFs, "a.md", "content", 1000);
+			addFile(remoteFs, "a.md", "content", 1000);
+			const originalStat = localFs.stat.bind(localFs);
+			localFs.stat = async (path) => {
+				const entity = await originalStat(path);
+				return entity ? { ...entity, pathAuthority: "requested_echo" } : null;
+			};
+			localTracker.acknowledge(localTracker.snapshot());
+			localTracker.markDirty("a.md");
+
+			const result = await collectChanges(makeDeps());
+
+			expect(result.observations).toContainEqual(expect.objectContaining({
+				kind: "present_unresolved", side: "local", requestedPath: "a.md",
+			}));
+			expect(result.entries.find((entry) => entry.path === "a.md")?.local).toBeUndefined();
 		});
 
 		it("warm mode: rename pair paths are included in changedPaths", async () => {
@@ -521,17 +548,49 @@ describe("collectChanges — temperature selection", () => {
 			const result = await collectChanges(makeDeps());
 
 			expect(result.temperature).toBe("warm");
-			expect(result.remoteRenamePairs).toEqual([{ oldPath: "a.md", newPath: "b.md" }]);
+			expect(result.observations).toContainEqual({
+				kind: "absent", side: "remote", requestedPath: "a.md",
+				authority: "checkpoint_deleted",
+			});
+			expect(result.identityEvidence).toContainEqual({
+				kind: "rename", side: "remote", oldPath: "a.md", newPath: "b.md",
+				isFolder: false, authority: "reported",
+			});
 		});
 
-		it("cold mode: remoteRenamePairs is empty", async () => {
+		it("warm mode: preserves a stat-confirmed unresolved remote presence", async () => {
+			await stateStore.put(makeRecord("a.md"));
+			addFile(localFs, "a.md", "content", 1000);
+			addFile(remoteFs, "a.md", "content", 1000);
+			remoteFs.checkpoint!.getChangedPaths = () => Promise.resolve({
+				modified: ["a.md"], deleted: [],
+			});
+			const originalStat = remoteFs.stat.bind(remoteFs);
+			let statCalls = 0;
+			remoteFs.stat = async (path) => {
+				statCalls += 1;
+				if (statCalls > 1) return null;
+				const candidate = await originalStat(path);
+				return candidate ? { ...candidate, pathAuthority: "requested_echo" } : null;
+			};
+
+			const result = await collectChanges(makeDeps());
+
+			expect(statCalls).toBe(1);
+			expect(result.observations).toContainEqual(expect.objectContaining({
+				kind: "present_unresolved", side: "remote", requestedPath: "a.md", source: "stat",
+			}));
+			expect(result.entries.find((entry) => entry.path === "a.md")?.remote).toBeUndefined();
+		});
+
+		it("cold mode has no reported rename evidence", async () => {
 			addFile(localFs, "a.md", "content", 1000);
 			addFile(remoteFs, "a.md", "content", 1000);
 
 			const result = await collectChanges(makeDeps());
 
 			expect(result.temperature).toBe("cold");
-			expect(result.remoteRenamePairs).toEqual([]);
+			expect(result.identityEvidence).toEqual([]);
 		});
 	});
 
@@ -544,9 +603,10 @@ describe("collectChanges — temperature selection", () => {
 
 			// Override stat() to return a different mtime (simulates stat/list divergence)
 			localFs.stat = async (path: string) => {
+				if (path === "old.md") return null;
 				const content = await localFs.read(path);
 				return {
-					path, isDirectory: false, size: content.byteLength,
+					path, pathAuthority: "actual_resolved", isDirectory: false, size: content.byteLength,
 					mtime: 9999, hash: await sha256(content),
 				};
 			};
@@ -560,6 +620,34 @@ describe("collectChanges — temperature selection", () => {
 			expect(entry?.local?.size).toBe(listEntity.size);
 		});
 
+		it("records an alias found while enriching as identity evidence", async () => {
+			await stateStore.put(makeRecord("old.md", {
+				hash: "sha256abc", localMtime: 1000, localSize: 7,
+			}));
+			addFile(localFs, "new.md", "content", 1000);
+			addFile(remoteFs, "old.md", "content", 1000);
+			localTracker.markRenamed("new.md", "old.md");
+			const originalStat = localFs.stat.bind(localFs);
+			localFs.stat = async (path) => {
+				if (path !== "new.md") return originalStat(path);
+				const candidate = await originalStat(path);
+				return candidate ? {
+					...candidate, path: "New.md", pathAuthority: "actual_resolved",
+				} : null;
+			};
+
+			const result = await collectChanges(makeDeps());
+
+			expect(result.entries.find((entry) => entry.path === "new.md")?.local)
+				.toBeUndefined();
+			expect(result.observations).toContainEqual(expect.objectContaining({
+				kind: "alias", side: "local", requestedPath: "new.md", resolvedPath: "New.md",
+			}));
+			expect(result.identityEvidence).toContainEqual({
+				kind: "alias", side: "local", requestedPath: "new.md", resolvedPath: "New.md",
+			});
+		});
+
 		it("does not enrich when no rename pairs exist", async () => {
 			await stateStore.put(makeRecord("a.md", { localMtime: 500 }));
 			addFile(localFs, "a.md", "modified", 2000);
@@ -571,7 +659,7 @@ describe("collectChanges — temperature selection", () => {
 			expect(entry?.local?.hash).toBe("");
 		});
 
-		it("preserves local entry unchanged when stat() throws", async () => {
+		it("aborts when authoritative deletion confirmation throws", async () => {
 			await stateStore.put(makeRecord("old.md", { hash: "sha256abc", localMtime: 1000, localSize: 7 }));
 			const listEntity = addFile(localFs, "new.md", "content", 1000);
 			addFile(remoteFs, "old.md", "content", 1000);
@@ -579,17 +667,18 @@ describe("collectChanges — temperature selection", () => {
 
 			localFs.stat = () => { throw new Error("disk error"); };
 
-			const result = await collectChanges(makeDeps());
-
-			expect(result.temperature).toBe("warm");
-			const entry = result.entries.find((e) => e.path === "new.md");
-			expect(entry?.local?.hash).toBe("");
-			expect(entry?.local?.mtime).toBe(listEntity.mtime);
-			expect(entry?.local?.size).toBe(listEntity.size);
+			await expect(collectChanges(makeDeps())).rejects.toThrow("disk error");
+			expect(listEntity.hash).toBe("");
 		});
 	});
 
 	describe("enrichHashesForRenames (unit)", () => {
+		let observations: PathObservation[];
+
+		beforeEach(() => {
+			observations = [];
+		});
+
 		function entry(path: string, localHash: string): MixedEntity {
 			return { path, local: { path, isDirectory: false, size: 7, mtime: 1000, hash: localHash } };
 		}
@@ -606,16 +695,19 @@ describe("collectChanges — temperature selection", () => {
 				return e;
 			};
 
-			await enrichHashesForRenames(entries, localFs, pairs);
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
 
 			expect(entries[0]!.local!.hash).toBe("sha256-hash");
+			expect(observations).toContainEqual(expect.objectContaining({
+				kind: "exact", side: "local", requestedPath: "new.md",
+			}));
 		});
 
 		it("skips entries where hash is already present", async () => {
 			const entries = [entry("new.md", "existing-hash")];
 			const pairs = new Map([["new.md", "old.md"]]);
 
-			await enrichHashesForRenames(entries, localFs, pairs);
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
 
 			expect(entries[0]!.local!.hash).toBe("existing-hash");
 		});
@@ -624,7 +716,7 @@ describe("collectChanges — temperature selection", () => {
 			const entries: MixedEntity[] = [{ path: "new.md" }];
 			const pairs = new Map([["new.md", "old.md"]]);
 
-			await enrichHashesForRenames(entries, localFs, pairs);
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
 
 			expect(entries[0]!.local).toBeUndefined();
 		});
@@ -633,37 +725,74 @@ describe("collectChanges — temperature selection", () => {
 			const entries = [entry("unrelated.md", "")];
 			const pairs = new Map([["new.md", "old.md"]]);
 
-			await enrichHashesForRenames(entries, localFs, pairs);
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
 
 			expect(entries[0]!.local!.hash).toBe("");
 		});
 
-		it("skips when stat() throws", async () => {
+		it("aborts when stat() throws", async () => {
 			const entries = [entry("new.md", "")];
 			const pairs = new Map([["new.md", "old.md"]]);
 
 			localFs.stat = () => { throw new Error("disk error"); };
 
-			await enrichHashesForRenames(entries, localFs, pairs);
+			await expect(
+				enrichHashesForRenames(entries, observations, localFs, pairs),
+			).rejects.toThrow("disk error");
 
 			expect(entries[0]!.local!.hash).toBe("");
 		});
 
-		it("skips when stat() returns null", async () => {
+		it("replaces a stale listing entry when stat() returns null", async () => {
 			const entries = [entry("new.md", "")];
 			const pairs = new Map([["new.md", "old.md"]]);
 
 			localFs.stat = () => Promise.resolve(null);
 
-			await enrichHashesForRenames(entries, localFs, pairs);
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
 
-			expect(entries[0]!.local!.hash).toBe("");
+			expect(entries[0]!.local).toBeUndefined();
+			expect(observations).toContainEqual({
+				kind: "absent", side: "local", requestedPath: "new.md", authority: "stat",
+			});
+		});
+
+		it("does not copy a requested-echo stat hash into an exact entry", async () => {
+			const entries = [entry("new.md", "")];
+			const pairs = new Map([["new.md", "old.md"]]);
+			localFs.stat = () => Promise.resolve({
+				path: "new.md", pathAuthority: "requested_echo", isDirectory: false,
+				size: 7, mtime: 1000, hash: "untrusted-hash",
+			});
+
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
+
+			expect(entries[0]!.local).toBeUndefined();
+			expect(observations).toContainEqual(expect.objectContaining({
+				kind: "present_unresolved", requestedPath: "new.md", source: "stat",
+			}));
+		});
+
+		it("does not copy an alias stat hash into the requested-path entry", async () => {
+			const entries = [entry("new.md", "")];
+			const pairs = new Map([["new.md", "old.md"]]);
+			localFs.stat = () => Promise.resolve({
+				path: "New.md", pathAuthority: "actual_resolved", isDirectory: false,
+				size: 7, mtime: 1000, hash: "alias-hash",
+			});
+
+			await enrichHashesForRenames(entries, observations, localFs, pairs);
+
+			expect(entries[0]!.local).toBeUndefined();
+			expect(observations).toContainEqual(expect.objectContaining({
+				kind: "alias", requestedPath: "new.md", resolvedPath: "New.md",
+			}));
 		});
 
 		it("no-ops when rename pairs is empty", async () => {
 			const entries = [entry("new.md", "")];
 
-			await enrichHashesForRenames(entries, localFs, new Map());
+			await enrichHashesForRenames(entries, observations, localFs, new Map());
 
 			expect(entries[0]!.local!.hash).toBe("");
 		});

--- a/src/sync/change-detector.test.ts
+++ b/src/sync/change-detector.test.ts
@@ -8,6 +8,7 @@ import type { FileEntity, RemoteChecksum } from "../fs/types";
 import type { MixedEntity, PathObservation, SyncRecord } from "./types";
 import { md5 } from "../utils/md5";
 import { sha256, sha1 } from "../utils/hash";
+import { projectRenameScope, projectScope } from "./scope-projection";
 
 function makeRecord(path: string, overrides: Partial<SyncRecord> = {}): SyncRecord {
 	return {
@@ -591,6 +592,121 @@ describe("collectChanges — temperature selection", () => {
 
 			expect(result.temperature).toBe("cold");
 			expect(result.identityEvidence).toEqual([]);
+		});
+
+		it("authoritatively observes otherwise-unseen folder rename roots", async () => {
+			await localFs.mkdir("new");
+			localTracker.markFolderRenamed("new", "old");
+
+			const result = await collectChanges(makeDeps(), { forceFullScan: true });
+
+			expect(result.identityEvidence).toContainEqual({
+				kind: "rename", side: "local", oldPath: "old", newPath: "new",
+				isFolder: true, authority: "reported",
+			});
+			expect(result.observations).toContainEqual({
+				kind: "absent", side: "local", requestedPath: "old", authority: "stat",
+			});
+			expect(result.observations).toContainEqual(expect.objectContaining({
+				kind: "exact", side: "local", requestedPath: "new",
+			}));
+		});
+
+		it("aborts when an unseen folder endpoint cannot be confirmed", async () => {
+			localTracker.markFolderRenamed("new", "old");
+			localFs.stat = () => { throw new Error("folder stat failed"); };
+
+			await expect(collectChanges(makeDeps(), { forceFullScan: true }))
+				.rejects.toThrow("folder stat failed");
+		});
+
+		it.each([false, true])(
+			"lists folder descendants when initialized with concurrent dirty=%s",
+			async (withConcurrentDirty) => {
+				await stateStore.put(makeRecord("old/a.md"));
+				addFile(remoteFs, "old/a.md", "content", 1000);
+				addFile(localFs, "new/a.md", "content", 1000);
+				if (withConcurrentDirty) {
+					await stateStore.put(makeRecord("other.md"));
+					addFile(localFs, "other.md", "changed", 2000);
+					addFile(remoteFs, "other.md", "original", 1000);
+				}
+				localTracker.acknowledge(localTracker.snapshot());
+				localTracker.markFolderRenamed("new", "old");
+				if (withConcurrentDirty) localTracker.markDirty("other.md");
+
+				const result = await collectChanges(makeDeps());
+
+				expect(result.temperature).toBe("warm");
+				expect(result.entries.map((entry) => entry.path)).toEqual(expect.arrayContaining([
+					"old/a.md", "new/a.md",
+				]));
+				const folderEvidence = result.identityEvidence.find((e) =>
+					e.kind === "rename" && e.isFolder);
+				expect(folderEvidence?.kind).toBe("rename");
+				if (!folderEvidence || folderEvidence.kind !== "rename") return;
+
+				const rootsOut = projectScope(result, {
+					classifyPath: (path) => path === "old" || path === "new"
+						? "policy_out"
+						: "included",
+				});
+				expect(projectRenameScope(folderEvidence, rootsOut).consequence).toBe("defer");
+
+				const mixedChild = projectScope(result, {
+					classifyPath: (path) => path === "new/a.md" ? "policy_out" : "included",
+				});
+				expect(projectRenameScope(folderEvidence, mixedChild).consequence).toBe("defer");
+			},
+		);
+
+		it.each([false, true])(
+			"promotes a remote folder rename to cold with concurrent dirty=%s",
+			async (withConcurrentDirty) => {
+			await stateStore.put(makeRecord("old/a.md"));
+			addFile(localFs, "old/a.md", "content", 1000);
+			addFile(remoteFs, "new/a.md", "content", 1000);
+			const getChangedPaths = vi.fn(() => Promise.resolve({
+				modified: ["new"],
+				deleted: ["old"],
+				renamed: [{ oldPath: "old", newPath: "new", isFolder: true }],
+			}));
+			remoteFs.checkpoint!.getChangedPaths = getChangedPaths;
+			localTracker.acknowledge(localTracker.snapshot());
+			if (withConcurrentDirty) localTracker.markDirty("unrelated.md");
+
+			const result = await collectChanges(makeDeps());
+
+			expect(getChangedPaths).toHaveBeenCalledTimes(1);
+			expect(result.temperature).toBe("cold");
+			expect(result.entries.map((entry) => entry.path)).toEqual(expect.arrayContaining([
+				"old/a.md", "new/a.md",
+			]));
+			const folderEvidence = result.identityEvidence.find((e) =>
+				e.kind === "rename" && e.side === "remote" && e.isFolder);
+			expect(folderEvidence?.kind).toBe("rename");
+			if (!folderEvidence || folderEvidence.kind !== "rename") return;
+
+			const mixedChild = projectScope(result, {
+				classifyPath: (path) => path === "new/a.md" ? "policy_out" : "included",
+			});
+			expect(projectRenameScope(folderEvidence, mixedChild).consequence).toBe("defer");
+			},
+		);
+
+		it("fails closed when a remote folder delta has no replay-free snapshot", async () => {
+			await stateStore.put(makeRecord("old/a.md"));
+			remoteFs.checkpoint!.getChangedPaths = () => Promise.resolve({
+				modified: ["new"], deleted: ["old"],
+				renamed: [{ oldPath: "old", newPath: "new", isFolder: true }],
+			});
+			delete remoteFs.checkpoint!.listCurrentSnapshot;
+			localTracker.acknowledge(localTracker.snapshot());
+			localTracker.markDirty("unrelated.md");
+
+			await expect(collectChanges(makeDeps())).rejects.toThrow(
+				"Remote folder rename requires a replay-free checkpoint snapshot",
+			);
 		});
 	});
 

--- a/src/sync/change-detector.test.ts
+++ b/src/sync/change-detector.test.ts
@@ -4,7 +4,7 @@ import { enrichHashesForRenames } from "./change-hash-enrichment";
 import { planSync } from "./decision-engine";
 import type { ChangeDetectorDeps } from "./change-detector";
 import { LocalChangeTracker } from "./local-tracker";
-import { createMockFs, createMockStateStore, addFile } from "../__mocks__/sync-test-helpers";
+import { createMockLocalFs, createMockRemoteFs, type MockFileSystem, createMockStateStore, addFile } from "../__mocks__/sync-test-helpers";
 import type { FileEntity, RemoteChecksum } from "../fs/types";
 import type { MixedEntity, PathObservation, SyncRecord } from "./types";
 import { md5 } from "../utils/md5";
@@ -25,8 +25,8 @@ function makeRecord(path: string, overrides: Partial<SyncRecord> = {}): SyncReco
 }
 
 describe("collectChanges — temperature selection", () => {
-	let localFs: ReturnType<typeof createMockFs>;
-	let remoteFs: ReturnType<typeof createMockFs>;
+	let localFs: MockFileSystem;
+	let remoteFs: MockFileSystem;
 	let stateStore: ReturnType<typeof createMockStateStore>;
 	let localTracker: LocalChangeTracker;
 
@@ -35,15 +35,15 @@ describe("collectChanges — temperature selection", () => {
 	}
 
 	beforeEach(() => {
-		localFs = createMockFs("local");
-		remoteFs = createMockFs("remote");
+		localFs = createMockLocalFs();
+		remoteFs = createMockRemoteFs();
 		stateStore = createMockStateStore();
 		localTracker = new LocalChangeTracker();
 	});
 
 	/** Add a file to mock FS with a remote-provided checksum (e.g. Google Drive md5). */
 	function addFileWithChecksum(
-		fs: ReturnType<typeof createMockFs>,
+		fs: MockFileSystem,
 		path: string,
 		text: string,
 		mtime: number,
@@ -987,12 +987,61 @@ describe("collectChanges — temperature selection", () => {
 
 			expect(entries[0]!.local!.hash).toBe("");
 		});
+
+		it("fills hashes for every file below a folder rename destination", async () => {
+			const entries = [
+				entry("Published/a.md", ""),
+				entry("Published/nested/b.md", ""),
+				entry("unrelated.md", ""),
+			];
+			addFile(localFs, "Published/a.md", "a", 1000).hash = "hash-a";
+			addFile(localFs, "Published/nested/b.md", "b", 1000).hash = "hash-b";
+			addFile(localFs, "unrelated.md", "other", 1000).hash = "hash-other";
+
+			await enrichHashesForRenames(
+				entries, observations, localFs, new Map(), new Map([["Published", "Drafts"]]),
+			);
+
+			expect(entries.map((candidate) => candidate.local?.hash)).toEqual([
+				"hash-a", "hash-b", "",
+			]);
+		});
+
+		it("bounds folder descendant stat work to ten concurrent operations", async () => {
+			const entries = Array.from({ length: 12 }, (_, index) =>
+				entry(`Published/${index}.md`, ""));
+			let active = 0;
+			let maxActive = 0;
+			let releaseStats!: () => void;
+			const statsReleased = new Promise<void>((resolve) => { releaseStats = resolve; });
+			localFs.stat = async (path) => {
+				active++;
+				maxActive = Math.max(maxActive, active);
+				await statsReleased;
+				active--;
+				return {
+					path, pathAuthority: "actual_resolved", isDirectory: false,
+					size: 7, mtime: 1000, hash: `hash-${path}`,
+				};
+			};
+
+			const enrichment = enrichHashesForRenames(
+				entries, observations, localFs, new Map(), new Map([["Published", "Drafts"]]),
+			);
+			await vi.waitFor(() => expect(maxActive).toBe(10));
+			releaseStats();
+			await enrichment;
+
+			expect(maxActive).toBe(10);
+			expect(entries.every((candidate) => candidate.local?.hash.startsWith("hash-")))
+				.toBe(true);
+		});
 	});
 });
 
 describe("collectChanges — warm deletion confirmation", () => {
-	let localFs: ReturnType<typeof createMockFs>;
-	let remoteFs: ReturnType<typeof createMockFs>;
+	let localFs: MockFileSystem;
+	let remoteFs: MockFileSystem;
 	let stateStore: ReturnType<typeof createMockStateStore>;
 	let localTracker: LocalChangeTracker;
 
@@ -1001,8 +1050,8 @@ describe("collectChanges — warm deletion confirmation", () => {
 	}
 
 	beforeEach(() => {
-		localFs = createMockFs("local");
-		remoteFs = createMockFs("remote");
+		localFs = createMockLocalFs();
+		remoteFs = createMockRemoteFs();
 		stateStore = createMockStateStore();
 		localTracker = new LocalChangeTracker();
 	});
@@ -1045,8 +1094,8 @@ describe("collectChanges — warm deletion confirmation", () => {
  * which is the only mode that rediscovers such orphans.
  */
 describe("collectChanges — forceFullScan rediscovers un-baselined remote files", () => {
-	let localFs: ReturnType<typeof createMockFs>;
-	let remoteFs: ReturnType<typeof createMockFs>;
+	let localFs: MockFileSystem;
+	let remoteFs: MockFileSystem;
 	let stateStore: ReturnType<typeof createMockStateStore>;
 	let localTracker: LocalChangeTracker;
 
@@ -1055,8 +1104,8 @@ describe("collectChanges — forceFullScan rediscovers un-baselined remote files
 	}
 
 	beforeEach(async () => {
-		localFs = createMockFs("local");
-		remoteFs = createMockFs("remote");
+		localFs = createMockLocalFs();
+		remoteFs = createMockRemoteFs();
 		stateStore = createMockStateStore();
 		localTracker = new LocalChangeTracker();
 		// Post-crash state: synced.md was pulled and its baseline committed;

--- a/src/sync/change-detector.test.ts
+++ b/src/sync/change-detector.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { collectChanges, enrichHashesForRenames } from "./change-detector";
+import { collectChanges } from "./change-detector";
+import { enrichHashesForRenames } from "./change-hash-enrichment";
 import { planSync } from "./decision-engine";
 import type { ChangeDetectorDeps } from "./change-detector";
 import { LocalChangeTracker } from "./local-tracker";
@@ -264,6 +265,25 @@ describe("collectChanges — temperature selection", () => {
 			const entry = result.entries.find((e) => e.path === "remote-changed.md");
 			expect(entry).toBeDefined();
 			expect(entry?.remote).toBeDefined();
+		});
+
+		it("confirms local absence for a new remote-only delta path", async () => {
+			await stateStore.put(makeRecord("existing.md"));
+			addFile(remoteFs, "new-remote.md", "remote", 2000);
+			remoteFs.checkpoint!.getChangedPaths = () => Promise.resolve({
+				modified: ["new-remote.md"], deleted: [],
+			});
+
+			const result = await collectChanges(makeDeps());
+
+			expect(result.entries.find((entry) => entry.path === "new-remote.md")).toMatchObject({
+				local: undefined,
+				remote: { path: "new-remote.md" },
+				prevSync: undefined,
+			});
+			expect(result.observations).toContainEqual({
+				kind: "absent", side: "local", requestedPath: "new-remote.md", authority: "stat",
+			});
 		});
 	});
 

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -1,13 +1,21 @@
 import type { IFileSystem } from "../fs/interface";
-import type { IdentityEvidence, MixedEntity, PathObservation, RenameEvidence, SyncRecord } from "./types";
+import type { FileEntity } from "../fs/types";
+import type { IdentityEvidence, MixedEntity, PathObservation, SyncRecord } from "./types";
 import type { SyncStateStore } from "./state";
 import type { TrackerSnapshot } from "./local-tracker";
 import { hasChanged, hasRemoteChanged } from "./change-compare";
 import { sha256, digest, isLocallyComputable } from "../utils/hash";
 import { AsyncPool } from "../queue/async-queue";
-import { collectLocalRenameEvidence, collectRemoteRenameEvidence, completeIdentityEvidence } from "./identity-evidence";
+import { collectLocalRenameEvidence, completeIdentityEvidence } from "./identity-evidence";
+import {
+	getRemoteChanges,
+	hasFolderRename,
+	remoteSnapshotAfterDelta,
+	type RemoteChanges,
+} from "./remote-change-source";
 import {
 	confirmBaselineAbsences,
+	confirmUnknownRenameEndpoints,
 	ensureRenameEndpointObservations,
 	exactEntity,
 	observePath,
@@ -56,8 +64,20 @@ export async function collectChanges(
 	let changeSet: ChangeSet;
 
 	// Determine temperature
-	if (!opts.forceFullScan && changes.initialized && changes.dirtyPaths.size > 0) {
-		changeSet = await collectHot(deps);
+	if (!opts.forceFullScan && changes.initialized && changes.dirtyPaths.size > 0 &&
+		changes.folderRenamePairs.size === 0) {
+		const remoteChanges = await getRemoteChanges(deps.remoteFs);
+		if (hasFolderRename(remoteChanges)) {
+			changeSet = await collectCold(
+				deps,
+				await stateStore.getAll(),
+				remoteChanges,
+				undefined,
+				await remoteSnapshotAfterDelta(deps.remoteFs),
+			);
+		} else {
+			changeSet = await collectHot(deps, remoteChanges);
+		}
 	} else {
 		const allRecords = await stateStore.getAll();
 		changeSet = opts.forceFullScan || allRecords.length === 0
@@ -66,6 +86,7 @@ export async function collectChanges(
 	}
 	changeSet.identityEvidence.unshift(...collectLocalRenameEvidence(changes));
 	ensureRenameEndpointObservations(changeSet.observations, changeSet.identityEvidence);
+	await confirmUnknownRenameEndpoints(changeSet, deps.localFs, deps.remoteFs);
 
 	// WARM/COLD listings can under-report. Confirm every baseline path whose current
 	// side is missing before planning; a thrown stat aborts rather than becoming absence.
@@ -86,13 +107,13 @@ export async function collectChanges(
 	return changeSet;
 }
 
-async function collectHot(deps: ChangeDetectorDeps): Promise<ChangeSet> {
+async function collectHot(
+	deps: ChangeDetectorDeps,
+	remoteChanges: RemoteChanges,
+): Promise<ChangeSet> {
 	const { localFs, remoteFs, stateStore, changes } = deps;
 
 	const dirtyPaths = changes.dirtyPaths;
-
-	// Get remote changed paths if supported
-	const remoteChanges = await getRemoteChanges(remoteFs);
 
 	// Union of local dirty and remote changed paths
 	const changedPaths = new Set<string>(dirtyPaths);
@@ -160,6 +181,15 @@ async function collectWarm(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 		localFs.list(),
 		getRemoteChanges(remoteFs),
 	]);
+	if (hasFolderRename(remoteChanges)) {
+		return collectCold(
+			deps,
+			allRecords,
+			remoteChanges,
+			localFiles,
+			await remoteSnapshotAfterDelta(remoteFs),
+		);
+	}
 
 	const recordMap = new Map(allRecords.map((r) => [r.path, r]));
 	const changedPaths = new Set<string>();
@@ -224,12 +254,18 @@ async function collectWarm(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 	return { entries, observations, identityEvidence: remoteChanges.renameEvidence, temperature: "warm" };
 }
 
-async function collectCold(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): Promise<ChangeSet> {
+async function collectCold(
+	deps: ChangeDetectorDeps,
+	allRecords: SyncRecord[],
+	remoteChanges?: RemoteChanges,
+	prefetchedLocalFiles?: FileEntity[],
+	prefetchedRemoteFiles?: FileEntity[],
+): Promise<ChangeSet> {
 	const { localFs, remoteFs } = deps;
 
 	const [localFiles, remoteFiles] = await Promise.all([
-		localFs.list(),
-		remoteFs.list(),
+		prefetchedLocalFiles ?? localFs.list(),
+		prefetchedRemoteFiles ?? remoteFs.list(),
 	]);
 	const syncRecords = allRecords;
 
@@ -263,7 +299,12 @@ async function collectCold(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 		getOrCreate(record.path).prevSync = record;
 	}
 
-	return { entries: Array.from(pathMap.values()), observations, identityEvidence: [], temperature: "cold" };
+	return {
+		entries: Array.from(pathMap.values()),
+		observations,
+		identityEvidence: remoteChanges?.renameEvidence ?? [],
+		temperature: "cold",
+	};
 }
 
 /**
@@ -340,26 +381,4 @@ export async function enrichHashesForRenames(
 				: undefined;
 		})
 	);
-}
-
-interface RemoteChanges {
-	paths: string[];
-	deletedPaths: ReadonlySet<string>;
-	renameEvidence: RenameEvidence[];
-}
-
-async function getRemoteChanges(remoteFs: IFileSystem): Promise<RemoteChanges> {
-	if (!remoteFs.checkpoint) return { paths: [], deletedPaths: new Set(), renameEvidence: [] };
-	const result = await remoteFs.checkpoint.getChangedPaths();
-	if (!result) return { paths: [], deletedPaths: new Set(), renameEvidence: [] };
-	const renameEvidence = collectRemoteRenameEvidence(result.renamed ?? []);
-	return {
-		paths: [
-			...result.modified,
-			...result.deleted,
-			...renameEvidence.flatMap(({ oldPath, newPath }) => [oldPath, newPath]),
-		],
-		deletedPaths: new Set(result.deleted),
-		renameEvidence,
-	};
 }

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -6,7 +6,7 @@ import type { TrackerSnapshot } from "./local-tracker";
 import { hasChanged, hasRemoteChanged } from "./change-compare";
 import { sha256, digest, isLocallyComputable } from "../utils/hash";
 import { AsyncPool } from "../queue/async-queue";
-import { collectLocalRenameEvidence, completeIdentityEvidence } from "./identity-evidence";
+import { collectLocalRenameEvidence, completeIdentityEvidence, renameOptimizerView } from "./identity-evidence";
 import {
 	getRemoteChanges,
 	hasFolderRename,
@@ -15,6 +15,7 @@ import {
 } from "./remote-change-source";
 import {
 	confirmBaselineAbsences,
+	confirmCarriedRenameOppositeEndpoints,
 	confirmUnknownRenameEndpoints,
 	ensureRenameEndpointObservations,
 	exactEntity,
@@ -34,6 +35,7 @@ export interface ChangeDetectorDeps {
 	remoteFs: IFileSystem;
 	stateStore: SyncStateStore;
 	changes: TrackerSnapshot;
+	onRemoteIdentityEvidence?: (evidence: readonly IdentityEvidence[]) => void;
 }
 
 export interface CollectChangesOptions {
@@ -44,6 +46,8 @@ export interface CollectChangesOptions {
 	 * (the cursor has moved past them). A full remote list vs records can.
 	 */
 	forceFullScan?: boolean;
+	/** Durable local rename evidence replayed before endpoint confirmation/hash enrichment. */
+	carriedIdentityEvidence?: readonly IdentityEvidence[];
 }
 
 /**
@@ -66,7 +70,7 @@ export async function collectChanges(
 	// Determine temperature
 	if (!opts.forceFullScan && changes.initialized && changes.dirtyPaths.size > 0 &&
 		changes.folderRenamePairs.size === 0) {
-		const remoteChanges = await getRemoteChanges(deps.remoteFs);
+		const remoteChanges = await getRemoteChanges(deps.remoteFs, deps.onRemoteIdentityEvidence);
 		if (hasFolderRename(remoteChanges)) {
 			changeSet = await collectCold(
 				deps,
@@ -84,9 +88,16 @@ export async function collectChanges(
 			? await collectCold(deps, allRecords)
 			: await collectWarm(deps, allRecords);
 	}
-	changeSet.identityEvidence.unshift(...collectLocalRenameEvidence(changes));
+	changeSet.identityEvidence.unshift(...(opts.carriedIdentityEvidence ?? []),
+		...collectLocalRenameEvidence(changes));
 	ensureRenameEndpointObservations(changeSet.observations, changeSet.identityEvidence);
 	await confirmUnknownRenameEndpoints(changeSet, deps.localFs, deps.remoteFs);
+	await confirmCarriedRenameOppositeEndpoints(
+		changeSet.observations,
+		opts.carriedIdentityEvidence ?? [],
+		deps.localFs,
+		deps.remoteFs,
+	);
 
 	// WARM/COLD listings can under-report. Confirm every baseline path whose current
 	// side is missing before planning; a thrown stat aborts rather than becoming absence.
@@ -96,7 +107,8 @@ export async function collectChanges(
 	// Hash enrichment operates only on exact entries and cannot upgrade observations.
 	await enrichHashesForInitialMatch(changeSet.entries, deps.localFs);
 	await enrichHashesForRenames(
-		changeSet.entries, changeSet.observations, deps.localFs, changes.renamePairs,
+		changeSet.entries, changeSet.observations, deps.localFs,
+		renameOptimizerView(changeSet.identityEvidence).localFiles,
 	);
 	changeSet.identityEvidence = completeIdentityEvidence(
 		changeSet.identityEvidence,
@@ -179,7 +191,7 @@ async function collectWarm(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 
 	const [localFiles, remoteChanges] = await Promise.all([
 		localFs.list(),
-		getRemoteChanges(remoteFs),
+		getRemoteChanges(remoteFs, deps.onRemoteIdentityEvidence),
 	]);
 	if (hasFolderRename(remoteChanges)) {
 		return collectCold(

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -119,6 +119,11 @@ async function collectHot(deps: ChangeDetectorDeps): Promise<ChangeSet> {
 		if (!prev) return true;
 		// Local deleted but remote still exists (e.g. rename source)
 		if (!e.local && e.remote) return true;
+		// A checkpoint tombstone is authoritative remote absence. Preserve it even
+		// when the surviving local file is unchanged so the decision engine can
+		// propagate the deletion. Do not infer this from remote stat() absence alone:
+		// locally dirty paths also pass through HOT without a remote change signal.
+		if (e.local && !e.remote && remoteChanges.deletedPaths.has(e.path)) return true;
 		// Local changed
 		if (e.local && hasChanged(e.local, prev)) return true;
 		// Remote changed
@@ -335,15 +340,17 @@ async function confirmLocalDeletions(
 
 interface RemoteChanges {
 	paths: string[];
+	deletedPaths: ReadonlySet<string>;
 	renamed: RenamePair[];
 }
 
 async function getRemoteChanges(remoteFs: IFileSystem): Promise<RemoteChanges> {
-	if (!remoteFs.checkpoint) return { paths: [], renamed: [] };
+	if (!remoteFs.checkpoint) return { paths: [], deletedPaths: new Set(), renamed: [] };
 	const result = await remoteFs.checkpoint.getChangedPaths();
-	if (!result) return { paths: [], renamed: [] };
+	if (!result) return { paths: [], deletedPaths: new Set(), renamed: [] };
 	return {
 		paths: [...result.modified, ...result.deleted],
+		deletedPaths: new Set(result.deleted),
 		renamed: result.renamed ?? [],
 	};
 }

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -104,9 +104,10 @@ export async function collectChanges(
 	}
 	// Hash enrichment operates only on exact entries and cannot upgrade observations.
 	await enrichHashesForInitialMatch(changeSet.entries, deps.localFs);
+	const renameView = renameOptimizerView(changeSet.identityEvidence);
 	await enrichHashesForRenames(
 		changeSet.entries, changeSet.observations, deps.localFs,
-		renameOptimizerView(changeSet.identityEvidence).localFiles,
+		renameView.localFiles, renameView.localFolders,
 	);
 	changeSet.identityEvidence = completeIdentityEvidence(
 		changeSet.identityEvidence,

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -1,15 +1,24 @@
 import type { IFileSystem } from "../fs/interface";
-import type { MixedEntity, RenamePair, SyncRecord } from "./types";
+import type { IdentityEvidence, MixedEntity, PathObservation, RenameEvidence, SyncRecord } from "./types";
 import type { SyncStateStore } from "./state";
 import type { TrackerSnapshot } from "./local-tracker";
 import { hasChanged, hasRemoteChanged } from "./change-compare";
 import { sha256, digest, isLocallyComputable } from "../utils/hash";
 import { AsyncPool } from "../queue/async-queue";
+import { collectLocalRenameEvidence, collectRemoteRenameEvidence, completeIdentityEvidence } from "./identity-evidence";
+import {
+	confirmBaselineAbsences,
+	ensureRenameEndpointObservations,
+	exactEntity,
+	observePath,
+	replaceObservation,
+} from "./path-observation";
 
 export interface ChangeSet {
 	entries: MixedEntity[];
+	observations: PathObservation[];
+	identityEvidence: IdentityEvidence[];
 	temperature: "hot" | "warm" | "cold";
-	remoteRenamePairs: RenamePair[];
 }
 
 export interface ChangeDetectorDeps {
@@ -55,19 +64,24 @@ export async function collectChanges(
 			? await collectCold(deps, allRecords)
 			: await collectWarm(deps, allRecords);
 	}
+	changeSet.identityEvidence.unshift(...collectLocalRenameEvidence(changes));
+	ensureRenameEndpointObservations(changeSet.observations, changeSet.identityEvidence);
 
-	// Enrich empty hashes for entries without baseline (all temperature modes)
-	await enrichHashesForInitialMatch(changeSet.entries, deps.localFs);
-
-	// Ensure rename-related local entries have hashes (WARM/COLD use list() → hash:"")
-	await enrichHashesForRenames(changeSet.entries, deps.localFs, changes.renamePairs);
-
-	// Warm mode infers local deletions from absence in list() (the in-memory vault
-	// index), which can under-report. Confirm each candidate against the authoritative
-	// filesystem so an unindexed-but-on-disk file is never deleted.
-	if (changeSet.temperature === "warm") {
-		await confirmLocalDeletions(changeSet.entries, deps.localFs);
+	// WARM/COLD listings can under-report. Confirm every baseline path whose current
+	// side is missing before planning; a thrown stat aborts rather than becoming absence.
+	if (changeSet.temperature !== "hot") {
+		await confirmBaselineAbsences(changeSet, deps.localFs, deps.remoteFs);
 	}
+	// Hash enrichment operates only on exact entries and cannot upgrade observations.
+	await enrichHashesForInitialMatch(changeSet.entries, deps.localFs);
+	await enrichHashesForRenames(
+		changeSet.entries, changeSet.observations, deps.localFs, changes.renamePairs,
+	);
+	changeSet.identityEvidence = completeIdentityEvidence(
+		changeSet.identityEvidence,
+		changeSet.observations,
+		changeSet.entries,
+	);
 
 	return changeSet;
 }
@@ -94,15 +108,20 @@ async function collectHot(deps: ChangeDetectorDeps): Promise<ChangeSet> {
 		Promise.all(pathArray.map((p) => remoteFs.stat(p))),
 		stateStore.getMany(pathArray),
 	]);
+	const observations: PathObservation[] = [];
 
 	const entries: MixedEntity[] = pathArray.map((path, i) => {
-		const local = localStats[i] ?? undefined;
-		const remote = remoteStats[i] ?? undefined;
+		const localObservation = observePath("local", path, localStats[i]);
+		const remoteObservation = observePath(
+			"remote", path, remoteStats[i],
+			remoteChanges.deletedPaths.has(path) ? "checkpoint_deleted" : "stat",
+		);
+		observations.push(localObservation, remoteObservation);
 		const prevSync = syncRecords.get(path);
 		return {
 			path,
-			local: local?.isDirectory ? undefined : local,
-			remote: remote?.isDirectory ? undefined : remote,
+			local: exactEntity(localObservation),
+			remote: exactEntity(remoteObservation),
 			prevSync,
 		};
 	});
@@ -131,7 +150,7 @@ async function collectHot(deps: ChangeDetectorDeps): Promise<ChangeSet> {
 		return false;
 	});
 
-	return { entries: changed, temperature: "hot", remoteRenamePairs: remoteChanges.renamed };
+	return { entries: changed, observations, identityEvidence: remoteChanges.renameEvidence, temperature: "hot" };
 }
 
 async function collectWarm(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): Promise<ChangeSet> {
@@ -177,19 +196,32 @@ async function collectWarm(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 	const pathArray = Array.from(changedPaths);
 	const remoteStats = await Promise.all(pathArray.map((p) => remoteFs.stat(p)));
 
-	const localFileMap = new Map(localFiles.filter((f) => !f.isDirectory).map((f) => [f.path, f]));
+	const observations: PathObservation[] = localFiles.map((file) =>
+		observePath("local", file.path, file, "stat", "list"));
+	const localFileMap = new Map(observations.flatMap((observation) => {
+		const entity = exactEntity(observation);
+		return entity ? [[entity.path, entity] as const] : [];
+	}));
 
 	const entries: MixedEntity[] = pathArray.map((path, i) => {
-		const remote = remoteStats[i] ?? undefined;
+		const remoteObservation = observePath(
+			"remote", path, remoteStats[i],
+			remoteChanges.deletedPaths.has(path) ? "checkpoint_deleted" : "stat",
+		);
+		observations.push(remoteObservation);
+		if (!observations.some((observation) =>
+			observation.side === "local" && observation.requestedPath === path)) {
+			observations.push({ kind: "unknown", side: "local", requestedPath: path, reason: "not_observed" });
+		}
 		return {
 			path,
 			local: localFileMap.get(path),
-			remote: remote?.isDirectory ? undefined : remote,
+			remote: exactEntity(remoteObservation),
 			prevSync: recordMap.get(path),
 		};
 	});
 
-	return { entries, temperature: "warm", remoteRenamePairs: remoteChanges.renamed };
+	return { entries, observations, identityEvidence: remoteChanges.renameEvidence, temperature: "warm" };
 }
 
 async function collectCold(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): Promise<ChangeSet> {
@@ -202,6 +234,7 @@ async function collectCold(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 	const syncRecords = allRecords;
 
 	const pathMap = new Map<string, MixedEntity>();
+	const observations: PathObservation[] = [];
 
 	const getOrCreate = (path: string): MixedEntity => {
 		let entity = pathMap.get(path);
@@ -213,20 +246,24 @@ async function collectCold(deps: ChangeDetectorDeps, allRecords: SyncRecord[]): 
 	};
 
 	for (const file of localFiles) {
-		if (file.isDirectory) continue;
-		getOrCreate(file.path).local = file;
+		const observation = observePath("local", file.path, file, "stat", "list");
+		observations.push(observation);
+		const entity = exactEntity(observation);
+		if (entity) getOrCreate(entity.path).local = entity;
 	}
 
 	for (const file of remoteFiles) {
-		if (file.isDirectory) continue;
-		getOrCreate(file.path).remote = file;
+		const observation = observePath("remote", file.path, file, "stat", "list");
+		observations.push(observation);
+		const entity = exactEntity(observation);
+		if (entity) getOrCreate(entity.path).remote = entity;
 	}
 
 	for (const record of syncRecords) {
 		getOrCreate(record.path).prevSync = record;
 	}
 
-	return { entries: Array.from(pathMap.values()), temperature: "cold", remoteRenamePairs: [] };
+	return { entries: Array.from(pathMap.values()), observations, identityEvidence: [], temperature: "cold" };
 }
 
 /**
@@ -281,6 +318,7 @@ async function enrichHashesForInitialMatch(
  */
 export async function enrichHashesForRenames(
 	entries: MixedEntity[],
+	observations: PathObservation[],
 	localFs: IFileSystem,
 	renamePairs: ReadonlyMap<string, string>,
 ): Promise<void> {
@@ -294,63 +332,34 @@ export async function enrichHashesForRenames(
 
 	await Promise.all(
 		candidates.map(async (entry) => {
-			try {
-				const stat = await localFs.stat(entry.path);
-				if (stat && !stat.isDirectory && stat.hash) {
-					entry.local = { ...entry.local!, hash: stat.hash };
-				}
-			} catch {
-				// Skip — rename optimizer falls back to push+delete
-			}
+			const observation = observePath("local", entry.path, await localFs.stat(entry.path));
+			replaceObservation(observations, observation);
+			const statEntity = exactEntity(observation);
+			entry.local = statEntity
+				? { ...entry.local!, hash: statEntity.hash }
+				: undefined;
 		})
-	);
-}
-
-/**
- * Confirm warm-mode local deletions against the authoritative filesystem.
- * A baseline path absent from localFs.list() (the in-memory vault index) but
- * present on disk was simply not indexed — it was NOT deleted. Re-stat each such
- * candidate; if it exists, set entry.local so an incomplete listing cannot drive
- * an erroneous delete_remote. (When the remote is also gone, the file is then
- * compared as a genuine remote deletion rather than a no-op cleanup.)
- */
-async function confirmLocalDeletions(
-	entries: MixedEntity[],
-	localFs: IFileSystem,
-): Promise<void> {
-	const candidates = entries.filter((e) => !e.local && e.prevSync);
-	if (candidates.length === 0) return;
-
-	const pool = new AsyncPool(10);
-	await Promise.all(
-		candidates.map((entry) =>
-			pool.run(async () => {
-				try {
-					const stat = await localFs.stat(entry.path);
-					if (stat && !stat.isDirectory) {
-						entry.local = stat;
-					}
-				} catch {
-					// Skip — a genuinely missing file returns null/throws → stays a deletion
-				}
-			})
-		)
 	);
 }
 
 interface RemoteChanges {
 	paths: string[];
 	deletedPaths: ReadonlySet<string>;
-	renamed: RenamePair[];
+	renameEvidence: RenameEvidence[];
 }
 
 async function getRemoteChanges(remoteFs: IFileSystem): Promise<RemoteChanges> {
-	if (!remoteFs.checkpoint) return { paths: [], deletedPaths: new Set(), renamed: [] };
+	if (!remoteFs.checkpoint) return { paths: [], deletedPaths: new Set(), renameEvidence: [] };
 	const result = await remoteFs.checkpoint.getChangedPaths();
-	if (!result) return { paths: [], deletedPaths: new Set(), renamed: [] };
+	if (!result) return { paths: [], deletedPaths: new Set(), renameEvidence: [] };
+	const renameEvidence = collectRemoteRenameEvidence(result.renamed ?? []);
 	return {
-		paths: [...result.modified, ...result.deleted],
+		paths: [
+			...result.modified,
+			...result.deleted,
+			...renameEvidence.flatMap(({ oldPath, newPath }) => [oldPath, newPath]),
+		],
 		deletedPaths: new Set(result.deleted),
-		renamed: result.renamed ?? [],
+		renameEvidence,
 	};
 }

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -4,8 +4,7 @@ import type { IdentityEvidence, MixedEntity, PathObservation, SyncRecord } from 
 import type { SyncStateStore } from "./state";
 import type { TrackerSnapshot } from "./local-tracker";
 import { hasChanged, hasRemoteChanged } from "./change-compare";
-import { sha256, digest, isLocallyComputable } from "../utils/hash";
-import { AsyncPool } from "../queue/async-queue";
+import { enrichHashesForInitialMatch, enrichHashesForRenames } from "./change-hash-enrichment";
 import { collectLocalRenameEvidence, completeIdentityEvidence, renameOptimizerView } from "./identity-evidence";
 import {
 	getRemoteChanges,
@@ -14,13 +13,12 @@ import {
 	type RemoteChanges,
 } from "./remote-change-source";
 import {
-	confirmBaselineAbsences,
+	confirmEntryAbsences,
 	confirmCarriedRenameOppositeEndpoints,
 	confirmUnknownRenameEndpoints,
 	ensureRenameEndpointObservations,
 	exactEntity,
 	observePath,
-	replaceObservation,
 } from "./path-observation";
 
 export interface ChangeSet {
@@ -102,7 +100,7 @@ export async function collectChanges(
 	// WARM/COLD listings can under-report. Confirm every baseline path whose current
 	// side is missing before planning; a thrown stat aborts rather than becoming absence.
 	if (changeSet.temperature !== "hot") {
-		await confirmBaselineAbsences(changeSet, deps.localFs, deps.remoteFs);
+		await confirmEntryAbsences(changeSet, deps.localFs, deps.remoteFs);
 	}
 	// Hash enrichment operates only on exact entries and cannot upgrade observations.
 	await enrichHashesForInitialMatch(changeSet.entries, deps.localFs);
@@ -330,80 +328,4 @@ async function collectCold(
 		identityEvidence: remoteChanges?.renameEvidence ?? [],
 		temperature: "cold",
 	};
-}
-
-/**
- * Enrich empty hashes for entries without baseline by comparing the local
- * digest with the remote's backend-provided checksum. Runs for all temperature
- * modes to handle partial initial syncs and simultaneous file creation.
- *
- * Only fires when the remote checksum's algorithm is locally computable
- * (everything except `"opaque"` — md5/sha1/sha256/dropbox/quickxor). Backends
- * whose checksum is "opaque" (e.g. pCloud's internal content hash) cannot be
- * matched against local content, so their entries are skipped here and left to
- * the normal conflict path.
- */
-async function enrichHashesForInitialMatch(
-	entries: MixedEntity[],
-	localFs: IFileSystem,
-): Promise<void> {
-	const candidates = entries.filter(
-		(e) => e.local && e.remote && !e.prevSync &&
-			!e.local.hash && !e.remote.hash &&
-			e.local.size === e.remote.size &&
-			e.remote.remoteChecksum !== undefined &&
-			isLocallyComputable(e.remote.remoteChecksum.algo)
-	);
-	if (candidates.length === 0) return;
-
-	const pool = new AsyncPool(10);
-	await Promise.all(
-		candidates.map((entry) =>
-			pool.run(async () => {
-				try {
-					const remoteChecksum = entry.remote!.remoteChecksum!;
-					const content = await localFs.read(entry.path);
-					const localDigest = await digest(content, remoteChecksum.algo);
-					if (localDigest === remoteChecksum.value) {
-						const contentHash = await sha256(content);
-						entry.local = { ...entry.local!, hash: contentHash };
-						entry.remote = { ...entry.remote!, hash: contentHash };
-					}
-				} catch {
-					// Skip failed reads — entry stays unenriched (conflict, safe side)
-				}
-			})
-		)
-	);
-}
-
-/**
- * Ensure rename destination entries have hashes via stat().
- * In WARM/COLD mode, list() returns hash:"" — the rename optimizer
- * needs a real hash to verify content equivalence.
- */
-export async function enrichHashesForRenames(
-	entries: MixedEntity[],
-	observations: PathObservation[],
-	localFs: IFileSystem,
-	renamePairs: ReadonlyMap<string, string>,
-): Promise<void> {
-	if (renamePairs.size === 0) return;
-
-	const newPaths = new Set(renamePairs.keys());
-	const candidates = entries.filter(
-		(e) => newPaths.has(e.path) && e.local && !e.local.hash,
-	);
-	if (candidates.length === 0) return;
-
-	await Promise.all(
-		candidates.map(async (entry) => {
-			const observation = observePath("local", entry.path, await localFs.stat(entry.path));
-			replaceObservation(observations, observation);
-			const statEntity = exactEntity(observation);
-			entry.local = statEntity
-				? { ...entry.local!, hash: statEntity.hash }
-				: undefined;
-		})
-	);
 }

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -94,9 +94,18 @@ async function collectHot(deps: ChangeDetectorDeps): Promise<ChangeSet> {
 		Promise.all(pathArray.map((p) => remoteFs.stat(p))),
 		stateStore.getMany(pathArray),
 	]);
+	const renameSourcePaths = new Set(changes.renamePairs.values());
 
 	const entries: MixedEntity[] = pathArray.map((path, i) => {
-		const local = localStats[i] ?? undefined;
+		const localStat = localStats[i] ?? undefined;
+		// A case-insensitive filesystem can resolve a recorded rename source to
+		// the destination file. The tracker is authoritative for the logical
+		// rename: only accept the source as still present when stat() returns that
+		// exact path (for example, the user recreated the source before syncing).
+		const isRenameSourceAlias =
+			renameSourcePaths.has(path) &&
+			localStat?.path !== path;
+		const local = isRenameSourceAlias ? undefined : localStat;
 		const remote = remoteStats[i] ?? undefined;
 		const prevSync = syncRecords.get(path);
 		return {

--- a/src/sync/change-hash-enrichment.ts
+++ b/src/sync/change-hash-enrichment.ts
@@ -38,15 +38,19 @@ export async function enrichHashesForRenames(
 	observations: PathObservation[],
 	localFs: IFileSystem,
 	renamePairs: ReadonlyMap<string, string>,
+	folderRenamePairs: ReadonlyMap<string, string> = new Map(),
 ): Promise<void> {
 	const newPaths = new Set(renamePairs.keys());
+	const newFolderPrefixes = [...folderRenamePairs.keys()].map((path) => path + "/");
 	const candidates = entries.filter(
-		(entry) => newPaths.has(entry.path) && entry.local && !entry.local.hash,
+		(entry) => entry.local && !entry.local.isDirectory && !entry.local.hash &&
+			(newPaths.has(entry.path) || newFolderPrefixes.some((prefix) => entry.path.startsWith(prefix))),
 	);
-	await Promise.all(candidates.map(async (entry) => {
+	const pool = new AsyncPool(10);
+	await Promise.all(candidates.map((entry) => pool.run(async () => {
 		const observation = observePath("local", entry.path, await localFs.stat(entry.path));
 		replaceObservation(observations, observation);
 		const statEntity = exactEntity(observation);
 		entry.local = statEntity ? { ...entry.local!, hash: statEntity.hash } : undefined;
-	}));
+	})));
 }

--- a/src/sync/change-hash-enrichment.ts
+++ b/src/sync/change-hash-enrichment.ts
@@ -1,0 +1,52 @@
+import type { IFileSystem } from "../fs/interface";
+import { AsyncPool } from "../queue/async-queue";
+import { digest, isLocallyComputable, sha256 } from "../utils/hash";
+import { exactEntity, observePath, replaceObservation } from "./path-observation";
+import type { MixedEntity, PathObservation } from "./types";
+
+/** Enrich initial same-size pairs when the remote checksum is locally reproducible. */
+export async function enrichHashesForInitialMatch(
+	entries: MixedEntity[],
+	localFs: IFileSystem,
+): Promise<void> {
+	const candidates = entries.filter(
+		(entry) => entry.local && entry.remote && !entry.prevSync &&
+			!entry.local.hash && !entry.remote.hash &&
+			entry.local.size === entry.remote.size &&
+			entry.remote.remoteChecksum !== undefined &&
+			isLocallyComputable(entry.remote.remoteChecksum.algo),
+	);
+	const pool = new AsyncPool(10);
+	await Promise.all(candidates.map((entry) => pool.run(async () => {
+		try {
+			const remoteChecksum = entry.remote!.remoteChecksum!;
+			const content = await localFs.read(entry.path);
+			if (await digest(content, remoteChecksum.algo) === remoteChecksum.value) {
+				const hash = await sha256(content);
+				entry.local = { ...entry.local!, hash };
+				entry.remote = { ...entry.remote!, hash };
+			}
+		} catch {
+			// A failed read stays unenriched and therefore takes the safe conflict path.
+		}
+	})));
+}
+
+/** Resolve and hash rename destinations that came from hash-free listings. */
+export async function enrichHashesForRenames(
+	entries: MixedEntity[],
+	observations: PathObservation[],
+	localFs: IFileSystem,
+	renamePairs: ReadonlyMap<string, string>,
+): Promise<void> {
+	const newPaths = new Set(renamePairs.keys());
+	const candidates = entries.filter(
+		(entry) => newPaths.has(entry.path) && entry.local && !entry.local.hash,
+	);
+	await Promise.all(candidates.map(async (entry) => {
+		const observation = observePath("local", entry.path, await localFs.stat(entry.path));
+		replaceObservation(observations, observation);
+		const statEntity = exactEntity(observation);
+		entry.local = statEntity ? { ...entry.local!, hash: statEntity.hash } : undefined;
+	}));
+}

--- a/src/sync/conflict-resolver.test.ts
+++ b/src/sync/conflict-resolver.test.ts
@@ -2,19 +2,19 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { resolveConflict } from "./conflict-resolver";
 import type { SyncRecord } from "./types";
 import {
-	createMockFs,
+	createMockLocalFs, createMockRemoteFs, type MockFileSystem,
 	createMockStateStore,
 	addFile,
 	readText,
 } from "../__mocks__/sync-test-helpers";
 
 describe("resolveConflict", () => {
-	let localFs: ReturnType<typeof createMockFs>;
-	let remoteFs: ReturnType<typeof createMockFs>;
+	let localFs: MockFileSystem;
+	let remoteFs: MockFileSystem;
 
 	beforeEach(() => {
-		localFs = createMockFs("local");
-		remoteFs = createMockFs("remote");
+		localFs = createMockLocalFs();
+		remoteFs = createMockRemoteFs();
 	});
 
 	describe("duplicate strategy", () => {

--- a/src/sync/conflict.test.ts
+++ b/src/sync/conflict.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { resolveWithStrategy, generateConflictPath } from "./conflict";
 import {
-	createMockFs,
+	createMockLocalFs, createMockRemoteFs, type MockFileSystem,
 	createMockStateStore,
 	addFile,
 	readText,
@@ -13,12 +13,12 @@ function encode(s: string): ArrayBuffer {
 }
 
 describe("resolveWithStrategy", () => {
-	let localFs: ReturnType<typeof createMockFs>;
-	let remoteFs: ReturnType<typeof createMockFs>;
+	let localFs: MockFileSystem;
+	let remoteFs: MockFileSystem;
 
 	beforeEach(() => {
-		localFs = createMockFs("local");
-		remoteFs = createMockFs("remote");
+		localFs = createMockLocalFs();
+		remoteFs = createMockRemoteFs();
 	});
 
 	describe("keep_newer", () => {
@@ -189,16 +189,16 @@ describe("resolveWithStrategy", () => {
 
 describe("generateConflictPath", () => {
 	it("returns the .conflict path when it is free", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		expect(
 			await generateConflictPath("notes/file.md", localFs, remoteFs),
 		).toBe("notes/file.conflict.md");
 	});
 
 	it("numbers sequentially when the conflict path is occupied on any side", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		addFile(remoteFs, "notes/file.conflict.md", "already here");
 		expect(
 			await generateConflictPath("notes/file.md", localFs, remoteFs),

--- a/src/sync/convergence.test.ts
+++ b/src/sync/convergence.test.ts
@@ -5,7 +5,7 @@ import { refinePlan } from "./rename-optimizer";
 import { executePlan } from "./plan-executor";
 import { LocalChangeTracker } from "./local-tracker";
 import {
-	createMockFs,
+	confirmMockPath, createMockLocalFs, createMockRemoteFs, type MockFileSystem,
 	createMockStateStore,
 	addFile,
 	readText,
@@ -30,16 +30,16 @@ import type { RenamePair, SyncPlan } from "./types";
  */
 
 interface Env {
-	localFs: ReturnType<typeof createMockFs>;
-	remoteFs: ReturnType<typeof createMockFs>;
+	localFs: MockFileSystem;
+	remoteFs: MockFileSystem;
 	stateStore: ReturnType<typeof createMockStateStore>;
 	localTracker: LocalChangeTracker;
 }
 
 function makeEnv(): Env {
 	return {
-		localFs: createMockFs("local"),
-		remoteFs: createMockFs("remote"),
+		localFs: createMockLocalFs(),
+		remoteFs: createMockRemoteFs(),
 		stateStore: createMockStateStore(),
 		localTracker: new LocalChangeTracker(),
 	};
@@ -183,6 +183,7 @@ describe("sync converges to a fixed point", () => {
 
 		// The folder is renamed on the remote: move it there and report the rename once.
 		await env.remoteFs.rename("dir", "papers");
+		confirmMockPath(env.remoteFs, "papers");
 		deliverOnce(env, {
 			modified: ["papers/b.md", "papers/c.md"],
 			deleted: ["dir/b.md", "dir/c.md"],
@@ -210,6 +211,7 @@ describe("sync converges to a fixed point", () => {
 		expect(actionTypes(await runCycle(env))).toEqual(["push"]);
 
 		await env.remoteFs.rename("note.md", "renamed.md");
+		confirmMockPath(env.remoteFs, "renamed.md");
 		deliverOnce(env, {
 			modified: ["renamed.md"],
 			deleted: ["note.md"],

--- a/src/sync/convergence.test.ts
+++ b/src/sync/convergence.test.ts
@@ -66,9 +66,7 @@ async function runCycle(env: Env): Promise<SyncPlan> {
 	});
 	const plan = refinePlan(
 		planSync(changeSet.entries),
-		snapshot.renamePairs,
-		snapshot.folderRenamePairs,
-		changeSet.remoteRenamePairs,
+		changeSet.identityEvidence,
 	);
 	await executePlan(plan, {
 		localFs,

--- a/src/sync/convergence.test.ts
+++ b/src/sync/convergence.test.ts
@@ -11,6 +11,8 @@ import {
 	readText,
 } from "../__mocks__/sync-test-helpers";
 import type { RenamePair, SyncPlan } from "./types";
+import { admitDestructivePlan, captureCycleAdmissionSnapshot } from "./plan-admission";
+import { projectScope } from "./scope-projection";
 
 /**
  * Convergence (fixed-point) contract — the emergent property the whole engine
@@ -68,7 +70,11 @@ async function runCycle(env: Env): Promise<SyncPlan> {
 		planSync(changeSet.entries),
 		changeSet.identityEvidence,
 	);
-	await executePlan(plan, {
+	const scope = projectScope(changeSet, { classifyPath: () => "included" });
+	const admission = admitDestructivePlan(captureCycleAdmissionSnapshot(
+		plan, changeSet.identityEvidence, changeSet.observations, scope, "convergence-test",
+	));
+	await executePlan(admission.executable, {
 		localFs,
 		remoteFs,
 		committer: { stateStore },

--- a/src/sync/crash-safety.test.ts
+++ b/src/sync/crash-safety.test.ts
@@ -6,7 +6,7 @@ import { executePlan } from "./plan-executor";
 import type { ExecutionResult } from "./plan-executor";
 import { LocalChangeTracker } from "./local-tracker";
 import {
-	createMockFs,
+	createMockLocalFs, createMockRemoteFs, type MockFileSystem,
 	createMockStateStore,
 	addFile,
 	readText,
@@ -25,16 +25,16 @@ import type { SyncPlan } from "./types";
  */
 
 interface Env {
-	localFs: ReturnType<typeof createMockFs>;
-	remoteFs: ReturnType<typeof createMockFs>;
+	localFs: MockFileSystem;
+	remoteFs: MockFileSystem;
 	stateStore: ReturnType<typeof createMockStateStore>;
 	localTracker: LocalChangeTracker;
 }
 
 function makeEnv(): Env {
 	return {
-		localFs: createMockFs("local"),
-		remoteFs: createMockFs("remote"),
+		localFs: createMockLocalFs(),
+		remoteFs: createMockRemoteFs(),
 		stateStore: createMockStateStore(),
 		localTracker: new LocalChangeTracker(),
 	};

--- a/src/sync/crash-safety.test.ts
+++ b/src/sync/crash-safety.test.ts
@@ -56,9 +56,7 @@ async function runCycle(
 	});
 	const plan = refinePlan(
 		planSync(changeSet.entries),
-		snapshot.renamePairs,
-		snapshot.folderRenamePairs,
-		changeSet.remoteRenamePairs,
+		changeSet.identityEvidence,
 	);
 	const result = await executePlan(plan, {
 		localFs,

--- a/src/sync/crash-safety.test.ts
+++ b/src/sync/crash-safety.test.ts
@@ -12,6 +12,8 @@ import {
 	readText,
 } from "../__mocks__/sync-test-helpers";
 import type { SyncPlan } from "./types";
+import { admitDestructivePlan, captureCycleAdmissionSnapshot } from "./plan-admission";
+import { projectScope } from "./scope-projection";
 
 /**
  * Crash-safety contract (ARCHITECTURE.md design principle #5,
@@ -58,7 +60,11 @@ async function runCycle(
 		planSync(changeSet.entries),
 		changeSet.identityEvidence,
 	);
-	const result = await executePlan(plan, {
+	const scope = projectScope(changeSet, { classifyPath: () => "included" });
+	const admission = admitDestructivePlan(captureCycleAdmissionSnapshot(
+		plan, changeSet.identityEvidence, changeSet.observations, scope, "crash-safety-test",
+	));
+	const result = await executePlan(admission.executable, {
 		localFs,
 		remoteFs,
 		committer: { stateStore },

--- a/src/sync/delete-safety.test.ts
+++ b/src/sync/delete-safety.test.ts
@@ -4,7 +4,7 @@ import { executePlan } from "./plan-executor";
 import { collectChanges } from "./change-detector";
 import { LocalChangeTracker } from "./local-tracker";
 import {
-	createMockFs,
+	createMockLocalFs, createMockRemoteFs,
 	createMockStateStore,
 	addFile,
 } from "../__mocks__/sync-test-helpers";
@@ -66,8 +66,8 @@ describe("§2-1 (fixed): a lone deletion is no longer silently aborted", () => {
 	});
 
 	it("a lone delete_remote actually executes (no abort path remains)", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		const stateStore = createMockStateStore();
 		addFile(remoteFs, "note.md", CONTENT, 1000);
 		await stateStore.put(baselineRecord("note.md"));
@@ -95,8 +95,8 @@ describe("phantom warm deletion: an incomplete listing does not mass-delete", ()
 	// against the authoritative filesystem; the files exist on disk, so no
 	// deletion is planned. This is prevention at the source — not recovery.
 	it("a warm sync whose listing omits on-disk files plans zero delete_remote", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		const stateStore = createMockStateStore();
 		const localTracker = new LocalChangeTracker();
 
@@ -130,8 +130,8 @@ describe("phantom warm deletion: an incomplete listing does not mass-delete", ()
 	});
 
 	it("a genuinely deleted file (absent on disk too) is still planned as delete_remote", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		const stateStore = createMockStateStore();
 		const localTracker = new LocalChangeTracker();
 

--- a/src/sync/delete-safety.test.ts
+++ b/src/sync/delete-safety.test.ts
@@ -11,6 +11,7 @@ import {
 import type { MixedEntity, SyncRecord } from "./types";
 import type { FileEntity } from "../fs/types";
 import { sha256 } from "../utils/hash";
+import { admitDestructivePlan, captureCycleAdmissionSnapshot } from "./plan-admission";
 
 /**
  * Delete-safety contracts.
@@ -72,8 +73,15 @@ describe("§2-1 (fixed): a lone deletion is no longer silently aborted", () => {
 		addFile(remoteFs, "note.md", CONTENT, 1000);
 		await stateStore.put(baselineRecord("note.md"));
 
-		const result = await executePlan(
+		const admission = admitDestructivePlan(captureCycleAdmissionSnapshot(
 			{ actions: [{ path: "note.md", action: "delete_remote" }] },
+			[],
+			[{ kind: "absent", side: "local", requestedPath: "note.md", authority: "stat" }],
+			{ byEndpoint: new Map([["note.md", "included"]]) },
+			"delete-safety-test",
+		));
+		const result = await executePlan(
+			admission.executable,
 			{
 				localFs,
 				remoteFs,

--- a/src/sync/delta-first.test.ts
+++ b/src/sync/delta-first.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { collectChanges } from "./change-detector";
 import { LocalChangeTracker } from "./local-tracker";
 import {
-	createMockFs,
+	createMockLocalFs, createMockRemoteFs,
 	createMockStateStore,
 	addFile,
 } from "../__mocks__/sync-test-helpers";
@@ -33,8 +33,8 @@ function baseline(path: string): SyncRecord {
 
 describe("the hot path is O(delta), not O(vault)", () => {
 	it("stats only the dirty path and never lists the whole vault", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		const stateStore = createMockStateStore();
 		const localTracker = new LocalChangeTracker();
 
@@ -76,8 +76,8 @@ describe("the hot path is O(delta), not O(vault)", () => {
 	});
 
 	it("cold start is the one place a full scan is allowed", async () => {
-		const localFs = createMockFs("local");
-		const remoteFs = createMockFs("remote");
+		const localFs = createMockLocalFs();
+		const remoteFs = createMockRemoteFs();
 		const stateStore = createMockStateStore();
 		const localTracker = new LocalChangeTracker();
 

--- a/src/sync/execution-result.ts
+++ b/src/sync/execution-result.ts
@@ -1,6 +1,7 @@
 import type { FileEntity } from "../fs/types";
 import type { ConflictRecord, ConflictStrategy, SyncAction } from "./types";
 import type { ConflictResolutionResult } from "./conflict-resolver";
+import type { DeferredComponent } from "./plan-admission";
 
 export interface CompletedAction {
 	action: SyncAction;
@@ -30,6 +31,7 @@ export interface ExecutionResult {
 	failed: FailedAction[];
 	blocked: BlockedAction[];
 	conflicts: ResolvedConflict[];
+	deferred: DeferredComponent[];
 }
 
 export function toConflictRecords(

--- a/src/sync/identity-evidence.test.ts
+++ b/src/sync/identity-evidence.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { FileEntity } from "../fs/types";
+import type { MixedEntity, PathObservation } from "./types";
+import {
+	collectLocalRenameEvidence,
+	collectRemoteRenameEvidence,
+	completeIdentityEvidence,
+	renameOptimizerView,
+} from "./identity-evidence";
+
+describe("identity evidence", () => {
+	it("normalizes tracker and checkpoint reports into one rename representation", () => {
+		const local = collectLocalRenameEvidence({
+			dirtyPaths: new Set(), renamePairs: new Map([["b.md", "a.md"]]),
+			folderRenamePairs: new Map([["Docs", "docs"]]), initialized: true,
+		});
+		const remote = collectRemoteRenameEvidence([
+			{ oldPath: "x.md", newPath: "y.md" },
+			{ oldPath: "x.md", newPath: "y.md" },
+		]);
+
+		expect(local).toHaveLength(2);
+		expect(remote).toEqual([{
+			kind: "rename", side: "remote", oldPath: "x.md", newPath: "y.md",
+			isFolder: false, authority: "reported",
+		}]);
+		const view = renameOptimizerView([...local, ...remote]);
+		expect(view.localFiles.get("b.md")).toBe("a.md");
+		expect(view.localFolders.get("Docs")).toBe("docs");
+		expect(view.remote).toEqual([{ oldPath: "x.md", newPath: "y.md", isFolder: undefined }]);
+	});
+
+	it("attaches native identity and relates cross-path baseline/current occurrences", () => {
+		const remote: FileEntity = {
+			path: "b.md", pathAuthority: "actual_resolved", identityKey: "id-1",
+			isDirectory: false, size: 1, mtime: 1, hash: "",
+		};
+		const observations: PathObservation[] = [
+			{ kind: "exact", side: "remote", requestedPath: "b.md", entity: remote },
+		];
+		const entries: MixedEntity[] = [{
+			path: "a.md",
+			prevSync: {
+				path: "a.md", hash: "h", localMtime: 1, remoteMtime: 1,
+				localSize: 1, remoteSize: 1, remoteIdentityKey: "id-1", syncedAt: 1,
+			},
+		}, { path: "b.md", remote }];
+		const completed = completeIdentityEvidence(
+			collectRemoteRenameEvidence([{ oldPath: "a.md", newPath: "b.md" }]),
+			observations,
+			entries,
+		);
+
+		expect(completed[0]).toMatchObject({ kind: "rename", identityKey: "id-1" });
+		expect(completed).toContainEqual({
+			kind: "stable_identity", side: "remote", identityKey: "id-1",
+			occurrences: [
+				{ side: "remote", phase: "baseline", path: "a.md", identityKey: "id-1" },
+				{ side: "remote", phase: "current", path: "b.md", identityKey: "id-1" },
+			],
+		});
+	});
+
+	it("does not create cross-path evidence for ordinary same-path continuity", () => {
+		const remote: FileEntity = {
+			path: "a.md", pathAuthority: "actual_resolved", identityKey: "id-1",
+			isDirectory: false, size: 1, mtime: 1, hash: "",
+		};
+		const completed = completeIdentityEvidence([], [
+			{ kind: "exact", side: "remote", requestedPath: "a.md", entity: remote },
+		], [{
+			path: "a.md", remote,
+			prevSync: {
+				path: "a.md", hash: "h", localMtime: 1, remoteMtime: 1,
+				localSize: 1, remoteSize: 1, remoteIdentityKey: "id-1", syncedAt: 1,
+			},
+		}]);
+
+		expect(completed).toEqual([]);
+	});
+});

--- a/src/sync/identity-evidence.ts
+++ b/src/sync/identity-evidence.ts
@@ -1,0 +1,108 @@
+import type { RenamePair } from "../fs/types";
+import type { EntityOccurrence, IdentityEvidence, MixedEntity, PathObservation, RenameEvidence } from "./types";
+import type { TrackerSnapshot } from "./local-tracker";
+
+export function collectLocalRenameEvidence(changes: TrackerSnapshot): RenameEvidence[] {
+	return dedupeRenameEvidence([
+		...[...changes.renamePairs].map(([newPath, oldPath]): RenameEvidence => ({
+			kind: "rename", side: "local", oldPath, newPath, isFolder: false, authority: "reported",
+		})),
+		...[...changes.folderRenamePairs].map(([newPath, oldPath]): RenameEvidence => ({
+			kind: "rename", side: "local", oldPath, newPath, isFolder: true, authority: "reported",
+		})),
+	]);
+}
+
+export function collectRemoteRenameEvidence(pairs: readonly RenamePair[]): RenameEvidence[] {
+	return dedupeRenameEvidence(pairs.map(({ oldPath, newPath, isFolder }): RenameEvidence => ({
+		kind: "rename", side: "remote", oldPath, newPath, isFolder: isFolder === true, authority: "reported",
+	})));
+}
+
+export function renameOptimizerView(evidence: readonly IdentityEvidence[]): {
+	localFiles: ReadonlyMap<string, string>;
+	localFolders: ReadonlyMap<string, string>;
+	remote: RenamePair[];
+} {
+	const localFiles = new Map<string, string>();
+	const localFolders = new Map<string, string>();
+	const remote: RenamePair[] = [];
+	for (const item of evidence) {
+		if (item.kind !== "rename") continue;
+		if (item.side === "remote") {
+			remote.push({ oldPath: item.oldPath, newPath: item.newPath, isFolder: item.isFolder || undefined });
+		} else {
+			(item.isFolder ? localFolders : localFiles).set(item.newPath, item.oldPath);
+		}
+	}
+	return { localFiles, localFolders, remote };
+}
+
+export function completeIdentityEvidence(
+	reported: readonly IdentityEvidence[],
+	observations: readonly PathObservation[],
+	entries: readonly MixedEntity[],
+): IdentityEvidence[] {
+	const currentRemote = new Map<string, string>();
+	for (const observation of observations) {
+		if (observation.side !== "remote" ||
+			(observation.kind !== "exact" && observation.kind !== "alias")) continue;
+		const path = observation.kind === "alias" ? observation.resolvedPath : observation.requestedPath;
+		if (observation.entity.identityKey) currentRemote.set(path, observation.entity.identityKey);
+	}
+	for (const entry of entries) {
+		if (entry.remote?.identityKey) currentRemote.set(entry.path, entry.remote.identityKey);
+	}
+	const completed = reported.map((item): IdentityEvidence =>
+		item.kind === "rename" && item.side === "remote" && !item.identityKey
+			? { ...item, identityKey: currentRemote.get(item.newPath) }
+			: item);
+
+	for (const observation of observations) {
+		if (observation.kind === "alias") {
+			completed.push({
+				kind: "alias", side: observation.side, requestedPath: observation.requestedPath,
+				resolvedPath: observation.resolvedPath,
+			});
+		}
+	}
+
+	const byIdentity = new Map<string, EntityOccurrence[]>();
+	for (const entry of entries) {
+		if (entry.prevSync?.remoteIdentityKey) {
+			appendOccurrence(byIdentity, entry.prevSync.remoteIdentityKey, {
+				side: "remote", phase: "baseline", path: entry.path,
+				identityKey: entry.prevSync.remoteIdentityKey,
+			});
+		}
+	}
+	for (const [path, identityKey] of currentRemote) {
+		appendOccurrence(byIdentity, identityKey, {
+			side: "remote", phase: "current", path, identityKey,
+		});
+	}
+	for (const [identityKey, occurrences] of byIdentity) {
+		if (new Set(occurrences.map((occurrence) => occurrence.path)).size > 1) {
+			completed.push({ kind: "stable_identity", side: "remote", identityKey, occurrences });
+		}
+	}
+	return completed;
+}
+
+function appendOccurrence(
+	byIdentity: Map<string, EntityOccurrence[]>,
+	identityKey: string,
+	occurrence: EntityOccurrence,
+): void {
+	const occurrences = byIdentity.get(identityKey) ?? [];
+	occurrences.push(occurrence);
+	byIdentity.set(identityKey, occurrences);
+}
+
+function dedupeRenameEvidence(evidence: RenameEvidence[]): RenameEvidence[] {
+	const unique = new Map<string, RenameEvidence>();
+	for (const item of evidence) {
+		unique.set(JSON.stringify([item.side, item.oldPath, item.newPath, item.isFolder]), item);
+	}
+	return [...unique.values()];
+}

--- a/src/sync/local-tracker.test.ts
+++ b/src/sync/local-tracker.test.ts
@@ -196,9 +196,10 @@ describe("LocalChangeTracker", () => {
 	});
 
 	describe("markFolderRenamed", () => {
-		it("records folder rename pair", () => {
+		it("records folder rename pair without pretending roots cover descendants", () => {
 			tracker.markFolderRenamed("B", "A");
 			expect(tracker.getFolderRenamePairs().get("B")).toBe("A");
+			expect(tracker.getDirtyPaths().size).toBe(0);
 		});
 
 		it("collapses folder rename chain A→B→C into A→C", () => {

--- a/src/sync/optimize-local-renames.test.ts
+++ b/src/sync/optimize-local-renames.test.ts
@@ -235,7 +235,7 @@ describe("optimizeLocalFileRenames", () => {
 });
 
 describe("coalesceLocalFolderRenames", () => {
-	it("coalesces all child file renames into a single folder rename_remote", () => {
+	it("derives all child mappings from actions for a folder-only event", () => {
 		const actions: SyncAction[] = [
 			{
 				path: "A/f1.md",
@@ -253,10 +253,7 @@ describe("coalesceLocalFolderRenames", () => {
 			{ path: "B/f2.md", action: "push", local: entity("B/f2.md", "h2") },
 		];
 		const folderPairs = new Map([["B", "A"]]);
-		const filePairs = new Map([
-			["B/f1.md", "A/f1.md"],
-			["B/f2.md", "A/f2.md"],
-		]);
+		const filePairs = new Map<string, string>();
 		const result = coalesceLocalFolderRenames(
 			actions,
 			folderPairs,

--- a/src/sync/optimize-local-renames.ts
+++ b/src/sync/optimize-local-renames.ts
@@ -106,14 +106,24 @@ export function coalesceLocalFolderRenames(
 		const oldPrefix = oldFolder + "/";
 		const newPrefix = newFolder + "/";
 
-		const descendants: RenamePair[] = [];
-		let skipReason: SkippedRename["reason"] | null = null;
-
+		const descendantPairs = new Map<string, string>();
+		for (const action of actions) {
+			if (action.action !== "delete_remote" || !action.path.startsWith(oldPrefix)) continue;
+			const suffix = action.path.substring(oldPrefix.length);
+			descendantPairs.set(newPrefix + suffix, action.path);
+		}
+		// File events are optional corroboration. Obsidian reports a TFolder rename
+		// as one root edge, so the cycle action inventory is the descendant SSOT.
 		for (const [newFile, oldFile] of fileRenamePairs) {
 			if (!oldFile.startsWith(oldPrefix) || !newFile.startsWith(newPrefix)) continue;
 			const suffix = oldFile.substring(oldPrefix.length);
-			if (newFile !== newPrefix + suffix) continue;
+			if (newFile === newPrefix + suffix) descendantPairs.set(newFile, oldFile);
+		}
 
+		const descendants: RenamePair[] = [];
+		let skipReason: SkippedRename["reason"] | null = null;
+
+		for (const [newFile, oldFile] of descendantPairs) {
 			const del = byPath.get(oldFile);
 			const push = byPath.get(newFile);
 			if (!del || !push || !isValidLocalRename(del, push)) {
@@ -132,7 +142,7 @@ export function coalesceLocalFolderRenames(
 			continue;
 		}
 
-		if (descendants.length === 0) {
+		if (descendantPairs.size === 0) {
 			skipped.push({ pair: { oldPath: oldFolder, newPath: newFolder }, reason: "no_descendants" });
 			logger?.debug("Folder rename coalescing skipped", { oldFolder, newFolder, reason: "no_descendants" });
 			continue;

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -391,6 +391,57 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
+		// Regression (issue #43): Windows resolves the source spelling of a case-only
+		// rename to the same on-disk file. The tracker is authoritative that the old
+		// logical path was renamed, so that alias must not make the old endpoint look
+		// locally present and suppress the delete_remote half of the rename pair.
+		it("optimizes a case-only local rename on a case-insensitive filesystem", async () => {
+			const deps = createDeps();
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			deps.localFs = () => localFs;
+			deps.remoteFs = () => remoteFs;
+
+			const localEntity = addFile(localFs, "PRUEBa.md", "content", 1000);
+			localEntity.hash = "h1";
+			const remoteEntity = addFile(remoteFs, "PRUEBA.md", "content", 1000);
+			remoteEntity.hash = "h1";
+
+			// Model Windows/Obsidian adapter fallback: stat(old spelling) resolves the
+			// file now indexed under the new spelling instead of reporting it absent.
+			const exactStat = localFs.stat.bind(localFs);
+			vi.spyOn(localFs, "stat").mockImplementation(async (path) => {
+				const exact = await exactStat(path);
+				if (exact) return exact;
+				const alias = [...localFs.files.keys()].find(
+					(candidate) => candidate.toLowerCase() === path.toLowerCase(),
+				);
+				return alias ? exactStat(alias) : null;
+			});
+
+			deps.localTracker.acknowledge(deps.localTracker.snapshot());
+			deps.localTracker.markRenamed("PRUEBa.md", "PRUEBA.md");
+
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "PRUEBA.md",
+				hash: "h1",
+				localMtime: 1000,
+				remoteMtime: 1000,
+				localSize: 7,
+				remoteSize: 7,
+				syncedAt: 900,
+			});
+
+			const renameSpy = vi.spyOn(remoteFs, "rename");
+			const writeSpy = vi.spyOn(remoteFs, "write");
+			await orchestrator.runSync();
+
+			expect(renameSpy).toHaveBeenCalledWith("PRUEBA.md", "PRUEBa.md");
+			expect(writeSpy).not.toHaveBeenCalled();
+			await orchestrator.close();
+		});
+
 		it("acknowledges dirty paths after sync", async () => {
 			const deps = createDeps();
 			const localFs = createMockFs("local");

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -203,6 +203,48 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
+		it("executes a remote case-only rename when local destination stat aliases the source", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			addFile(localFs, "C.md", "same", 1000);
+			addFile(remoteFs, "c.md", "same", 1000);
+			confirmMockPath(remoteFs, "c.md");
+			const settings = baseMockSettings({ backendType: "test", vaultId: `test-${Math.random()}` });
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			remoteFs.checkpoint!.getChangedPaths = vi.fn().mockResolvedValue({
+				modified: ["c.md"], deleted: ["C.md"],
+				renamed: [{ oldPath: "C.md", newPath: "c.md" }],
+			});
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const exactLocalStat = localFs.stat.bind(localFs);
+			vi.spyOn(localFs, "stat").mockImplementation(async (path) => {
+				const exact = await exactLocalStat(path);
+				if (exact || path !== "c.md") return exact;
+				return exactLocalStat("C.md");
+			});
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "C.md", hash: "baseline", localMtime: 1000, remoteMtime: 1000,
+				localSize: 4, remoteSize: 4, syncedAt: 900,
+			});
+			const localRename = vi.spyOn(localFs, "rename");
+			const localDelete = vi.spyOn(localFs, "delete");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+
+			await orchestrator.runSync();
+
+			expect(localRename).toHaveBeenCalledWith("C.md", "c.md");
+			expect(localDelete).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(commitCheckpoint).toHaveBeenCalledTimes(1);
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			await orchestrator.close();
+		});
+
 		it("reports an actionless unresolved rename and withholds the checkpoint", async () => {
 			const localFs = createMockLocalFs();
 			const remoteFs = createMockRemoteFs();

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -10,6 +10,8 @@ import {
 } from "../__mocks__/sync-test-helpers";
 import type { AirSyncSettings } from "../settings";
 import { AuthError } from "../fs/errors";
+import { sha256 } from "../utils/hash";
+import type { Logger } from "../logging/logger";
 
 // Make retry backoff instant: the retry tests assert behaviour (retry count,
 // status), not wall-clock timing, and real exponential backoff + jitter added
@@ -72,6 +74,222 @@ function mockProvider(
 }
 
 describe("SyncOrchestrator", () => {
+	describe("plan admission and durable rename debt", () => {
+		it("defers a mismatched local rename component without I/O or checkpoint advance", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "a.md", "changed", 2000);
+			addFile(remoteFs, "A.md", "old", 1000);
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`,
+				lastSyncedIdentity: "test:root", showSyncNotifications: true,
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const remoteWrite = vi.spyOn(remoteFs, "write");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+			const remoteList = vi.spyOn(remoteFs, "list");
+			const warn = vi.fn();
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn(), flush: vi.fn() } as unknown as Logger,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "A.md", hash: "different-baseline-hash", localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+			await orchestrator.state.upsertRenameDebts([{
+				namespace: "test:root", side: "local", oldPath: "A.md", newPath: "a.md",
+				isFolder: false, oldDisposition: "included", newDisposition: "included",
+			}]);
+
+			await orchestrator.runSync();
+
+			expect(remoteWrite).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(commitCheckpoint).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenCalledWith("partial_error");
+			expect(deps.notify).toHaveBeenCalledWith("Sync: 1 deferred");
+			expect(warn).toHaveBeenCalledWith("Sync plan component deferred", expect.objectContaining({
+				reasons: ["rename_mismatch"], paths: ["A.md", "a.md"],
+			}));
+			expect(await orchestrator.state.getRenameDebts("test:root")).toHaveLength(1);
+			expect(remoteList).toHaveBeenCalledTimes(1);
+
+			await orchestrator.runSync();
+			expect(remoteList).toHaveBeenCalledTimes(2);
+			await orchestrator.close();
+		});
+
+		it("retains a deferred remote rename edge across the same-session forced COLD cycle", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "A.md", "changed", 2000);
+			addFile(remoteFs, "a.md", "old", 1000);
+			const settings = baseMockSettings({ backendType: "test", vaultId: `test-${Math.random()}` });
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const getChangedPaths = vi.fn().mockResolvedValue({
+				modified: ["a.md"], deleted: ["A.md"],
+				renamed: [{ oldPath: "A.md", newPath: "a.md" }],
+			});
+			remoteFs.checkpoint!.getChangedPaths = getChangedPaths;
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const localWrite = vi.spyOn(localFs, "write");
+			const remoteWrite = vi.spyOn(remoteFs, "write");
+			const deps = createDeps({ getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs });
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "A.md", hash: "baseline", localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+
+			await orchestrator.runSync();
+			await orchestrator.runSync();
+
+			expect(getChangedPaths).toHaveBeenCalledTimes(1);
+			expect(localWrite).not.toHaveBeenCalled();
+			expect(remoteWrite).not.toHaveBeenCalled();
+			expect(commitCheckpoint).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
+			await orchestrator.close();
+		});
+
+		it("captures a remote rename before later stat failure so retry cannot commit past it", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "A.md", "changed", 2000);
+			addFile(remoteFs, "a.md", "old", 1000);
+			const settings = baseMockSettings({ backendType: "test", vaultId: `test-${Math.random()}` });
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const getChangedPaths = vi.fn()
+				.mockResolvedValueOnce({
+					modified: ["a.md"], deleted: ["A.md"],
+					renamed: [{ oldPath: "A.md", newPath: "a.md" }],
+				})
+				.mockResolvedValue({ modified: [], deleted: [], renamed: [] });
+			remoteFs.checkpoint!.getChangedPaths = getChangedPaths;
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const originalStat = remoteFs.stat.bind(remoteFs);
+			vi.spyOn(remoteFs, "stat")
+				.mockRejectedValueOnce(Object.assign(new Error("temporary stat failure"), { status: 500 }))
+				.mockImplementation(originalStat);
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "A.md", hash: "baseline", localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+
+			await orchestrator.runSync();
+
+			expect(getChangedPaths).toHaveBeenCalledTimes(2);
+			expect(commitCheckpoint).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
+			await orchestrator.close();
+		});
+
+		it("deletes persisted debt only after the admitted rename and clean checkpoint succeed", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "a.md", "old", 1000);
+			addFile(remoteFs, "A.md", "old", 1000);
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:root",
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const deps = createDeps({ getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs });
+			const orchestrator = new SyncOrchestrator(deps);
+			const content = new TextEncoder().encode("old").buffer;
+			await orchestrator.state.put({
+				path: "A.md", hash: await sha256(content), localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+			await orchestrator.state.upsertRenameDebts([{
+				namespace: "test:root", side: "local", oldPath: "A.md", newPath: "a.md",
+				isFolder: false, oldDisposition: "included", newDisposition: "included",
+			}]);
+
+			await orchestrator.runSync();
+
+			expect(remoteFs.files.has("A.md")).toBe(false);
+			expect(remoteFs.files.has("a.md")).toBe(true);
+			expect(commitCheckpoint).toHaveBeenCalledTimes(1);
+			expect(await orchestrator.state.getRenameDebts("test:root")).toEqual([]);
+			await orchestrator.close();
+		});
+
+		it("retires debt after replay proves convergence when checkpoint commit failed after rename I/O", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "a.md", "old", 1000);
+			addFile(remoteFs, "A.md", "old", 1000);
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:root",
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const commitCheckpoint = vi.fn()
+				.mockRejectedValueOnce(new Error("checkpoint failed"))
+				.mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const renameRemote = vi.spyOn(remoteFs, "rename");
+			const deps = createDeps({ getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs });
+			const orchestrator = new SyncOrchestrator(deps);
+			const content = new TextEncoder().encode("old").buffer;
+			await orchestrator.state.put({
+				path: "A.md", hash: await sha256(content), localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+			await orchestrator.state.upsertRenameDebts([{
+				namespace: "test:root", side: "local", oldPath: "A.md", newPath: "a.md",
+				isFolder: false, oldDisposition: "included", newDisposition: "included",
+			}]);
+
+			await orchestrator.runSync();
+
+			expect(renameRemote).toHaveBeenCalledTimes(1);
+			expect(commitCheckpoint).toHaveBeenCalledTimes(2);
+			expect(await orchestrator.state.getRenameDebts("test:root")).toEqual([]);
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			await orchestrator.close();
+		});
+
+		it("surfaces debt persistence failure before plan I/O and tracker acknowledgement", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "a.md", "old", 1000);
+			addFile(remoteFs, "A.md", "old", 1000);
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:root",
+			});
+			const tracker = new LocalChangeTracker();
+			tracker.markRenamed("a.md", "A.md");
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			vi.spyOn(orchestrator.state, "upsertRenameDebts").mockRejectedValue(new Error("quota"));
+			const remoteWrite = vi.spyOn(remoteFs, "write");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+
+			await orchestrator.runSync();
+
+			expect(remoteWrite).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(tracker.getRenamePairs()).toEqual(new Map([["a.md", "A.md"]]));
+			expect(deps.onStatusChange).toHaveBeenCalledWith("error");
+			await orchestrator.close();
+		});
+	});
+
 	describe("isSyncing()", () => {
 		it("returns false when not syncing", async () => {
 			const deps = createDeps();
@@ -879,6 +1097,50 @@ describe("SyncOrchestrator", () => {
 
 			const all = await orchestrator.state.getAll();
 			expect(all).toHaveLength(0);
+			await orchestrator.close();
+		});
+
+		it("waits for an in-flight old-target cycle before clearing its rename debt", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "a.md", "changed", 2000);
+			addFile(remoteFs, "A.md", "old", 1000);
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:old-root",
+			});
+			const tracker = new LocalChangeTracker();
+			tracker.markRenamed("a.md", "A.md");
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "A.md", hash: "different-baseline", localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+			let releasePersist!: () => void;
+			let markPersistStarted!: () => void;
+			const persistStarted = new Promise<void>((resolve) => { markPersistStarted = resolve; });
+			const persistGate = new Promise<void>((resolve) => { releasePersist = resolve; });
+			const originalUpsert = orchestrator.state.upsertRenameDebts.bind(orchestrator.state);
+			vi.spyOn(orchestrator.state, "upsertRenameDebts").mockImplementation(async (debts) => {
+				markPersistStarted();
+				await persistGate;
+				return originalUpsert(debts);
+			});
+
+			const sync = orchestrator.runSync();
+			await persistStarted;
+			let clearFinished = false;
+			const clear = orchestrator.clearSyncState().then(() => { clearFinished = true; });
+			await Promise.resolve();
+			expect(clearFinished).toBe(false);
+
+			releasePersist();
+			await sync;
+			await clear;
+			expect(await orchestrator.state.getRenameDebts("test:old-root")).toEqual([]);
 			await orchestrator.close();
 		});
 	});

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -203,7 +203,57 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
-		it("captures a remote rename before later stat failure so retry cannot commit past it", async () => {
+		it("reports an actionless unresolved rename and withholds the checkpoint", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			addFile(localFs, "a.md", "same", 1000);
+			addFile(remoteFs, "a.md", "same", 1000);
+			confirmMockPath(localFs, "a.md");
+			confirmMockPath(remoteFs, "a.md");
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, showSyncNotifications: true,
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			remoteFs.checkpoint!.getChangedPaths = vi.fn().mockResolvedValue({
+				modified: ["a.md"], deleted: ["A.md"],
+				renamed: [{ oldPath: "A.md", newPath: "a.md" }],
+			});
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const originalRemoteStat = remoteFs.stat.bind(remoteFs);
+			vi.spyOn(remoteFs, "stat").mockImplementation(async (path) => {
+				const found = await originalRemoteStat(path === "A.md" ? "a.md" : path);
+				return path === "A.md" && found
+					? { ...found, pathAuthority: "requested_echo" }
+					: found;
+			});
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			const content = new TextEncoder().encode("same").buffer;
+			await orchestrator.state.put({
+				path: "a.md", hash: await sha256(content), localMtime: 1000, remoteMtime: 1000,
+				localSize: 4, remoteSize: 4, syncedAt: 900,
+			});
+			const localWrite = vi.spyOn(localFs, "write");
+			const remoteWrite = vi.spyOn(remoteFs, "write");
+			const localDelete = vi.spyOn(localFs, "delete");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+
+			await orchestrator.runSync();
+
+			expect(localWrite).not.toHaveBeenCalled();
+			expect(remoteWrite).not.toHaveBeenCalled();
+			expect(localDelete).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(commitCheckpoint).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
+			expect(deps.notify).toHaveBeenCalledWith("Sync: 1 deferred");
+			await orchestrator.close();
+		});
+
+		it("retains pre-Admission evidence and defers recovery to a later COLD cycle", async () => {
 			const localFs = createMockLocalFs();
 			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "A.md", "changed", 2000);
@@ -219,6 +269,7 @@ describe("SyncOrchestrator", () => {
 			remoteFs.checkpoint!.getChangedPaths = getChangedPaths;
 			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
 			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const remoteList = vi.spyOn(remoteFs, "list");
 			const originalStat = remoteFs.stat.bind(remoteFs);
 			vi.spyOn(remoteFs, "stat")
 				.mockRejectedValueOnce(Object.assign(new Error("temporary stat failure"), { status: 500 }))
@@ -234,7 +285,14 @@ describe("SyncOrchestrator", () => {
 
 			await orchestrator.runSync();
 
-			expect(getChangedPaths).toHaveBeenCalledTimes(2);
+			expect(getChangedPaths).toHaveBeenCalledTimes(1);
+			expect(commitCheckpoint).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("error");
+
+			await orchestrator.runSync();
+
+			expect(getChangedPaths).toHaveBeenCalledTimes(1);
+			expect(remoteList).toHaveBeenCalledTimes(1);
 			expect(commitCheckpoint).not.toHaveBeenCalled();
 			expect(deps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
 			await orchestrator.close();

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -4,7 +4,7 @@ import { SyncOrchestrator } from "./orchestrator";
 import type { SyncOrchestratorDeps } from "./orchestrator";
 import { LocalChangeTracker } from "./local-tracker";
 import {
-	createMockFs,
+	confirmMockPath, createMockLocalFs, createMockRemoteFs, type MockFileSystem,
 	addFile,
 	readText,
 	mockSettings as baseMockSettings,
@@ -45,8 +45,8 @@ function mockSettings(): AirSyncSettings {
 function createDeps(
 	overrides: Partial<SyncOrchestratorDeps> = {},
 ): SyncOrchestratorDeps {
-	const localFs = createMockFs("local");
-	const remoteFs = createMockFs("remote");
+	const localFs = createMockLocalFs();
+	const remoteFs = createMockRemoteFs();
 	return {
 		getSettings: () => mockSettings(),
 		saveSettings: vi.fn().mockResolvedValue(undefined),
@@ -76,9 +76,54 @@ function mockProvider(
 
 describe("SyncOrchestrator", () => {
 	describe("plan admission and durable rename debt", () => {
+		it("defers a mutation-backed folder rename until provider confirmation", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const tracker = new LocalChangeTracker();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`,
+				lastSyncedIdentity: "test:root",
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			const localDelete = vi.spyOn(localFs, "delete");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+			const remoteRename = vi.spyOn(remoteFs, "rename");
+
+			await localFs.write("Drafts/nested/note.md", new TextEncoder().encode("kept").buffer, 1000);
+			await orchestrator.runSync();
+			expect((await remoteFs.stat("Drafts"))?.pathAuthority).toBe("requested_echo");
+			expect((await remoteFs.stat("Drafts/nested/note.md"))?.pathAuthority).toBe("requested_echo");
+
+			await localFs.rename("Drafts", "Published");
+			tracker.markFolderRenamed("Published", "Drafts");
+			await orchestrator.runSync();
+
+			expect(remoteRename).not.toHaveBeenCalled();
+			expect(localDelete).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(remoteFs.files.has("Drafts/nested/note.md")).toBe(true);
+			expect(await orchestrator.state.getRenameDebts("test:root")).toHaveLength(1);
+
+			confirmMockPath(remoteFs, "Drafts");
+			await orchestrator.runSync();
+
+			expect(remoteRename).toHaveBeenCalledWith("Drafts", "Published");
+			expect(remoteFs.files.has("Published/nested/note.md")).toBe(true);
+			expect(remoteFs.files.has("Drafts/nested/note.md")).toBe(false);
+			expect(localDelete).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(await orchestrator.state.getRenameDebts("test:root")).toEqual([]);
+			await orchestrator.close();
+		});
+
 		it("defers a mismatched local rename component without I/O or checkpoint advance", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "a.md", "changed", 2000);
 			addFile(remoteFs, "A.md", "old", 1000);
 			const settings = baseMockSettings({
@@ -125,8 +170,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("retains a deferred remote rename edge across the same-session forced COLD cycle", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "A.md", "changed", 2000);
 			addFile(remoteFs, "a.md", "old", 1000);
 			const settings = baseMockSettings({ backendType: "test", vaultId: `test-${Math.random()}` });
@@ -159,8 +204,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("captures a remote rename before later stat failure so retry cannot commit past it", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "A.md", "changed", 2000);
 			addFile(remoteFs, "a.md", "old", 1000);
 			const settings = baseMockSettings({ backendType: "test", vaultId: `test-${Math.random()}` });
@@ -196,8 +241,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("deletes persisted debt only after the admitted rename and clean checkpoint succeed", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "a.md", "old", 1000);
 			addFile(remoteFs, "A.md", "old", 1000);
 			const settings = baseMockSettings({
@@ -228,8 +273,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("replays a deferred local rename from durable debt after orchestrator restart", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "a.md", "changed", 2000);
 			addFile(remoteFs, "A.md", "old", 1000);
 			const settings = baseMockSettings({
@@ -268,8 +313,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("retires debt after replay proves convergence when checkpoint commit failed after rename I/O", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "a.md", "old", 1000);
 			addFile(remoteFs, "A.md", "old", 1000);
 			const settings = baseMockSettings({
@@ -303,8 +348,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("surfaces debt persistence failure before plan I/O and tracker acknowledgement", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "a.md", "old", 1000);
 			addFile(remoteFs, "A.md", "old", 1000);
 			const settings = baseMockSettings({
@@ -341,8 +386,8 @@ describe("SyncOrchestrator", () => {
 
 		it("returns true while sync is running", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			let resolveSync!: () => void;
 			const syncStarted = new Promise<void>((res) => {
 				resolveSync = res;
@@ -411,8 +456,8 @@ describe("SyncOrchestrator", () => {
 
 		it("queues a pending sync when called while locked", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -446,8 +491,8 @@ describe("SyncOrchestrator", () => {
 			// The burst must emit a single notice, not one per cycle.
 			const settings = { ...mockSettings(), showSyncNotifications: true };
 			const deps = createDeps({ getSettings: () => settings });
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -478,8 +523,8 @@ describe("SyncOrchestrator", () => {
 
 		it("sets status to error and notifies on AuthError", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -498,8 +543,8 @@ describe("SyncOrchestrator", () => {
 
 		it("retries on transient error and succeeds", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -520,8 +565,8 @@ describe("SyncOrchestrator", () => {
 
 		it("fails after MAX_RETRIES and sets error status", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -543,8 +588,8 @@ describe("SyncOrchestrator", () => {
 			const settings = mockSettings();
 			settings.ignorePatterns = ["*.tmp"];
 			const deps = createDeps({ getSettings: () => settings });
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(localFs, "file.tmp", "ignored");
@@ -571,8 +616,8 @@ describe("SyncOrchestrator", () => {
 			const settings = mockSettings();
 			settings.syncDotPaths = [];
 			const deps = createDeps({ getSettings: () => settings });
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			// A hidden path present only on the remote (e.g. another device's logs).
@@ -592,8 +637,8 @@ describe("SyncOrchestrator", () => {
 			const settings = mockSettings();
 			settings.syncDotPaths = [".airsync"];
 			const deps = createDeps({ getSettings: () => settings });
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(remoteFs, ".airsync/logs/d/x.log", "log");
@@ -632,8 +677,8 @@ describe("SyncOrchestrator", () => {
 		it("optimizes rename pair into rename_remote action", async () => {
 			const settings = { ...mockSettings(), showSyncNotifications: true };
 			const deps = createDeps({ getSettings: () => settings });
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -675,8 +720,8 @@ describe("SyncOrchestrator", () => {
 		// locally present and suppress the delete_remote half of the rename pair.
 		it("optimizes a case-only local rename on a case-insensitive filesystem", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -722,8 +767,8 @@ describe("SyncOrchestrator", () => {
 
 		it("acknowledges dirty paths after sync", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -749,8 +794,8 @@ describe("SyncOrchestrator", () => {
 			// The cycle must not sweep this path: it was never part of this cycle, so
 			// it must stay dirty (keeping it on the HOT path for the next cycle).
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -778,8 +823,8 @@ describe("SyncOrchestrator", () => {
 
 		it("retries a rate-limited transfer in-cycle, so the cycle completes clean", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(localFs, "a.md", "content"); // local-only ⇒ push
@@ -802,8 +847,8 @@ describe("SyncOrchestrator", () => {
 
 		it("a persistent rate-limit fails the file in ONE cycle (no cycle-level retry storm)", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(localFs, "a.md", "content");
@@ -828,8 +873,8 @@ describe("SyncOrchestrator", () => {
 	describe("pullSingle()", () => {
 		it("pulls a remote file and saves sync record", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(remoteFs, "note.md", "remote content", 2000);
@@ -846,8 +891,8 @@ describe("SyncOrchestrator", () => {
 
 		it("acknowledges path after pull", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(remoteFs, "note.md", "content", 2000);
@@ -873,8 +918,8 @@ describe("SyncOrchestrator", () => {
 					flush: vi.fn().mockResolvedValue(undefined),
 				} as unknown as SyncOrchestratorDeps["logger"],
 			});
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 
@@ -911,8 +956,8 @@ describe("SyncOrchestrator", () => {
 					flush: vi.fn().mockResolvedValue(undefined),
 				} as unknown as SyncOrchestratorDeps["logger"],
 			});
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			// remote file does not exist
@@ -927,8 +972,8 @@ describe("SyncOrchestrator", () => {
 
 		it("runs pullSingle within mutex (exclusive with runSync)", async () => {
 			const deps = createDeps();
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(remoteFs, "note.md", "content", 2000);
@@ -1197,8 +1242,8 @@ describe("SyncOrchestrator", () => {
 			const orchestrator = new SyncOrchestrator(deps);
 
 			// Put a record first via a sync
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			deps.localFs = () => localFs;
 			deps.remoteFs = () => remoteFs;
 			addFile(remoteFs, "a.md", "content", 1000);
@@ -1212,8 +1257,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("waits for an in-flight old-target cycle before clearing its rename debt", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "a.md", "changed", 2000);
 			addFile(remoteFs, "A.md", "old", 1000);
 			const settings = baseMockSettings({
@@ -1258,8 +1303,8 @@ describe("SyncOrchestrator", () => {
 
 	describe("layoutReady gate", () => {
 		it("runSync is a no-op while the vault layout is not ready", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			const listSpy = vi.spyOn(localFs, "list");
 			const deps = createDeps({
 				localFs: () => localFs,
@@ -1277,8 +1322,8 @@ describe("SyncOrchestrator", () => {
 
 		it("runs once the layout becomes ready", async () => {
 			let ready = false;
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			const deps = createDeps({
 				localFs: () => localFs,
 				remoteFs: () => remoteFs,
@@ -1316,8 +1361,8 @@ describe("SyncOrchestrator", () => {
 		 * COLD full reconcile that rediscovers and pulls the orphan.
 		 */
 		it("hasCheckpoint=false forces a cold reconcile that pulls the un-synced file", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "synced.md", "kept", 1000);
 			addFile(remoteFs, "synced.md", "kept", 1000);
 			addFile(remoteFs, "orphan.md", "left behind", 1000);
@@ -1359,8 +1404,8 @@ describe("SyncOrchestrator", () => {
 			// The reset must run through the orchestrator's sync mutex (not be fired
 			// straight at the live FS from outside) so it can't clear the cache mid-cycle
 			// and corrupt an in-flight sync. After the reset, hasCheckpoint is false → cold.
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "synced.md", "kept", 1000);
 			addFile(remoteFs, "synced.md", "kept", 1000);
 			addFile(remoteFs, "orphan.md", "left behind", 1000); // only a COLD reconcile finds this
@@ -1400,8 +1445,8 @@ describe("SyncOrchestrator", () => {
 		 * changesStartPageToken, so the next run still re-detects the un-pulled work.
 		 */
 		it("forces a cold reconcile on the cycle after a failure (in-memory cursor may have advanced past the committed one)", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "synced.md", "kept", 1000);
 			addFile(localFs, "push.md", "body", 1000); // local-only → push, fails in cycle 1
 			addFile(remoteFs, "synced.md", "kept", 1000);
@@ -1449,8 +1494,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("does not keep cold-scanning and re-pushing the same poison file after repeated identical failures", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "synced.md", "kept", 1000);
 			addFile(localFs, "poison.zip", "large file", 1000);
 			addFile(remoteFs, "synced.md", "kept", 1000);
@@ -1507,8 +1552,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("does not quarantine uncoded permanent push failures", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "uncoded.md", "body", 1000);
 
 			const settings = baseMockSettings({
@@ -1541,8 +1586,8 @@ describe("SyncOrchestrator", () => {
 			["transient", () => new Error("network dropped")],
 			["rateLimit", () => Object.assign(new Error("rate limited"), { status: 429 })],
 		])("does not quarantine repeated %s push failures", async (_kind, makeError) => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "flaky.md", "body", 1000);
 
 			const settings = baseMockSettings({
@@ -1578,8 +1623,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("does not quarantine persistent pull failures", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(remoteFs, "remote.md", "body", 1000);
 
 			const settings = baseMockSettings({
@@ -1609,8 +1654,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("does not advance the committed cursor when a cycle has failures", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(localFs, "push.md", "body", 1000); // local-only → planned push
 
 			// Pull/scan succeed; the push write fails → result.failed.length === 1.
@@ -1649,8 +1694,8 @@ describe("SyncOrchestrator", () => {
 		 * See docs/adr/0001-metadata-cache-is-subordinate-to-commit-last.md.
 		 */
 		it("does not advance the committed cursor when the checkpoint flush (cache persist) fails", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			// Steady state, matching baseline → a CLEAN cycle (no failed actions), so the
 			// orchestrator reaches commitCheckpoint.
 			addFile(localFs, "synced.md", "kept", 1000);
@@ -1706,7 +1751,7 @@ describe("SyncOrchestrator", () => {
 		 * reads back the last committed value (or the seed, or null).
 		 */
 		function wireScopeFingerprint(
-			remoteFs: ReturnType<typeof createMockFs>,
+			remoteFs: MockFileSystem,
 			seed: string | null,
 		): void {
 			let committed = seed;
@@ -1720,8 +1765,8 @@ describe("SyncOrchestrator", () => {
 		}
 
 		it("reruns cold and pulls a remote-only path once enableConfigSync widens scope", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			// A remote-only file under the config dir — always existed on the remote,
 			// but out of scope until enableConfigSync is turned on. The delta cursor has
 			// already passed it (empty getChangedPaths), so only a forced cold reconcile
@@ -1758,8 +1803,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("reruns cold and pulls a remote-only snippet once its config scope is enabled", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			const path = `${TEST_CONFIG_DIR}/snippets/example.css`;
 			addFile(remoteFs, path, "css", 1000);
 
@@ -1791,8 +1836,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("does not force cold when settings are unchanged between cycles", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(remoteFs, "synced.md", "kept", 1000);
 			addFile(localFs, "synced.md", "kept", 1000);
 
@@ -1826,8 +1871,8 @@ describe("SyncOrchestrator", () => {
 		});
 
 		it("treats a checkpoint with no committed fingerprint as changed (one-time migration)", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			addFile(remoteFs, `${TEST_CONFIG_DIR}/hotkeys.json`, "keys", 1000);
 
 			const settings = baseMockSettings({
@@ -1858,8 +1903,8 @@ describe("SyncOrchestrator", () => {
 
 	describe("phantom warm deletion is prevented (not recovered)", () => {
 		it("does not delete a file missing from the listing but present on disk", async () => {
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			const deps = createDeps({
 				localFs: () => localFs,
 				remoteFs: () => remoteFs,

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -6,6 +6,7 @@ import { LocalChangeTracker } from "./local-tracker";
 import {
 	createMockFs,
 	addFile,
+	readText,
 	mockSettings as baseMockSettings,
 } from "../__mocks__/sync-test-helpers";
 import type { AirSyncSettings } from "../settings";
@@ -582,6 +583,25 @@ describe("SyncOrchestrator", () => {
 
 			// Out of scope → never pulled locally, and not deleted from the remote.
 			expect(localFs.files.has(".airsync/logs/d/x.log")).toBe(false);
+			expect(remoteFs.files.has(".airsync/logs/d/x.log")).toBe(true);
+			expect(deps.onStatusChange).toHaveBeenCalledWith("idle");
+			await orchestrator.close();
+		});
+
+		it("pulls a remote-only hidden path when its root is opted in", async () => {
+			const settings = mockSettings();
+			settings.syncDotPaths = [".airsync"];
+			const deps = createDeps({ getSettings: () => settings });
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			deps.localFs = () => localFs;
+			deps.remoteFs = () => remoteFs;
+			addFile(remoteFs, ".airsync/logs/d/x.log", "log");
+
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.runSync();
+
+			expect(readText(localFs, ".airsync/logs/d/x.log")).toBe("log");
 			expect(remoteFs.files.has(".airsync/logs/d/x.log")).toBe(true);
 			expect(deps.onStatusChange).toHaveBeenCalledWith("idle");
 			await orchestrator.close();

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -226,6 +226,46 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
+		it("replays a deferred local rename from durable debt after orchestrator restart", async () => {
+			const localFs = createMockFs("local");
+			const remoteFs = createMockFs("remote");
+			addFile(localFs, "a.md", "changed", 2000);
+			addFile(remoteFs, "A.md", "old", 1000);
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:root",
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			const firstTracker = new LocalChangeTracker();
+			firstTracker.markRenamed("a.md", "A.md");
+			const firstDeps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: firstTracker,
+			});
+			const first = new SyncOrchestrator(firstDeps);
+			await first.state.put({
+				path: "A.md", hash: "different-baseline", localMtime: 1000, remoteMtime: 1000,
+				localSize: 3, remoteSize: 3, syncedAt: 900,
+			});
+			await first.runSync();
+			expect(await first.state.getRenameDebts("test:root")).toHaveLength(1);
+			await first.close();
+
+			const remoteWrite = vi.spyOn(remoteFs, "write");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+			const secondDeps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: new LocalChangeTracker(),
+			});
+			const restarted = new SyncOrchestrator(secondDeps);
+			await restarted.runSync();
+
+			expect(remoteWrite).not.toHaveBeenCalled();
+			expect(remoteDelete).not.toHaveBeenCalled();
+			expect(await restarted.state.getRenameDebts("test:root")).toHaveLength(1);
+			expect(secondDeps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
+			await restarted.close();
+		});
+
 		it("retires debt after replay proves convergence when checkpoint commit failed after rename I/O", async () => {
 			const localFs = createMockFs("local");
 			const remoteFs = createMockFs("remote");

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -429,9 +429,7 @@ export class SyncOrchestrator {
 		}
 		const plan = refinePlan(
 			planSync(filtered),
-			renamePairs,
-			folderRenamePairs,
-			changeSet.remoteRenamePairs,
+			changeSet.identityEvidence,
 			this.deps.logger,
 		);
 

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -11,19 +11,19 @@ import { SyncStateStore } from "./state";
 import { LocalChangeTracker, type TrackerSnapshot } from "./local-tracker";
 import { collectChanges } from "./change-detector";
 import { computeScopeFingerprint } from "./scope-fingerprint";
-import { planSync } from "./decision-engine";
-import { refinePlan } from "./rename-optimizer";
 import { executePlan, toConflictRecords, DESKTOP_TRANSFER_POOL, MOBILE_TRANSFER_POOL } from "./plan-executor";
 import type { ExecutionContext, ExecutionResult } from "./plan-executor";
 import { classifyHttpError } from "../fs/errors";
 import type { ErrorClassification } from "../fs/errors";
 import { decideRetry, sleep } from "./error";
-import type { ConflictRecord, SyncStatus } from "./types";
+import type { ConflictRecord, IdentityEvidence, SyncStatus } from "./types";
 import { buildSyncRecord } from "./state-committer";
 import { CycleSummary } from "./sync-notification";
 import type { SyncCycleResult } from "./sync-notification";
 import { FailedActionTracker } from "./failed-action-tracker";
-import { projectScope } from "./scope-projection";
+import { mergeIdentityEvidence, renameDebtEvidence } from "./rename-debt";
+import { logChangeDetection, prepareSyncCyclePlan } from "./sync-cycle-planning";
+import { finalizeSyncCycle } from "./sync-cycle-finalization";
 
 export type { SyncStatus };
 
@@ -65,6 +65,8 @@ export class SyncOrchestrator {
 	 * cycle cold — a full list × baseline join recovers it regardless of cursor.
 	 */
 	private recoverViaColdScan = false;
+	/** Reported edges retained until a clean checkpoint; remote edges are not durable debt. */
+	private pendingAdmissionEvidence: IdentityEvidence[] = [];
 	private failedActionTracker = new FailedActionTracker();
 	/** Stable id grouping this plugin session's conflict-history records. */
 	private readonly sessionId = crypto.randomUUID();
@@ -93,8 +95,15 @@ export class SyncOrchestrator {
 	}
 
 	async clearSyncState(): Promise<void> {
-		this.deps.logger?.info("Clearing sync state");
-		await this.stateStore.clear();
+		// Serialize target teardown with execution. Otherwise an old-target cycle can
+		// recreate debt after disconnect/switch has cleared its namespace.
+		await this.syncMutex.run(async () => {
+			this.deps.logger?.info("Clearing sync state");
+			await this.stateStore.clear();
+			this.pendingAdmissionEvidence = [];
+			this.recoverViaColdScan = false;
+			this.syncPending = false;
+		});
 	}
 
 	shouldSync(): boolean {
@@ -220,17 +229,21 @@ export class SyncOrchestrator {
 				const result = await this.executeWithRetry(forceFullScan, snapshot, scopeFingerprint);
 				if (!result) return; // Fatal error already handled
 
-				const { succeeded, failed, blocked, conflicts } = result;
+				const { succeeded, failed, blocked, conflicts, deferred } = result;
 				// failed cycle では cursor が committed state より先に進んでいる可能性がある。
 				// ただし cold recovery を一度支払い済みの local-origin action だけが
 				// quarantine 対象なら、次 cycle の cold scan は不要。
 				this.recoverViaColdScan = this.needsColdRecovery(result.result);
-				if (failed > 0 || blocked > 0) {
+				if (failed > 0 || blocked > 0 || deferred > 0) {
 					this.deps.onStatusChange("partial_error");
-					this.deps.logger?.warn("Sync completed with errors", { succeeded, conflicts, failed, blocked });
+					this.deps.logger?.warn("Sync completed with errors", {
+						succeeded, conflicts, failed, blocked, deferred,
+					});
 				} else {
 					this.deps.onStatusChange("idle");
-					this.deps.logger?.info("Sync completed", { succeeded, conflicts, failed, blocked });
+					this.deps.logger?.info("Sync completed", {
+						succeeded, conflicts, failed, blocked, deferred,
+					});
 				}
 
 				summary.add(result.result);
@@ -280,6 +293,7 @@ export class SyncOrchestrator {
 					failed: lastResult.failed.length,
 					blocked: lastResult.blocked.length,
 					conflicts: lastResult.conflicts.length,
+					deferred: lastResult.deferred.length,
 				};
 			} catch (err) {
 				lastError = err;
@@ -367,59 +381,43 @@ export class SyncOrchestrator {
 			throw new Error("Cannot sync: local or remote filesystem is not available");
 		}
 		const settings = this.deps.getSettings();
+		const provider = this.deps.backendProvider();
+		const debtNamespace = (provider?.getIdentity?.(settings) ?? settings.lastSyncedIdentity) ||
+			`${settings.backendType}:${settings.vaultId}`;
+		const persistedDebts = await this.stateStore.getRenameDebts(debtNamespace);
+		const carriedEvidence = mergeIdentityEvidence(
+			this.pendingAdmissionEvidence,
+			persistedDebts.map(renameDebtEvidence),
+		);
 
 		const changeSet = await collectChanges({
 			localFs,
 			remoteFs,
 			stateStore: this.stateStore,
 			changes: snapshot,
-		}, { forceFullScan });
-
-		const { renamePairs, folderRenamePairs } = snapshot;
-		const remoteOnlyPaths = changeSet.entries.filter((e) => !e.local && e.remote).map((e) => e.path);
-		this.deps.logger?.info("Change detection completed", {
-			temperature: changeSet.temperature,
-			entries: changeSet.entries.length,
-			localOnly: changeSet.entries.filter((e) => e.local && !e.remote).length,
-			remoteOnly: remoteOnlyPaths.length,
-			both: changeSet.entries.filter((e) => e.local && e.remote).length,
-			enriched: changeSet.entries.filter((e) => e.local?.hash && !e.prevSync).length,
-			renamePairs: renamePairs.size,
+			onRemoteIdentityEvidence: (evidence) => {
+				this.pendingAdmissionEvidence = mergeIdentityEvidence(
+					this.pendingAdmissionEvidence,
+					evidence.filter((item) => item.kind === "rename"),
+				);
+			},
+		}, {
+			forceFullScan: forceFullScan || persistedDebts.length > 0,
+			carriedIdentityEvidence: carriedEvidence,
 		});
-		if (remoteOnlyPaths.length > 0) {
-			this.deps.logger?.debug("Remote-only paths", { paths: remoteOnlyPaths });
-		}
-		if (renamePairs.size > 0) {
-			const rpPaths = new Set([...renamePairs.keys(), ...renamePairs.values()]);
-			const rpEntries = changeSet.entries
-				.filter((e) => rpPaths.has(e.path))
-				.map((e) => ({
-					path: e.path,
-					local: !!e.local,
-					remote: !!e.remote,
-					prevSync: !!e.prevSync,
-					hash: (e.local?.hash || e.prevSync?.hash || "").substring(0, 8) || undefined,
-				}));
-			this.deps.logger?.debug("Rename entry details", { entries: rpEntries });
-		}
+		const { renamePairs, folderRenamePairs } = snapshot;
+		logChangeDetection(changeSet, renamePairs, this.deps.logger);
 
 		const isMobile = this.deps.isMobile();
 		const maxBytes = settings.mobileMaxFileSizeMB * 1024 * 1024;
-		const scopeProjection = projectScope(changeSet, {
+		const planning = prepareSyncCyclePlan(changeSet, persistedDebts, debtNamespace, {
 			classifyPath: (path) => this.isExcluded(path) ? "policy_out" : "included",
 			mobileMaxBytes: isMobile ? maxBytes : undefined,
-		});
-		const filtered = changeSet.entries.filter((e) => {
-			return scopeProjection.byEndpoint.get(e.path) === "included";
-		});
-
-		if (filtered.length !== changeSet.entries.length) {
-			this.deps.logger?.debug("Files filtered", {
-				total: changeSet.entries.length,
-				afterFilter: filtered.length,
-				excluded: changeSet.entries.length - filtered.length,
-			});
-		}
+		}, this.deps.logger);
+		this.pendingAdmissionEvidence = mergeIdentityEvidence(
+			this.pendingAdmissionEvidence,
+			changeSet.identityEvidence.filter((item) => item.kind === "rename"),
+		);
 
 		if (folderRenamePairs.size > 0) {
 			this.deps.logger?.info("Folder rename pairs detected", {
@@ -427,24 +425,11 @@ export class SyncOrchestrator {
 				pairs: [...folderRenamePairs.entries()].map(([n, o]) => `${o} → ${n}`),
 			});
 		}
-		const plan = refinePlan(
-			planSync(filtered),
-			changeSet.identityEvidence,
-			this.deps.logger,
-		);
+		// This write is deliberately before executePlan: a crash after tracker capture
+		// must not erase the only authoritative local rename edge.
+		await this.stateStore.upsertRenameDebts(planning.localRenameDebts);
+		const total = planning.admission.executable.actions.length;
 
-		const actionBreakdown: Record<string, number> = {};
-		for (const a of plan.actions) {
-			actionBreakdown[a.action] = (actionBreakdown[a.action] ?? 0) + 1;
-		}
-		this.deps.logger?.info("Sync plan created", {
-			total: plan.actions.length,
-			...actionBreakdown,
-		});
-
-		const total = plan.actions.length;
-
-		const provider = this.deps.backendProvider();
 		const classifyError = (err: unknown) => provider?.classifyError?.(err) ?? classifyHttpError(err);
 		const ctx: ExecutionContext = {
 			localFs,
@@ -465,17 +450,18 @@ export class SyncOrchestrator {
 			transferPool: this.deps.isMobile() ? MOBILE_TRANSFER_POOL : DESKTOP_TRANSFER_POOL,
 		};
 
-		const result = await executePlan(plan, ctx);
+		const execution = await executePlan(planning.admission.executable, ctx);
+		const result: ExecutionResult = { ...execution, deferred: planning.admission.deferred };
 		this.updateFailedActionTracker(settings.backendType, result, classifyError);
 
 		// Persist backend state. commitCheckpoint advances the delta cursor (+ file map,
 		// atomically) only on a fully clean cycle; a partial sync keeps the prior cursor.
-		const cleanCycle = result.failed.length === 0;
-		// The checkpoint lives on the FS now (no provider downcast): flush it only on a
-		// fully clean cycle so a partial sync keeps the prior committed cursor.
-		if (cleanCycle && remoteFs?.checkpoint) {
-			await remoteFs.checkpoint.commitCheckpoint({ scopeFingerprint });
-		}
+		this.pendingAdmissionEvidence = await finalizeSyncCycle({
+			result, pendingEvidence: this.pendingAdmissionEvidence, persistedDebts,
+			localRenameDebts: planning.localRenameDebts,
+			scopeProjection: planning.scopeProjection, observations: changeSet.observations,
+			checkpoint: remoteFs.checkpoint, scopeFingerprint, stateStore: this.stateStore,
+		});
 		// readBackendState now persists only non-secret token state (the cursor lives
 		// in the backend store, committed above) — safe to run every cycle.
 		if (provider?.readBackendState) {
@@ -510,7 +496,7 @@ export class SyncOrchestrator {
 		const settings = this.deps.getSettings();
 		const provider = this.deps.backendProvider();
 		const classifyError = (err: unknown) => provider?.classifyError?.(err) ?? classifyHttpError(err);
-		return result.failed.some((failed) =>
+		return result.deferred.length > 0 || result.failed.some((failed) =>
 			!this.failedActionTracker.isBlockingFailure(
 				settings.backendType,
 				failed,

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -9,7 +9,7 @@ import { getEffectiveIgnorePatterns, getEffectiveSyncDotPaths, isOwnPluginDataPa
 import { INTERNAL_METADATA_PATH } from "../fs/remote-vault-contract";
 import { SyncStateStore } from "./state";
 import { LocalChangeTracker, type TrackerSnapshot } from "./local-tracker";
-import { collectChanges } from "./change-detector";
+import { collectChanges, type ChangeSet } from "./change-detector";
 import { computeScopeFingerprint } from "./scope-fingerprint";
 import { executePlan, toConflictRecords, DESKTOP_TRANSFER_POOL, MOBILE_TRANSFER_POOL } from "./plan-executor";
 import type { ExecutionContext, ExecutionResult } from "./plan-executor";
@@ -22,8 +22,13 @@ import { CycleSummary } from "./sync-notification";
 import type { SyncCycleResult } from "./sync-notification";
 import { FailedActionTracker } from "./failed-action-tracker";
 import { mergeIdentityEvidence, renameDebtEvidence } from "./rename-debt";
-import { logChangeDetection, prepareSyncCyclePlan } from "./sync-cycle-planning";
+import {
+	logChangeDetection,
+	logSyncCyclePlan,
+	prepareSyncCycleSnapshot,
+} from "./sync-cycle-planning";
 import { finalizeSyncCycle } from "./sync-cycle-finalization";
+import { admitDestructivePlan } from "./plan-admission";
 
 export type { SyncStatus };
 
@@ -53,6 +58,13 @@ export interface SyncOrchestratorDeps {
 }
 
 const MAX_RETRIES = 3;
+
+class PreAdmissionRecoveryError extends Error {
+	constructor(cause: unknown) {
+		super(cause instanceof Error ? cause.message : String(cause));
+		this.name = "PreAdmissionRecoveryError";
+	}
+}
 
 export class SyncOrchestrator {
 	private syncMutex = new AsyncMutex();
@@ -297,6 +309,12 @@ export class SyncOrchestrator {
 				};
 			} catch (err) {
 				lastError = err;
+				if (err instanceof PreAdmissionRecoveryError) {
+					this.deps.logger?.error("Sync error before Admission; COLD recovery requested", {
+						message: err.message,
+					});
+					break;
+				}
 				// Classification is the backend's job (it knows its own error shapes,
 				// e.g. that Google 403 can mean rate-limit); the retry POLICY is the
 				// engine's and stays backend-neutral. Fall back to the generic HTTP
@@ -390,34 +408,54 @@ export class SyncOrchestrator {
 			persistedDebts.map(renameDebtEvidence),
 		);
 
-		const changeSet = await collectChanges({
-			localFs,
-			remoteFs,
-			stateStore: this.stateStore,
-			changes: snapshot,
-			onRemoteIdentityEvidence: (evidence) => {
-				this.pendingAdmissionEvidence = mergeIdentityEvidence(
-					this.pendingAdmissionEvidence,
-					evidence.filter((item) => item.kind === "rename"),
-				);
-			},
-		}, {
-			forceFullScan: forceFullScan || persistedDebts.length > 0,
-			carriedIdentityEvidence: carriedEvidence,
-		});
-		const { renamePairs, folderRenamePairs } = snapshot;
-		logChangeDetection(changeSet, renamePairs, this.deps.logger);
+		let changeSet: ChangeSet;
+		let planning: ReturnType<typeof prepareSyncCycleSnapshot>;
+		let capturedRemoteEvidence = false;
+		const hadPendingEvidence = this.pendingAdmissionEvidence.length > 0;
+		try {
+			changeSet = await collectChanges({
+				localFs,
+				remoteFs,
+				stateStore: this.stateStore,
+				changes: snapshot,
+				onRemoteIdentityEvidence: (evidence) => {
+					const remoteRenames = evidence.filter((item) => item.kind === "rename");
+					capturedRemoteEvidence ||= remoteRenames.length > 0;
+					this.pendingAdmissionEvidence = mergeIdentityEvidence(
+						this.pendingAdmissionEvidence,
+						remoteRenames,
+					);
+				},
+			}, {
+				forceFullScan: forceFullScan || persistedDebts.length > 0,
+				carriedIdentityEvidence: carriedEvidence,
+			});
+			const { renamePairs } = snapshot;
+			logChangeDetection(changeSet, renamePairs, this.deps.logger);
 
-		const isMobile = this.deps.isMobile();
-		const maxBytes = settings.mobileMaxFileSizeMB * 1024 * 1024;
-		const planning = prepareSyncCyclePlan(changeSet, persistedDebts, debtNamespace, {
-			classifyPath: (path) => this.isExcluded(path) ? "policy_out" : "included",
-			mobileMaxBytes: isMobile ? maxBytes : undefined,
-		}, this.deps.logger);
-		this.pendingAdmissionEvidence = mergeIdentityEvidence(
-			this.pendingAdmissionEvidence,
-			changeSet.identityEvidence.filter((item) => item.kind === "rename"),
-		);
+			const isMobile = this.deps.isMobile();
+			const maxBytes = settings.mobileMaxFileSizeMB * 1024 * 1024;
+			planning = prepareSyncCycleSnapshot(changeSet, persistedDebts, debtNamespace, {
+				classifyPath: (path) => this.isExcluded(path) ? "policy_out" : "included",
+				mobileMaxBytes: isMobile ? maxBytes : undefined,
+			}, this.deps.logger);
+			this.pendingAdmissionEvidence = mergeIdentityEvidence(
+				this.pendingAdmissionEvidence,
+				changeSet.identityEvidence.filter((item) => item.kind === "rename"),
+			);
+		} catch (err) {
+			if (capturedRemoteEvidence || hadPendingEvidence) {
+				this.recoverViaColdScan = true;
+				throw new PreAdmissionRecoveryError(err);
+			}
+			throw err;
+		}
+
+		// This call is the authorization cut point. Exceptions from this line onward
+		// are not reclassified as evidence-acquisition recovery.
+		const admission = admitDestructivePlan(planning.snapshot);
+		logSyncCyclePlan(this.deps.logger, admission);
+		const { folderRenamePairs } = snapshot;
 
 		if (folderRenamePairs.size > 0) {
 			this.deps.logger?.info("Folder rename pairs detected", {
@@ -428,7 +466,7 @@ export class SyncOrchestrator {
 		// This write is deliberately before executePlan: a crash after tracker capture
 		// must not erase the only authoritative local rename edge.
 		await this.stateStore.upsertRenameDebts(planning.localRenameDebts);
-		const total = planning.admission.executable.actions.length;
+		const total = admission.executable.actions.length;
 
 		const classifyError = (err: unknown) => provider?.classifyError?.(err) ?? classifyHttpError(err);
 		const ctx: ExecutionContext = {
@@ -450,16 +488,16 @@ export class SyncOrchestrator {
 			transferPool: this.deps.isMobile() ? MOBILE_TRANSFER_POOL : DESKTOP_TRANSFER_POOL,
 		};
 
-		const execution = await executePlan(planning.admission.executable, ctx);
-		const result: ExecutionResult = { ...execution, deferred: planning.admission.deferred };
+		const execution = await executePlan(admission.executable, ctx);
+		const result: ExecutionResult = { ...execution, deferred: admission.deferred };
 		this.updateFailedActionTracker(settings.backendType, result, classifyError);
 
 		// Persist backend state. commitCheckpoint advances the delta cursor (+ file map,
 		// atomically) only on a fully clean cycle; a partial sync keeps the prior cursor.
 		this.pendingAdmissionEvidence = await finalizeSyncCycle({
+			admission,
 			result, pendingEvidence: this.pendingAdmissionEvidence, persistedDebts,
 			localRenameDebts: planning.localRenameDebts,
-			scopeProjection: planning.scopeProjection, observations: changeSet.observations,
 			checkpoint: remoteFs.checkpoint, scopeFingerprint, stateStore: this.stateStore,
 		});
 		// readBackendState now persists only non-secret token state (the cursor lives

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -23,6 +23,7 @@ import { buildSyncRecord } from "./state-committer";
 import { CycleSummary } from "./sync-notification";
 import type { SyncCycleResult } from "./sync-notification";
 import { FailedActionTracker } from "./failed-action-tracker";
+import { projectScope } from "./scope-projection";
 
 export type { SyncStatus };
 
@@ -404,13 +405,12 @@ export class SyncOrchestrator {
 
 		const isMobile = this.deps.isMobile();
 		const maxBytes = settings.mobileMaxFileSizeMB * 1024 * 1024;
+		const scopeProjection = projectScope(changeSet, {
+			classifyPath: (path) => this.isExcluded(path) ? "policy_out" : "included",
+			mobileMaxBytes: isMobile ? maxBytes : undefined,
+		});
 		const filtered = changeSet.entries.filter((e) => {
-			if (this.isExcluded(e.path)) return false;
-			if (isMobile) {
-				const size = Math.max(e.local?.size ?? 0, e.remote?.size ?? 0);
-				if (size > maxBytes) return false;
-			}
-			return true;
+			return scopeProjection.byEndpoint.get(e.path) === "included";
 		});
 
 		if (filtered.length !== changeSet.entries.length) {

--- a/src/sync/path-observation.test.ts
+++ b/src/sync/path-observation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { FileEntity } from "../fs/types";
-import { exactEntity, observePath } from "./path-observation";
+import type { IFileSystem } from "../fs/interface";
+import type { PathObservation } from "./types";
+import { confirmEntryAbsences, exactEntity, observePath } from "./path-observation";
 
 function entity(path: string, pathAuthority?: FileEntity["pathAuthority"]): FileEntity {
 	return { path, pathAuthority, isDirectory: false, size: 1, mtime: 1, hash: "h" };
@@ -41,5 +43,31 @@ describe("observePath", () => {
 		expect(observePath("local", "A.md", null)).toEqual({
 			kind: "absent", side: "local", requestedPath: "A.md", authority: "stat",
 		});
+	});
+});
+
+describe("confirmEntryAbsences", () => {
+	it("indexes observations once instead of rescanning them for every entry", async () => {
+		const count = 80;
+		const entries = Array.from({ length: count }, (_, index) => ({
+			path: `file-${index}.md`, remote: entity(`file-${index}.md`, "actual_resolved"),
+		}));
+		const backing: PathObservation[] = entries.map(({ path }) => ({
+			kind: "unknown" as const, side: "local" as const, requestedPath: path,
+			reason: "not_observed" as const,
+		}));
+		let indexedReads = 0;
+		const observations = new Proxy(backing, {
+			get(target, property, receiver): unknown {
+				if (typeof property === "string" && /^\d+$/.test(property)) indexedReads += 1;
+				return Reflect.get(target, property, receiver) as unknown;
+			},
+		});
+		const fs = { stat: () => Promise.resolve(null) } as unknown as IFileSystem;
+
+		await confirmEntryAbsences({ entries, observations }, fs, fs);
+
+		expect(indexedReads).toBeLessThan(count * 5);
+		expect(observations.every((item) => item.kind === "absent")).toBe(true);
 	});
 });

--- a/src/sync/path-observation.test.ts
+++ b/src/sync/path-observation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { FileEntity } from "../fs/types";
+import { exactEntity, observePath } from "./path-observation";
+
+function entity(path: string, pathAuthority?: FileEntity["pathAuthority"]): FileEntity {
+	return { path, pathAuthority, isDirectory: false, size: 1, mtime: 1, hash: "h" };
+}
+
+describe("observePath", () => {
+	it("recognizes exact and alias paths only from actual-resolved producers", () => {
+		const exact = observePath("local", "A.md", entity("A.md", "actual_resolved"));
+		const alias = observePath("remote", "A.md", entity("a.md", "actual_resolved"));
+
+		expect(exact.kind).toBe("exact");
+		expect(exactEntity(exact)?.path).toBe("A.md");
+		expect(alias).toMatchObject({ kind: "alias", requestedPath: "A.md", resolvedPath: "a.md" });
+		expect(exactEntity(alias)).toBeUndefined();
+	});
+
+	it("keeps requested echoes and unspecified authority unresolved", () => {
+		for (const candidate of [entity("A.md", "requested_echo"), entity("A.md")]) {
+			expect(observePath("remote", "A.md", candidate)).toMatchObject({
+				kind: "present_unresolved", requestedPath: "A.md", returnedPath: "A.md", source: "stat",
+			});
+		}
+	});
+
+	it("records whether unresolved presence came from list or stat", () => {
+		expect(observePath("remote", "A.md", entity("A.md"), "stat", "list")).toMatchObject({
+			kind: "present_unresolved", source: "list",
+		});
+		expect(observePath("remote", "A.md", entity("A.md"))).toMatchObject({
+			kind: "present_unresolved", source: "stat",
+		});
+	});
+
+	it("distinguishes checkpoint tombstones from stat absence", () => {
+		expect(observePath("remote", "A.md", null, "checkpoint_deleted")).toEqual({
+			kind: "absent", side: "remote", requestedPath: "A.md", authority: "checkpoint_deleted",
+		});
+		expect(observePath("local", "A.md", null)).toEqual({
+			kind: "absent", side: "local", requestedPath: "A.md", authority: "stat",
+		});
+	});
+});

--- a/src/sync/path-observation.ts
+++ b/src/sync/path-observation.ts
@@ -26,14 +26,13 @@ export function exactEntity(observation: PathObservation): FileEntity | undefine
 		: undefined;
 }
 
-/** Replace listing uncertainty with authoritative stat observations for baseline paths. */
-export async function confirmBaselineAbsences(
+/** Replace listing uncertainty with authoritative stat observations before planning absence. */
+export async function confirmEntryAbsences(
 	changeSet: { entries: MixedEntity[]; observations: PathObservation[] },
 	localFs: IFileSystem,
 	remoteFs: IFileSystem,
 ): Promise<void> {
 	const candidates = changeSet.entries.flatMap((entry) => {
-		if (!entry.prevSync) return [];
 		const missing: Array<{ side: SyncSide; fs: IFileSystem }> = [];
 		if (!entry.local && needsConfirmation(changeSet.observations, "local", entry.path)) {
 			missing.push({ side: "local", fs: localFs });

--- a/src/sync/path-observation.ts
+++ b/src/sync/path-observation.ts
@@ -32,33 +32,60 @@ export async function confirmEntryAbsences(
 	localFs: IFileSystem,
 	remoteFs: IFileSystem,
 ): Promise<void> {
+	const observationIndexes = new Map<string, number>();
+	changeSet.observations.forEach((observation, index) => {
+		const key = observationKey(observation.side, observation.requestedPath);
+		if (!observationIndexes.has(key)) observationIndexes.set(key, index);
+	});
 	const candidates = changeSet.entries.flatMap((entry) => {
 		const missing: Array<{ side: SyncSide; fs: IFileSystem }> = [];
-		if (!entry.local && needsConfirmation(changeSet.observations, "local", entry.path)) {
+		if (!entry.local && needsConfirmation(observationAt(
+			changeSet.observations, observationIndexes, "local", entry.path,
+		))) {
 			missing.push({ side: "local", fs: localFs });
 		}
-		if (!entry.remote && needsConfirmation(changeSet.observations, "remote", entry.path)) {
+		if (!entry.remote && needsConfirmation(observationAt(
+			changeSet.observations, observationIndexes, "remote", entry.path,
+		))) {
 			missing.push({ side: "remote", fs: remoteFs });
 		}
 		return missing.map(({ side, fs }) => ({ entry, side, fs }));
 	});
 	const pool = new AsyncPool(10);
-	await Promise.all(candidates.map(({ entry, side, fs }) => pool.run(async () => {
+	const confirmed = await Promise.all(candidates.map(({ entry, side, fs }) => pool.run(async () => {
 		const observation = observePath(side, entry.path, await fs.stat(entry.path));
-		replaceObservation(changeSet.observations, observation);
+		return { entry, side, observation };
+	})));
+	for (const { entry, side, observation } of confirmed) {
+		const key = observationKey(side, entry.path);
+		const index = observationIndexes.get(key);
+		if (index === undefined) {
+			observationIndexes.set(key, changeSet.observations.length);
+			changeSet.observations.push(observation);
+		} else {
+			changeSet.observations[index] = observation;
+		}
 		const entity = exactEntity(observation);
 		if (side === "local") entry.local = entity;
 		else entry.remote = entity;
-	})));
+	}
 }
 
-function needsConfirmation(
+function observationAt(
 	observations: readonly PathObservation[],
+	indexes: ReadonlyMap<string, number>,
 	side: SyncSide,
 	path: string,
-): boolean {
-	const observation = observations.find((candidate) =>
-		candidate.side === side && candidate.requestedPath === path);
+): PathObservation | undefined {
+	const index = indexes.get(observationKey(side, path));
+	return index === undefined ? undefined : observations[index];
+}
+
+function observationKey(side: SyncSide, path: string): string {
+	return `${side}\0${path}`;
+}
+
+function needsConfirmation(observation: PathObservation | undefined): boolean {
 	return !observation || observation.kind === "unknown" ||
 		(observation.kind === "present_unresolved" && observation.source === "list");
 }

--- a/src/sync/path-observation.ts
+++ b/src/sync/path-observation.ts
@@ -1,0 +1,89 @@
+import type { FileEntity } from "../fs/types";
+import type { IFileSystem } from "../fs/interface";
+import type { IdentityEvidence, MixedEntity, PathObservation, SyncSide } from "./types";
+import { AsyncPool } from "../queue/async-queue";
+
+export function observePath(
+	side: SyncSide,
+	requestedPath: string,
+	entity: FileEntity | null | undefined,
+	absenceAuthority: "stat" | "checkpoint_deleted" = "stat",
+	source: "stat" | "list" = "stat",
+): PathObservation {
+	if (!entity) return { kind: "absent", side, requestedPath, authority: absenceAuthority };
+	if (entity.pathAuthority !== "actual_resolved") {
+		return {
+			kind: "present_unresolved", side, requestedPath, returnedPath: entity.path, entity, source,
+		};
+	}
+	if (entity.path === requestedPath) return { kind: "exact", side, requestedPath, entity };
+	return { kind: "alias", side, requestedPath, resolvedPath: entity.path, entity };
+}
+
+export function exactEntity(observation: PathObservation): FileEntity | undefined {
+	return observation.kind === "exact" && !observation.entity.isDirectory
+		? observation.entity
+		: undefined;
+}
+
+/** Replace listing uncertainty with authoritative stat observations for baseline paths. */
+export async function confirmBaselineAbsences(
+	changeSet: { entries: MixedEntity[]; observations: PathObservation[] },
+	localFs: IFileSystem,
+	remoteFs: IFileSystem,
+): Promise<void> {
+	const candidates = changeSet.entries.flatMap((entry) => {
+		if (!entry.prevSync) return [];
+		const missing: Array<{ side: SyncSide; fs: IFileSystem }> = [];
+		if (!entry.local && needsConfirmation(changeSet.observations, "local", entry.path)) {
+			missing.push({ side: "local", fs: localFs });
+		}
+		if (!entry.remote && needsConfirmation(changeSet.observations, "remote", entry.path)) {
+			missing.push({ side: "remote", fs: remoteFs });
+		}
+		return missing.map(({ side, fs }) => ({ entry, side, fs }));
+	});
+	const pool = new AsyncPool(10);
+	await Promise.all(candidates.map(({ entry, side, fs }) => pool.run(async () => {
+		const observation = observePath(side, entry.path, await fs.stat(entry.path));
+		replaceObservation(changeSet.observations, observation);
+		const entity = exactEntity(observation);
+		if (side === "local") entry.local = entity;
+		else entry.remote = entity;
+	})));
+}
+
+function needsConfirmation(
+	observations: readonly PathObservation[],
+	side: SyncSide,
+	path: string,
+): boolean {
+	const observation = observations.find((candidate) =>
+		candidate.side === side && candidate.requestedPath === path);
+	return !observation || observation.kind === "unknown" ||
+		(observation.kind === "present_unresolved" && observation.source === "list");
+}
+
+export function ensureRenameEndpointObservations(
+	observations: PathObservation[],
+	evidence: readonly IdentityEvidence[],
+): void {
+	for (const item of evidence) {
+		if (item.kind !== "rename") continue;
+		for (const requestedPath of [item.oldPath, item.newPath]) {
+			if (!observations.some((observation) =>
+				observation.side === item.side && observation.requestedPath === requestedPath)) {
+				observations.push({
+					kind: "unknown", side: item.side, requestedPath, reason: "not_observed",
+				});
+			}
+		}
+	}
+}
+
+export function replaceObservation(observations: PathObservation[], replacement: PathObservation): void {
+	const index = observations.findIndex((observation) =>
+		observation.side === replacement.side && observation.requestedPath === replacement.requestedPath);
+	if (index === -1) observations.push(replacement);
+	else observations[index] = replacement;
+}

--- a/src/sync/path-observation.ts
+++ b/src/sync/path-observation.ts
@@ -81,6 +81,33 @@ export function ensureRenameEndpointObservations(
 	}
 }
 
+/** Resolve rename-origin endpoints that collection did not otherwise observe. */
+export async function confirmUnknownRenameEndpoints(
+	changeSet: { observations: PathObservation[]; identityEvidence: readonly IdentityEvidence[] },
+	localFs: IFileSystem,
+	remoteFs: IFileSystem,
+): Promise<void> {
+	const candidates = new Map<string, { side: SyncSide; path: string; fs: IFileSystem }>();
+	for (const evidence of changeSet.identityEvidence) {
+		if (evidence.kind !== "rename") continue;
+		for (const path of [evidence.oldPath, evidence.newPath]) {
+			const observation = changeSet.observations.find((candidate) =>
+				candidate.side === evidence.side && candidate.requestedPath === path);
+			if (observation?.kind === "unknown" && observation.reason === "not_observed") {
+				candidates.set(`${evidence.side}\0${path}`, {
+					side: evidence.side,
+					path,
+					fs: evidence.side === "local" ? localFs : remoteFs,
+				});
+			}
+		}
+	}
+	const pool = new AsyncPool(10);
+	await Promise.all([...candidates.values()].map(({ side, path, fs }) => pool.run(async () => {
+		replaceObservation(changeSet.observations, observePath(side, path, await fs.stat(path)));
+	})));
+}
+
 export function replaceObservation(observations: PathObservation[], replacement: PathObservation): void {
 	const index = observations.findIndex((observation) =>
 		observation.side === replacement.side && observation.requestedPath === replacement.requestedPath);

--- a/src/sync/path-observation.ts
+++ b/src/sync/path-observation.ts
@@ -108,6 +108,33 @@ export async function confirmUnknownRenameEndpoints(
 	})));
 }
 
+/** Confirm the other side of durable rename evidence so a clean replay can retire its debt. */
+export async function confirmCarriedRenameOppositeEndpoints(
+	observations: PathObservation[],
+	evidence: readonly IdentityEvidence[],
+	localFs: IFileSystem,
+	remoteFs: IFileSystem,
+): Promise<void> {
+	const candidates = new Map<string, { side: SyncSide; path: string; fs: IFileSystem }>();
+	for (const item of evidence) {
+		if (item.kind !== "rename") continue;
+		const side = item.side === "local" ? "remote" : "local";
+		const fs = side === "local" ? localFs : remoteFs;
+		for (const path of [item.oldPath, item.newPath]) {
+			const existing = observations.find((observation) =>
+				observation.side === side && observation.requestedPath === path);
+			if (!existing || existing.kind === "unknown" ||
+				(existing.kind === "present_unresolved" && existing.source === "list")) {
+				candidates.set(`${side}\0${path}`, { side, path, fs });
+			}
+		}
+	}
+	const pool = new AsyncPool(10);
+	await Promise.all([...candidates.values()].map(({ side, path, fs }) => pool.run(async () => {
+		replaceObservation(observations, observePath(side, path, await fs.stat(path)));
+	})));
+}
+
 export function replaceObservation(observations: PathObservation[], replacement: PathObservation): void {
 	const index = observations.findIndex((observation) =>
 		observation.side === replacement.side && observation.requestedPath === replacement.requestedPath);

--- a/src/sync/plan-admission-graph.ts
+++ b/src/sync/plan-admission-graph.ts
@@ -1,0 +1,121 @@
+import type { RefinedSyncPlan } from "./rename-optimizer";
+import type { IdentityEvidence, PathObservation, ScopeProjection, SyncAction } from "./types";
+
+export interface AdmissionComponent {
+	paths: Set<string>;
+	actions: SyncAction[];
+	evidence: IdentityEvidence[];
+	observations: PathObservation[];
+}
+
+export function buildAdmissionComponents(
+	plan: RefinedSyncPlan,
+	observations: readonly PathObservation[],
+	scope: ScopeProjection,
+): AdmissionComponent[] {
+	const graph = new PathGraph();
+	const actionPathSets = plan.actions.map(actionPaths);
+	const evidencePathSets = plan.identityEvidence.map(evidencePaths);
+	const observationPathSets = observations.map(observationPaths);
+	const knownPaths = new Set([
+		...actionPathSets.flat(), ...evidencePathSets.flat(), ...observationPathSets.flat(),
+		...scope.byEndpoint.keys(),
+	]);
+	for (const paths of actionPathSets) graph.connect(paths);
+	for (const [index, evidence] of plan.identityEvidence.entries()) {
+		const paths = evidencePathSets[index]!;
+		graph.connect(evidence.kind === "rename" && evidence.isFolder
+			? [...paths, ...folderDescendantPaths(evidence.oldPath, evidence.newPath, knownPaths)]
+			: paths);
+	}
+	for (const paths of observationPathSets) graph.connect(paths);
+
+	const byRoot = new Map<string, AdmissionComponent>();
+	for (const path of graph.paths()) {
+		const root = graph.root(path);
+		const component = byRoot.get(root) ?? emptyComponent();
+		component.paths.add(path);
+		byRoot.set(root, component);
+	}
+	for (const action of plan.actions) componentFor(byRoot, graph, actionPaths(action)).actions.push(action);
+	for (const evidence of plan.identityEvidence) {
+		componentFor(byRoot, graph, evidencePaths(evidence)).evidence.push(evidence);
+	}
+	for (const observation of observations) {
+		componentFor(byRoot, graph, observationPaths(observation)).observations.push(observation);
+	}
+	return [...byRoot.values()].filter((component) => component.actions.length > 0);
+}
+
+function folderDescendantPaths(
+	oldPath: string,
+	newPath: string,
+	knownPaths: ReadonlySet<string>,
+): string[] {
+	const oldPrefix = `${oldPath}/`;
+	const newPrefix = `${newPath}/`;
+	return [...knownPaths].filter((path) => path.startsWith(oldPrefix) || path.startsWith(newPrefix));
+}
+
+function actionPaths(action: SyncAction): string[] {
+	if (action.action !== "rename_local" && action.action !== "rename_remote") return [action.path];
+	return [action.oldPath, action.path, ...(action.descendants?.flatMap((pair) => [pair.oldPath, pair.newPath]) ?? [])];
+}
+
+function evidencePaths(evidence: IdentityEvidence): string[] {
+	if (evidence.kind === "rename") return [evidence.oldPath, evidence.newPath];
+	if (evidence.kind === "alias") return [evidence.requestedPath, evidence.resolvedPath];
+	return evidence.occurrences.map((occurrence) => occurrence.path);
+}
+
+function observationPaths(observation: PathObservation): string[] {
+	if (observation.kind === "alias") return [observation.requestedPath, observation.resolvedPath];
+	if (observation.kind === "present_unresolved") {
+		return [observation.requestedPath, observation.returnedPath];
+	}
+	return [observation.requestedPath];
+}
+
+function emptyComponent(): AdmissionComponent {
+	return { paths: new Set(), actions: [], evidence: [], observations: [] };
+}
+
+function componentFor(
+	components: Map<string, AdmissionComponent>,
+	graph: PathGraph,
+	paths: readonly string[],
+): AdmissionComponent {
+	return components.get(graph.root(paths[0]!))!;
+}
+
+class PathGraph {
+	private readonly parent = new Map<string, string>();
+
+	connect(paths: readonly string[]): void {
+		if (paths.length === 0) return;
+		for (const path of paths) this.add(path);
+		for (const path of paths.slice(1)) this.union(paths[0]!, path);
+	}
+
+	paths(): Iterable<string> {
+		return this.parent.keys();
+	}
+
+	root(path: string): string {
+		const parent = this.parent.get(path);
+		if (!parent || parent === path) return path;
+		const root = this.root(parent);
+		this.parent.set(path, root);
+		return root;
+	}
+
+	private add(path: string): void {
+		if (!this.parent.has(path)) this.parent.set(path, path);
+	}
+
+	private union(left: string, right: string): void {
+		const leftRoot = this.root(left);
+		const rightRoot = this.root(right);
+		if (leftRoot !== rightRoot) this.parent.set(rightRoot, leftRoot);
+	}
+}

--- a/src/sync/plan-admission-graph.ts
+++ b/src/sync/plan-admission-graph.ts
@@ -1,5 +1,4 @@
-import type { RefinedSyncPlan } from "./rename-optimizer";
-import type { IdentityEvidence, PathObservation, ScopeProjection, SyncAction } from "./types";
+import type { IdentityEvidence, PathObservation, ScopeProjection, SyncAction, SyncPlan } from "./types";
 
 export interface AdmissionComponent {
 	paths: Set<string>;
@@ -9,20 +8,21 @@ export interface AdmissionComponent {
 }
 
 export function buildAdmissionComponents(
-	plan: RefinedSyncPlan,
+	plan: SyncPlan,
+	identityEvidence: readonly IdentityEvidence[],
 	observations: readonly PathObservation[],
 	scope: ScopeProjection,
 ): AdmissionComponent[] {
 	const graph = new PathGraph();
 	const actionPathSets = plan.actions.map(actionPaths);
-	const evidencePathSets = plan.identityEvidence.map(evidencePaths);
+	const evidencePathSets = identityEvidence.map(evidencePaths);
 	const observationPathSets = observations.map(observationPaths);
 	const knownPaths = new Set([
 		...actionPathSets.flat(), ...evidencePathSets.flat(), ...observationPathSets.flat(),
 		...scope.byEndpoint.keys(),
 	]);
 	for (const paths of actionPathSets) graph.connect(paths);
-	for (const [index, evidence] of plan.identityEvidence.entries()) {
+	for (const [index, evidence] of identityEvidence.entries()) {
 		const paths = evidencePathSets[index]!;
 		graph.connect(evidence.kind === "rename" && evidence.isFolder
 			? [...paths, ...folderDescendantPaths(evidence.oldPath, evidence.newPath, knownPaths)]
@@ -38,7 +38,7 @@ export function buildAdmissionComponents(
 		byRoot.set(root, component);
 	}
 	for (const action of plan.actions) componentFor(byRoot, graph, actionPaths(action)).actions.push(action);
-	for (const evidence of plan.identityEvidence) {
+	for (const evidence of identityEvidence) {
 		componentFor(byRoot, graph, evidencePaths(evidence)).evidence.push(evidence);
 	}
 	for (const observation of observations) {

--- a/src/sync/plan-admission-graph.ts
+++ b/src/sync/plan-admission-graph.ts
@@ -1,4 +1,4 @@
-import type { IdentityEvidence, PathObservation, ScopeProjection, SyncAction, SyncPlan } from "./types";
+import type { IdentityEvidence, PathObservation, ScopeProjection, SyncAction } from "./types";
 
 export interface AdmissionComponent {
 	paths: Set<string>;
@@ -8,7 +8,7 @@ export interface AdmissionComponent {
 }
 
 export function buildAdmissionComponents(
-	plan: SyncPlan,
+	plan: { readonly actions: readonly SyncAction[] },
 	identityEvidence: readonly IdentityEvidence[],
 	observations: readonly PathObservation[],
 	scope: ScopeProjection,
@@ -44,7 +44,10 @@ export function buildAdmissionComponents(
 	for (const observation of observations) {
 		componentFor(byRoot, graph, observationPaths(observation)).observations.push(observation);
 	}
-	return [...byRoot.values()].filter((component) => component.actions.length > 0);
+	return [...byRoot.values()].filter((component) =>
+		component.actions.length > 0 || component.evidence.length > 0 ||
+		component.observations.some((observation) =>
+			observation.kind === "present_unresolved" || observation.kind === "unknown"));
 }
 
 function folderDescendantPaths(

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -232,6 +232,45 @@ describe("admitDestructivePlan", () => {
 		expect(result.deferred).toEqual([]);
 	});
 
+	it("admits a remote case-only rename when the local destination aliases its source", () => {
+		const action: SyncAction = {
+			path: "a.md", oldPath: "A.md", action: "rename_local",
+			local: entity("A.md"), remote: entity("a.md", "X"),
+		};
+		const evidence: IdentityEvidence[] = [
+			remoteRename({ oldPath: "A.md", newPath: "a.md" }),
+			{ kind: "alias", side: "local", requestedPath: "a.md", resolvedPath: "A.md" },
+		];
+
+		const result = admit([action], evidence, [], projection({
+			"A.md": "included", "a.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("admits a local case-only rename when the remote destination aliases its source", () => {
+		const action: SyncAction = {
+			path: "a.md", oldPath: "A.md", action: "rename_remote",
+			local: entity("a.md"), remote: entity("A.md", "X"),
+		};
+		const evidence: IdentityEvidence[] = [
+			{
+				kind: "rename", side: "local", oldPath: "A.md", newPath: "a.md",
+				isFolder: false, authority: "reported",
+			},
+			{ kind: "alias", side: "remote", requestedPath: "a.md", resolvedPath: "A.md" },
+		];
+
+		const result = admit([action], evidence, [], projection({
+			"A.md": "included", "a.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+	});
+
 	it("defers a native rename whose current destination identity contradicts the report", () => {
 		const action: SyncAction = {
 			path: "B.md", oldPath: "A.md", action: "rename_local",

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { FileEntity } from "../fs/types";
-import { admitDestructivePlan } from "./plan-admission";
+import {
+	admitDestructivePlan,
+	captureCycleAdmissionSnapshot,
+	type AuthorizedSyncPlan,
+} from "./plan-admission";
 import type {
 	IdentityEvidence,
 	PathObservation,
@@ -23,7 +27,9 @@ function admit(
 	observations: PathObservation[] = [],
 	scope: ScopeProjection = projection({}),
 ) {
-	return admitDestructivePlan({ actions }, evidence, observations, scope);
+	return admitDestructivePlan(captureCycleAdmissionSnapshot(
+		{ actions }, evidence, observations, scope, "backend\0root",
+	));
 }
 
 function remoteRename(overrides: Partial<Extract<IdentityEvidence, { kind: "rename" }>> = {}): IdentityEvidence {
@@ -45,7 +51,7 @@ describe("admitDestructivePlan", () => {
 		expect(result.deferred).toEqual([]);
 	});
 
-	it("does not connect case-distinct paths without evidence", () => {
+	it("defers unobserved case-distinct deletions independently", () => {
 		const actions: SyncAction[] = [
 			{ path: "A.md", action: "delete_local", local: entity("A.md") },
 			{ path: "a.md", action: "delete_remote", remote: entity("a.md") },
@@ -53,8 +59,11 @@ describe("admitDestructivePlan", () => {
 
 		const result = admit(actions);
 
-		expect(result.executable.actions).toEqual(actions);
-		expect(result.deferred).toEqual([]);
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred).toHaveLength(2);
+		expect(result.deferred.map((item) => item.reasons)).toEqual([
+			["unknown_observation"], ["unknown_observation"],
+		]);
 	});
 
 	it("defers both opposing deletes joined by stable identity", () => {
@@ -92,6 +101,20 @@ describe("admitDestructivePlan", () => {
 		expect(result.deferred[0]!.reasons).toEqual(["identity_postcondition_unproven"]);
 	});
 
+	it("does not let unrelated stable identity replace authoritative delete absence", () => {
+		const action: SyncAction = { path: "A.md", action: "delete_local", local: entity("A.md") };
+		const evidence: IdentityEvidence[] = [{
+			kind: "stable_identity", side: "remote", identityKey: "X", occurrences: [
+				{ side: "remote", phase: "baseline", path: "A.md", identityKey: "X" },
+			],
+		}];
+
+		const result = admit([action], evidence);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]?.reasons).toEqual(["unknown_observation"]);
+	});
+
 	it("defers every action touching a requested-echo observation", () => {
 		const actions: SyncAction[] = [
 			{ path: "A.md", action: "delete_local", local: entity("A.md") },
@@ -109,6 +132,64 @@ describe("admitDestructivePlan", () => {
 		expect(result.deferred[0]).toMatchObject({
 			paths: ["A.md", "B.md"], reasons: ["present_unresolved"], actions: actions.slice(0, 2),
 		});
+	});
+
+	it("retains and defers an unresolved evidence component with no actions", () => {
+		const observations: PathObservation[] = [{
+			kind: "present_unresolved", side: "remote", requestedPath: "A.md", returnedPath: "B.md",
+			entity: { ...entity("B.md"), pathAuthority: "requested_echo" }, source: "stat",
+		}];
+
+		const result = admit([], [remoteRename()], observations);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred).toHaveLength(1);
+		expect(result.deferred[0]).toMatchObject({
+			paths: ["A.md", "B.md"], reasons: ["present_unresolved"], actions: [],
+		});
+	});
+
+	it("resolves an actionless rename after authoritative two-sided convergence", () => {
+		const observations: PathObservation[] = (["local", "remote"] as const).flatMap((side) => [
+			{ kind: "absent" as const, side, requestedPath: "A.md", authority: "stat" as const },
+			{ kind: "exact" as const, side, requestedPath: "B.md", entity: entity("B.md", "X") },
+		]);
+
+		const result = admit([], [remoteRename()], observations, projection({
+			"A.md": "included", "B.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred).toEqual([]);
+		expect(result.dispositions).toEqual([expect.objectContaining({
+			kind: "resolved_no_action", paths: ["A.md", "B.md"], actions: [],
+		})]);
+	});
+
+	it("keeps captured inputs stable when caller-owned containers change", () => {
+		const action: SyncAction = { path: "gone.md", action: "delete_local", local: entity("gone.md") };
+		const plan = { actions: [action] };
+		const evidence: IdentityEvidence[] = [];
+		const observations: PathObservation[] = [{
+			kind: "absent", side: "remote", requestedPath: "gone.md", authority: "checkpoint_deleted",
+		}];
+		const scope = projection({ "gone.md": "included" });
+		const snapshot = captureCycleAdmissionSnapshot(plan, evidence, observations, scope, "backend\0root");
+
+		plan.actions.length = 0;
+		observations.length = 0;
+		(scope.byEndpoint as Map<string, ScopeDisposition>).set("gone.md", "unknown");
+
+		const result = admitDestructivePlan(snapshot);
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.snapshot.namespace).toBe("backend\0root");
+	});
+
+	it("keeps plain proposals outside the executor contract", () => {
+		const proposal = { actions: [] };
+		// @ts-expect-error A plain proposal is not an Admission-issued plan.
+		const unauthorized: AuthorizedSyncPlan = proposal;
+		expect(unauthorized.actions).toEqual([]);
 	});
 
 	it("defers match and delete together when an alias links them", () => {
@@ -392,7 +473,9 @@ describe("admitDestructivePlan", () => {
 		const scope = projection({ "gone.md": "included" });
 		const plan = { actions: [action] };
 
-		admitDestructivePlan(plan, evidence, observations, scope);
+		admitDestructivePlan(captureCycleAdmissionSnapshot(
+			plan, evidence, observations, scope, "backend\0root",
+		));
 
 		expect(plan).toEqual({ actions: [action] });
 		expect(evidence).toEqual([]);

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, it } from "vitest";
+import type { FileEntity } from "../fs/types";
+import type { RefinedSyncPlan } from "./rename-optimizer";
+import { admitDestructivePlan } from "./plan-admission";
+import type {
+	IdentityEvidence,
+	PathObservation,
+	ScopeDisposition,
+	ScopeProjection,
+	SyncAction,
+} from "./types";
+
+function entity(path: string, identityKey?: string): FileEntity {
+	return { path, identityKey, pathAuthority: "actual_resolved", isDirectory: false, size: 1, mtime: 1, hash: "h" };
+}
+
+function projection(entries: Record<string, ScopeDisposition>): ScopeProjection {
+	return { byEndpoint: new Map(Object.entries(entries)) };
+}
+
+function admit(
+	actions: SyncAction[],
+	evidence: IdentityEvidence[] = [],
+	observations: PathObservation[] = [],
+	scope: ScopeProjection = projection({}),
+) {
+	const plan: RefinedSyncPlan = { actions, identityEvidence: evidence };
+	return admitDestructivePlan(plan, observations, scope);
+}
+
+function remoteRename(overrides: Partial<Extract<IdentityEvidence, { kind: "rename" }>> = {}): IdentityEvidence {
+	return {
+		kind: "rename", side: "remote", oldPath: "A.md", newPath: "B.md",
+		isFolder: false, authority: "reported", identityKey: "X", ...overrides,
+	};
+}
+
+describe("admitDestructivePlan", () => {
+	it("admits a genuine exact-path remote deletion without identity evidence", () => {
+		const action: SyncAction = { path: "gone.md", action: "delete_local", local: entity("gone.md") };
+
+		const result = admit([action], [], [{
+			kind: "absent", side: "remote", requestedPath: "gone.md", authority: "checkpoint_deleted",
+		}]);
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("does not connect case-distinct paths without evidence", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "delete_local", local: entity("A.md") },
+			{ path: "a.md", action: "delete_remote", remote: entity("a.md") },
+		];
+
+		const result = admit(actions);
+
+		expect(result.executable.actions).toEqual(actions);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("defers both opposing deletes joined by stable identity", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "delete_local", local: entity("A.md") },
+			{ path: "a.md", action: "delete_remote", remote: entity("a.md", "X") },
+		];
+		const evidence: IdentityEvidence[] = [{
+			kind: "stable_identity", side: "remote", identityKey: "X", occurrences: [
+				{ side: "remote", phase: "baseline", path: "A.md", identityKey: "X" },
+				{ side: "remote", phase: "current", path: "a.md", identityKey: "X" },
+			],
+		}];
+
+		const result = admit(actions, evidence);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]).toMatchObject({
+			paths: ["A.md", "a.md"], reasons: ["opposing_deletes"], actions,
+		});
+	});
+
+	it("defers a stable-identity component without a permitted postcondition", () => {
+		const action: SyncAction = { path: "A.md", action: "delete_local", local: entity("A.md") };
+		const evidence: IdentityEvidence[] = [{
+			kind: "stable_identity", side: "remote", identityKey: "X", occurrences: [
+				{ side: "remote", phase: "baseline", path: "A.md", identityKey: "X" },
+				{ side: "remote", phase: "current", path: "B.md", identityKey: "X" },
+			],
+		}];
+
+		const result = admit([action], evidence);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["identity_postcondition_unproven"]);
+	});
+
+	it("defers every action touching a requested-echo observation", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "delete_local", local: entity("A.md") },
+			{ path: "B.md", action: "match", remote: entity("B.md") },
+			{ path: "safe.md", action: "push", local: entity("safe.md") },
+		];
+		const observations: PathObservation[] = [{
+			kind: "present_unresolved", side: "remote", requestedPath: "A.md", returnedPath: "B.md",
+			entity: { ...entity("B.md"), pathAuthority: "requested_echo" }, source: "stat",
+		}];
+
+		const result = admit(actions, [], observations);
+
+		expect(result.executable.actions).toEqual([actions[2]]);
+		expect(result.deferred[0]).toMatchObject({
+			paths: ["A.md", "B.md"], reasons: ["present_unresolved"], actions: actions.slice(0, 2),
+		});
+	});
+
+	it("defers match and delete together when an alias links them", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "delete_local", local: entity("A.md") },
+			{ path: "a.md", action: "match", remote: entity("a.md") },
+		];
+		const evidence: IdentityEvidence[] = [{
+			kind: "alias", side: "local", requestedPath: "A.md", resolvedPath: "a.md",
+		}];
+
+		const result = admit(actions, evidence);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]).toMatchObject({ reasons: ["alias_target_mutation"], actions });
+	});
+
+	it("defers an opposite-side delete that treats an alias request as independently absent", () => {
+		const action: SyncAction = { path: "A.md", action: "delete_remote", remote: entity("A.md", "X") };
+		const evidence: IdentityEvidence[] = [{
+			kind: "alias", side: "local", requestedPath: "A.md", resolvedPath: "a.md",
+		}];
+
+		const result = admit([action], evidence);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["alias_target_mutation"]);
+	});
+
+	it("admits an exact native rename matching reported movement", () => {
+		const action: SyncAction = {
+			path: "B.md", oldPath: "A.md", action: "rename_local",
+			local: entity("A.md"), remote: entity("B.md", "X"),
+		};
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit([action], [remoteRename()], [], scope);
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("defers a native rename whose current destination identity contradicts the report", () => {
+		const action: SyncAction = {
+			path: "B.md", oldPath: "A.md", action: "rename_local",
+			local: entity("A.md"), remote: entity("B.md", "Y"),
+		};
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit([action], [remoteRename()], [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["conflicting_identity"]);
+	});
+
+	it("defers a reported rename that contradicts stable baseline identity", () => {
+		const action: SyncAction = {
+			path: "B.md", oldPath: "A.md", action: "rename_local",
+			local: entity("A.md"), remote: entity("B.md", "X"),
+		};
+		const evidence: IdentityEvidence[] = [remoteRename(), {
+			kind: "stable_identity", side: "remote", identityKey: "Y", occurrences: [
+				{ side: "remote", phase: "baseline", path: "A.md", identityKey: "Y" },
+				{ side: "remote", phase: "current", path: "C.md", identityKey: "Y" },
+			],
+		}];
+		const scope = projection({ "A.md": "included", "B.md": "included", "C.md": "included" });
+
+		const result = admit([action], evidence, [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["conflicting_identity"]);
+	});
+
+	it("admits a native rename when alias evidence is on the source side", () => {
+		const action: SyncAction = {
+			path: "a.md", oldPath: "A.md", action: "rename_remote",
+			local: entity("a.md"), remote: entity("A.md", "X"),
+		};
+		const evidence: IdentityEvidence[] = [
+			remoteRename({ side: "local", oldPath: "A.md", newPath: "a.md", identityKey: undefined }),
+			{ kind: "alias", side: "local", requestedPath: "A.md", resolvedPath: "a.md" },
+		];
+		const scope = projection({ "A.md": "included", "a.md": "included" });
+
+		const result = admit([action], evidence, [], scope);
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("defers a native rename when its target side already occupies the destination", () => {
+		const action: SyncAction = {
+			path: "B.md", oldPath: "A.md", action: "rename_remote",
+			local: entity("B.md"), remote: entity("A.md", "X"),
+		};
+		const evidence = [remoteRename({ side: "local", identityKey: undefined })];
+		const observations: PathObservation[] = [{
+			kind: "exact", side: "remote", requestedPath: "B.md", entity: entity("B.md", "Y"),
+		}];
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit([action], evidence, observations, scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["rename_mismatch"]);
+	});
+
+	it("defers a reported rename whose refined actions do not prove a safe postcondition", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "delete_local", local: entity("A.md") },
+			{ path: "B.md", action: "delete_remote", remote: entity("B.md", "X") },
+		];
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit(actions, [remoteRename()], [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["opposing_deletes"]);
+	});
+
+	it("admits the exact in-scope to policy-out consequence", () => {
+		const action: SyncAction = { path: "A.md", action: "delete_local", local: entity("A.md") };
+		const scope = projection({ "A.md": "included", "B.md": "policy_out" });
+
+		const result = admit([action], [remoteRename()], [], scope);
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("defers a rename crossing an unknown scope endpoint", () => {
+		const action: SyncAction = { path: "A.md", action: "delete_local", local: entity("A.md") };
+		const scope = projection({ "A.md": "included", "B.md": "unknown" });
+
+		const result = admit([action], [remoteRename()], [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["unknown_scope"]);
+	});
+
+	it("admits source recreation when unequal remote identities prove both resources", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "pull", remote: entity("A.md", "Y") },
+			{ path: "B.md", action: "pull", remote: entity("B.md", "X") },
+		];
+		const observations: PathObservation[] = [
+			{ kind: "exact", side: "remote", requestedPath: "A.md", entity: entity("A.md", "Y") },
+			{ kind: "exact", side: "remote", requestedPath: "B.md", entity: entity("B.md", "X") },
+		];
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit(actions, [remoteRename()], observations, scope);
+
+		expect(result.executable.actions).toEqual(actions);
+		expect(result.deferred).toEqual([]);
+	});
+
+	it("defers an unrecognized extra action in a source-recreation component", () => {
+		const actions: SyncAction[] = [
+			{ path: "B.md", action: "pull", remote: entity("B.md", "X") },
+			{ path: "B.md", oldPath: "A.md", action: "rename_remote" },
+		];
+		const observations: PathObservation[] = [
+			{ kind: "exact", side: "remote", requestedPath: "A.md", entity: entity("A.md", "Y") },
+			{ kind: "exact", side: "remote", requestedPath: "B.md", entity: entity("B.md", "X") },
+		];
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit(actions, [remoteRename()], observations, scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["rename_mismatch"]);
+	});
+
+	it("defers a source-recreation component containing an action outside both endpoints", () => {
+		const actions: SyncAction[] = [
+			{ path: "B.md", action: "pull", remote: entity("B.md", "X") },
+			{ path: "C.md", oldPath: "A.md", action: "rename_remote", remote: entity("C.md", "Z") },
+		];
+		const observations: PathObservation[] = [
+			{ kind: "exact", side: "remote", requestedPath: "A.md", entity: entity("A.md", "Y") },
+			{ kind: "exact", side: "remote", requestedPath: "B.md", entity: entity("B.md", "X") },
+			{ kind: "exact", side: "remote", requestedPath: "C.md", entity: entity("C.md", "Z") },
+		];
+		const scope = projection({ "A.md": "included", "B.md": "included", "C.md": "included" });
+
+		const result = admit(actions, [remoteRename()], observations, scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["rename_mismatch"]);
+	});
+
+	it("defers a conflict because its strategy cannot prove source-recreation survival", () => {
+		const actions: SyncAction[] = [
+			{ path: "A.md", action: "pull", remote: entity("A.md", "Y") },
+			{ path: "B.md", action: "conflict", local: entity("B.md"), remote: entity("B.md", "X") },
+		];
+		const observations: PathObservation[] = [
+			{ kind: "exact", side: "remote", requestedPath: "A.md", entity: entity("A.md", "Y") },
+			{ kind: "exact", side: "remote", requestedPath: "B.md", entity: entity("B.md", "X") },
+		];
+		const scope = projection({ "A.md": "included", "B.md": "included" });
+
+		const result = admit(actions, [remoteRename()], observations, scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["rename_mismatch"]);
+	});
+
+	it("defers an out-to-in transfer when the destination side is occupied", () => {
+		const action: SyncAction = { path: "B.md", action: "pull", remote: entity("B.md", "X") };
+		const scope = projection({ "A.md": "policy_out", "B.md": "included" });
+		const observations: PathObservation[] = [{
+			kind: "exact", side: "local", requestedPath: "B.md", entity: entity("B.md"),
+		}];
+
+		const result = admit([action], [remoteRename()], observations, scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["rename_mismatch"]);
+	});
+
+	it("defers a folder rename when a projected descendant is not mapped", () => {
+		const action: SyncAction = {
+			path: "B", oldPath: "A", action: "rename_local", isFolder: true,
+			descendants: [{ oldPath: "A/known.md", newPath: "B/known.md" }],
+		};
+		const evidence = [remoteRename({ oldPath: "A", newPath: "B", isFolder: true })];
+		const scope = projection({
+			A: "included", B: "included", "A/known.md": "included", "B/known.md": "included",
+			"A/missing.md": "included", "B/missing.md": "included",
+		});
+
+		const descendantAction: SyncAction = { path: "A/missing.md", action: "match" };
+		const result = admit([action, descendantAction], evidence, [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.actions).toEqual([action, descendantAction]);
+		expect(result.deferred[0]!.reasons).toEqual(["incomplete_folder_mapping"]);
+	});
+
+	it("defers a folder rename containing a descendant absent from scope projection", () => {
+		const action: SyncAction = {
+			path: "B", oldPath: "A", action: "rename_local", isFolder: true,
+			descendants: [{ oldPath: "A/hidden.md", newPath: "B/hidden.md" }],
+		};
+		const evidence = [remoteRename({ oldPath: "A", newPath: "B", isFolder: true })];
+		const scope = projection({ A: "included", B: "included" });
+
+		const result = admit([action], evidence, [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["incomplete_folder_mapping"]);
+	});
+
+	it("defers a folder rename whose descendant relative paths are crossed", () => {
+		const action: SyncAction = {
+			path: "B", oldPath: "A", action: "rename_local", isFolder: true,
+			descendants: [
+				{ oldPath: "A/x.md", newPath: "B/y.md" },
+				{ oldPath: "A/y.md", newPath: "B/x.md" },
+			],
+		};
+		const evidence = [remoteRename({ oldPath: "A", newPath: "B", isFolder: true })];
+		const scope = projection({
+			A: "included", B: "included", "A/x.md": "included", "B/x.md": "included",
+			"A/y.md": "included", "B/y.md": "included",
+		});
+
+		const result = admit([action], evidence, [], scope);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]!.reasons).toEqual(["incomplete_folder_mapping"]);
+	});
+
+	it("does not mutate the plan, observations, evidence, or projection", () => {
+		const action: SyncAction = { path: "gone.md", action: "delete_local", local: entity("gone.md") };
+		const evidence: IdentityEvidence[] = [];
+		const observations: PathObservation[] = [];
+		const scope = projection({ "gone.md": "included" });
+		const plan: RefinedSyncPlan = { actions: [action], identityEvidence: evidence };
+
+		admitDestructivePlan(plan, observations, scope);
+
+		expect(plan).toEqual({ actions: [action], identityEvidence: [] });
+		expect(observations).toEqual([]);
+		expect([...scope.byEndpoint]).toEqual([["gone.md", "included"]]);
+	});
+});

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import type { FileEntity } from "../fs/types";
-import type { RefinedSyncPlan } from "./rename-optimizer";
 import { admitDestructivePlan } from "./plan-admission";
 import type {
 	IdentityEvidence,
@@ -24,8 +23,7 @@ function admit(
 	observations: PathObservation[] = [],
 	scope: ScopeProjection = projection({}),
 ) {
-	const plan: RefinedSyncPlan = { actions, identityEvidence: evidence };
-	return admitDestructivePlan(plan, observations, scope);
+	return admitDestructivePlan({ actions }, evidence, observations, scope);
 }
 
 function remoteRename(overrides: Partial<Extract<IdentityEvidence, { kind: "rename" }>> = {}): IdentityEvidence {
@@ -392,11 +390,12 @@ describe("admitDestructivePlan", () => {
 		const evidence: IdentityEvidence[] = [];
 		const observations: PathObservation[] = [];
 		const scope = projection({ "gone.md": "included" });
-		const plan: RefinedSyncPlan = { actions: [action], identityEvidence: evidence };
+		const plan = { actions: [action] };
 
-		admitDestructivePlan(plan, observations, scope);
+		admitDestructivePlan(plan, evidence, observations, scope);
 
-		expect(plan).toEqual({ actions: [action], identityEvidence: [] });
+		expect(plan).toEqual({ actions: [action] });
+		expect(evidence).toEqual([]);
 		expect(observations).toEqual([]);
 		expect([...scope.byEndpoint]).toEqual([["gone.md", "included"]]);
 	});

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -356,13 +356,17 @@ function isMatchingAliasRename(
 	action: SyncAction,
 	alias: Extract<IdentityEvidence, { kind: "alias" }>,
 ): boolean {
-	const expected = alias.side === "local" ? "rename_remote" : "rename_local";
-	if (action.action !== expected || action.oldPath !== alias.requestedPath || action.path !== alias.resolvedPath) {
-		return false;
-	}
+	if (action.action !== "rename_local" && action.action !== "rename_remote") return false;
+	// A case-insensitive stat can expose either endpoint as the resolved spelling:
+	// stat(new) → old while the rename is still pending, or stat(old) → new after
+	// the provider has applied it. The alias is compatible only when it connects
+	// exactly the reported movement's endpoints; the reporting side, not the alias
+	// observation side, determines which filesystem the action must mutate.
+	if (!((alias.requestedPath === action.oldPath && alias.resolvedPath === action.path) ||
+		(alias.requestedPath === action.path && alias.resolvedPath === action.oldPath))) return false;
 	return component.evidence.some((evidence) => evidence.kind === "rename" &&
-		evidence.side === alias.side && evidence.oldPath === alias.requestedPath &&
-		evidence.newPath === alias.resolvedPath);
+		evidence.oldPath === action.oldPath && evidence.newPath === action.path &&
+		action.action === (evidence.side === "local" ? "rename_remote" : "rename_local"));
 }
 
 function hasConflictingIdentity(component: AdmissionComponent): boolean {

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -9,6 +9,22 @@ import type {
 	SyncPlan,
 } from "./types";
 
+const authorizedSyncPlanBrand: unique symbol = Symbol("AuthorizedSyncPlan");
+
+export interface CycleAdmissionSnapshot {
+	readonly plan: { readonly actions: readonly SyncAction[] };
+	readonly identityEvidence: readonly IdentityEvidence[];
+	readonly observations: readonly PathObservation[];
+	readonly scope: ScopeProjection;
+	readonly namespace: string;
+}
+
+/** The executor input that only Admission can construct. */
+export interface AuthorizedSyncPlan {
+	readonly actions: readonly SyncAction[];
+	readonly [authorizedSyncPlanBrand]: CycleAdmissionSnapshot;
+}
+
 type AdmissionDeferralReason =
 	| "alias_target_mutation"
 	| "conflicting_identity"
@@ -20,16 +36,52 @@ type AdmissionDeferralReason =
 	| "unknown_observation"
 	| "unknown_scope";
 
-export interface DeferredComponent {
+interface AdmissionComponentDisposition {
 	paths: string[];
 	actions: SyncAction[];
 	evidence: IdentityEvidence[];
+}
+
+export interface AuthorizedComponent extends AdmissionComponentDisposition {
+	kind: "authorized";
+}
+
+export interface ResolvedNoActionComponent extends AdmissionComponentDisposition {
+	kind: "resolved_no_action";
+}
+
+export interface DeferredComponent extends AdmissionComponentDisposition {
+	kind: "deferred";
 	reasons: AdmissionDeferralReason[];
 }
 
+export type AdmissionDisposition =
+	| AuthorizedComponent
+	| ResolvedNoActionComponent
+	| DeferredComponent;
+
 export interface AdmissionResult {
-	executable: { actions: SyncAction[] };
+	snapshot: CycleAdmissionSnapshot;
+	executable: AuthorizedSyncPlan;
+	dispositions: AdmissionDisposition[];
 	deferred: DeferredComponent[];
+}
+
+export function captureCycleAdmissionSnapshot(
+	plan: SyncPlan,
+	identityEvidence: readonly IdentityEvidence[],
+	observations: readonly PathObservation[],
+	scope: ScopeProjection,
+	namespace: string,
+): CycleAdmissionSnapshot {
+	const capturedScope = Object.freeze({ byEndpoint: new Map(scope.byEndpoint) });
+	return Object.freeze({
+		plan: Object.freeze({ actions: Object.freeze([...plan.actions]) }),
+		identityEvidence: Object.freeze([...identityEvidence]),
+		observations: Object.freeze([...observations]),
+		scope: capturedScope,
+		namespace,
+	});
 }
 
 /**
@@ -38,29 +90,44 @@ export interface AdmissionResult {
  * whose cross-path identity cannot be reconciled safely.
  */
 export function admitDestructivePlan(
-	plan: SyncPlan,
-	identityEvidence: readonly IdentityEvidence[],
-	observations: readonly PathObservation[],
-	scope: ScopeProjection,
+	snapshot: CycleAdmissionSnapshot,
 ): AdmissionResult {
-	const components = buildAdmissionComponents(plan, identityEvidence, observations, scope);
-	const deferredActions = new Set<SyncAction>();
-	const deferred: DeferredComponent[] = [];
+	const components = buildAdmissionComponents(
+		snapshot.plan, snapshot.identityEvidence, snapshot.observations, snapshot.scope,
+	);
+	const authorizedActions = new Set<SyncAction>();
+	const dispositions: AdmissionDisposition[] = [];
 	for (const component of components) {
-		const reasons = evaluateComponent(component, scope);
-		if (reasons.length === 0) continue;
-		for (const action of component.actions) deferredActions.add(action);
-		deferred.push({
+		const shared = {
 			paths: [...component.paths].sort(),
 			actions: [...component.actions],
 			evidence: [...component.evidence].sort(compareEvidence),
-			reasons,
-		});
+		};
+		const reasons = evaluateComponent(component, snapshot.scope);
+		if (reasons.length > 0) {
+			dispositions.push({
+				kind: "deferred",
+				...shared,
+				reasons,
+			});
+		} else if (component.actions.length === 0) {
+			dispositions.push({ kind: "resolved_no_action", ...shared });
+		} else {
+			for (const action of component.actions) authorizedActions.add(action);
+			dispositions.push({ kind: "authorized", ...shared });
+		}
 	}
-	deferred.sort((left, right) => left.paths.join("\0").localeCompare(right.paths.join("\0")));
+	dispositions.sort((left, right) => left.paths.join("\0").localeCompare(right.paths.join("\0")));
+	const actions = snapshot.plan.actions.filter((action) => authorizedActions.has(action));
+	const executable = Object.freeze({
+		actions: Object.freeze(actions),
+		[authorizedSyncPlanBrand]: snapshot,
+	});
 	return {
-		executable: { actions: plan.actions.filter((action) => !deferredActions.has(action)) },
-		deferred,
+		snapshot,
+		executable,
+		dispositions,
+		deferred: dispositions.filter((item): item is DeferredComponent => item.kind === "deferred"),
 	};
 }
 
@@ -82,12 +149,21 @@ function evaluateComponent(
 	}
 
 	const renames = component.evidence.filter((item): item is RenameEvidence => item.kind === "rename");
+	const resolvedNoAction = component.actions.length === 0 && renames.length > 0 &&
+		renames.every((rename) => projectRenameScope(rename, scope).consequence === "none" ||
+			resolvedAtBothSides(rename, component.observations));
 	if (renames.length > 0 && reasons.size === 0) {
-		const renameReason = evaluateRenames(component, renames, scope);
+		const renameReason = evaluateRenames(component, renames, scope, resolvedNoAction);
 		if (renameReason) reasons.add(renameReason);
 	} else if (renames.length === 0 && reasons.size === 0 &&
-		component.evidence.some((item) => item.kind === "stable_identity" &&
-			new Set(item.occurrences.map((occurrence) => occurrence.path)).size > 1)) {
+			component.evidence.some((item) => item.kind === "stable_identity" &&
+				new Set(item.occurrences.map((occurrence) => occurrence.path)).size > 1)) {
+		reasons.add("identity_postcondition_unproven");
+	}
+	if (reasons.size === 0 && hasUnprovenStandaloneDelete(component)) {
+		reasons.add("unknown_observation");
+	}
+	if (component.actions.length === 0 && reasons.size === 0 && !resolvedNoAction) {
 		reasons.add("identity_postcondition_unproven");
 	}
 	return [...reasons].sort();
@@ -97,6 +173,7 @@ function evaluateRenames(
 	component: AdmissionComponent,
 	renames: RenameEvidence[],
 	scope: ScopeProjection,
+	resolvedNoAction: boolean,
 ): AdmissionDeferralReason | undefined {
 	const rules = renames.map((rename) => ({ rename, rule: projectRenameScope(rename, scope) }));
 	if (rules.some(({ rename, rule }) => rename.isFolder && rule.consequence === "defer")) {
@@ -106,6 +183,7 @@ function evaluateRenames(
 	if (hasIncompleteNativeFolderMapping(component, rules.map(({ rename, rule }) => ({
 		rename, consequence: rule.consequence,
 	})), scope)) return "incomplete_folder_mapping";
+	if (resolvedNoAction) return undefined;
 	if (matchesNativeRenames(component, rules.map(({ rename, rule }) => ({
 		rename, consequence: rule.consequence,
 	})), scope)) return undefined;
@@ -116,6 +194,37 @@ function evaluateRenames(
 		return undefined;
 	}
 	return "rename_mismatch";
+}
+
+function resolvedAtBothSides(
+	rename: RenameEvidence,
+	observations: readonly PathObservation[],
+): boolean {
+	return (["local", "remote"] as const).every((side) => {
+		const oldObservation = observations.find((item) =>
+			item.side === side && item.requestedPath === rename.oldPath);
+		const newObservation = observations.find((item) =>
+			item.side === side && item.requestedPath === rename.newPath);
+		const oldResolved = oldObservation?.kind === "absent" ||
+			(oldObservation?.kind === "alias" && oldObservation.resolvedPath === rename.newPath);
+		const newResolved = newObservation?.kind === "exact" ||
+			(newObservation?.kind === "alias" && newObservation.resolvedPath === rename.newPath);
+		return oldResolved && newResolved;
+	});
+}
+
+function hasUnprovenStandaloneDelete(component: AdmissionComponent): boolean {
+	if (component.evidence.some((item) => item.kind === "rename")) return false;
+	return component.actions.some((action) => {
+		if (action.action !== "delete_local" && action.action !== "delete_remote") return false;
+		const authoritySide = action.action === "delete_local" ? "remote" : "local";
+		return !component.observations.some((observation) =>
+			observation.kind === "absent" && observation.side === authoritySide &&
+			observation.requestedPath === action.path &&
+			(authoritySide === "remote"
+				? observation.authority === "checkpoint_deleted"
+				: observation.authority === "stat"));
+	});
 }
 
 function matchesNativeRenames(

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -9,7 +9,7 @@ import type {
 	SyncPlan,
 } from "./types";
 
-export type AdmissionDeferralReason =
+type AdmissionDeferralReason =
 	| "alias_target_mutation"
 	| "conflicting_identity"
 	| "identity_postcondition_unproven"

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -1,4 +1,3 @@
-import type { RefinedSyncPlan } from "./rename-optimizer";
 import { projectRenameScope, type RenameScopeConsequence } from "./scope-projection";
 import { buildAdmissionComponents, type AdmissionComponent } from "./plan-admission-graph";
 import type {
@@ -7,6 +6,7 @@ import type {
 	RenameEvidence,
 	ScopeProjection,
 	SyncAction,
+	SyncPlan,
 } from "./types";
 
 export type AdmissionDeferralReason =
@@ -38,11 +38,12 @@ export interface AdmissionResult {
  * whose cross-path identity cannot be reconciled safely.
  */
 export function admitDestructivePlan(
-	plan: RefinedSyncPlan,
+	plan: SyncPlan,
+	identityEvidence: readonly IdentityEvidence[],
 	observations: readonly PathObservation[],
 	scope: ScopeProjection,
 ): AdmissionResult {
-	const components = buildAdmissionComponents(plan, observations, scope);
+	const components = buildAdmissionComponents(plan, identityEvidence, observations, scope);
 	const deferredActions = new Set<SyncAction>();
 	const deferred: DeferredComponent[] = [];
 	for (const component of components) {

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -1,0 +1,325 @@
+import type { RefinedSyncPlan } from "./rename-optimizer";
+import { projectRenameScope, type RenameScopeConsequence } from "./scope-projection";
+import { buildAdmissionComponents, type AdmissionComponent } from "./plan-admission-graph";
+import type {
+	IdentityEvidence,
+	PathObservation,
+	RenameEvidence,
+	ScopeProjection,
+	SyncAction,
+} from "./types";
+
+export type AdmissionDeferralReason =
+	| "alias_target_mutation"
+	| "conflicting_identity"
+	| "identity_postcondition_unproven"
+	| "incomplete_folder_mapping"
+	| "opposing_deletes"
+	| "present_unresolved"
+	| "rename_mismatch"
+	| "unknown_observation"
+	| "unknown_scope";
+
+export interface DeferredComponent {
+	paths: string[];
+	actions: SyncAction[];
+	evidence: IdentityEvidence[];
+	reasons: AdmissionDeferralReason[];
+}
+
+export interface AdmissionResult {
+	executable: { actions: SyncAction[] };
+	deferred: DeferredComponent[];
+}
+
+/**
+ * Pure final policy boundary before execution. It leaves ordinary exact-path
+ * actions alone and fails closed only for the evidence-connected component
+ * whose cross-path identity cannot be reconciled safely.
+ */
+export function admitDestructivePlan(
+	plan: RefinedSyncPlan,
+	observations: readonly PathObservation[],
+	scope: ScopeProjection,
+): AdmissionResult {
+	const components = buildAdmissionComponents(plan, observations, scope);
+	const deferredActions = new Set<SyncAction>();
+	const deferred: DeferredComponent[] = [];
+	for (const component of components) {
+		const reasons = evaluateComponent(component, scope);
+		if (reasons.length === 0) continue;
+		for (const action of component.actions) deferredActions.add(action);
+		deferred.push({
+			paths: [...component.paths].sort(),
+			actions: [...component.actions],
+			evidence: [...component.evidence].sort(compareEvidence),
+			reasons,
+		});
+	}
+	deferred.sort((left, right) => left.paths.join("\0").localeCompare(right.paths.join("\0")));
+	return {
+		executable: { actions: plan.actions.filter((action) => !deferredActions.has(action)) },
+		deferred,
+	};
+}
+
+function evaluateComponent(
+	component: AdmissionComponent,
+	scope: ScopeProjection,
+): AdmissionDeferralReason[] {
+	const reasons = new Set<AdmissionDeferralReason>();
+	if (component.observations.some((item) => item.kind === "present_unresolved")) {
+		reasons.add("present_unresolved");
+	}
+	if (component.observations.some((item) => item.kind === "unknown")) {
+		reasons.add("unknown_observation");
+	}
+	if (hasConflictingIdentity(component)) reasons.add("conflicting_identity");
+	if (hasOpposingDeletes(component.actions)) reasons.add("opposing_deletes");
+	if (hasAliasTargetMutation(component)) {
+		reasons.add("alias_target_mutation");
+	}
+
+	const renames = component.evidence.filter((item): item is RenameEvidence => item.kind === "rename");
+	if (renames.length > 0 && reasons.size === 0) {
+		const renameReason = evaluateRenames(component, renames, scope);
+		if (renameReason) reasons.add(renameReason);
+	} else if (renames.length === 0 && reasons.size === 0 &&
+		component.evidence.some((item) => item.kind === "stable_identity" &&
+			new Set(item.occurrences.map((occurrence) => occurrence.path)).size > 1)) {
+		reasons.add("identity_postcondition_unproven");
+	}
+	return [...reasons].sort();
+}
+
+function evaluateRenames(
+	component: AdmissionComponent,
+	renames: RenameEvidence[],
+	scope: ScopeProjection,
+): AdmissionDeferralReason | undefined {
+	const rules = renames.map((rename) => ({ rename, rule: projectRenameScope(rename, scope) }));
+	if (rules.some(({ rename, rule }) => rename.isFolder && rule.consequence === "defer")) {
+		return "incomplete_folder_mapping";
+	}
+	if (rules.some(({ rule }) => rule.consequence === "defer")) return "unknown_scope";
+	if (hasIncompleteNativeFolderMapping(component, rules.map(({ rename, rule }) => ({
+		rename, consequence: rule.consequence,
+	})), scope)) return "incomplete_folder_mapping";
+	if (matchesNativeRenames(component, rules.map(({ rename, rule }) => ({
+		rename, consequence: rule.consequence,
+	})), scope)) return undefined;
+	if (rules.length === 1 && matchesScopeTransition(component, rules[0]!.rename, rules[0]!.rule.consequence)) {
+		return undefined;
+	}
+	if (rules.length === 1 && preservesRecreatedRemoteSource(component, rules[0]!.rename)) {
+		return undefined;
+	}
+	return "rename_mismatch";
+}
+
+function matchesNativeRenames(
+	component: AdmissionComponent,
+	rules: readonly { rename: RenameEvidence; consequence: RenameScopeConsequence }[],
+	scope: ScopeProjection,
+): boolean {
+	const actions = component.actions;
+	if (actions.length !== rules.length) return false;
+	return rules.every(({ rename, consequence }) => {
+		const expected = consequence === "rename_local" || consequence === "rename_remote"
+			? consequence : undefined;
+		if (!expected) return false;
+		const action = actions.find((candidate) =>
+			candidate.action === expected && candidate.oldPath === rename.oldPath && candidate.path === rename.newPath);
+		if (!action || action.action !== expected || nativeDestinationOccupied(component, rename, expected)) {
+			return false;
+		}
+		return !rename.isFolder || folderMappingComplete(action, rename, scope);
+	});
+}
+
+function hasIncompleteNativeFolderMapping(
+	component: AdmissionComponent,
+	rules: readonly { rename: RenameEvidence; consequence: RenameScopeConsequence }[],
+	scope: ScopeProjection,
+): boolean {
+	return rules.some(({ rename, consequence }) => {
+		if (!rename.isFolder || (consequence !== "rename_local" && consequence !== "rename_remote")) {
+			return false;
+		}
+		const action = component.actions.find((candidate) =>
+			candidate.action === consequence && candidate.oldPath === rename.oldPath && candidate.path === rename.newPath);
+		return action?.action === consequence && !folderMappingComplete(action, rename, scope);
+	});
+}
+
+function nativeDestinationOccupied(
+	component: AdmissionComponent,
+	rename: RenameEvidence,
+	action: "rename_local" | "rename_remote",
+): boolean {
+	const targetSide = action === "rename_local" ? "local" : "remote";
+	return component.observations.some((observation) => {
+		if (observation.side !== targetSide) return false;
+		if (observation.kind === "exact") return observation.requestedPath === rename.newPath;
+		if (observation.kind === "alias") return observation.resolvedPath === rename.newPath;
+		return observation.kind === "present_unresolved" && observation.returnedPath === rename.newPath;
+	});
+}
+
+function matchesScopeTransition(
+	component: AdmissionComponent,
+	rename: RenameEvidence,
+	consequence: RenameScopeConsequence,
+): boolean {
+	const actions = component.actions;
+	if (consequence === "none") return actions.length === 0;
+	if (consequence === "defer" || consequence === "rename_local" || consequence === "rename_remote") {
+		return false;
+	}
+	if (actions.length !== 1) return false;
+	const expectedPath = consequence === "delete_local" || consequence === "delete_remote"
+		? rename.oldPath : rename.newPath;
+	if (actions[0]!.action !== consequence || actions[0]!.path !== expectedPath) return false;
+	if (consequence === "push") return !isOccupied(component, "remote", rename.newPath);
+	if (consequence === "pull") return !isOccupied(component, "local", rename.newPath);
+	return true;
+}
+
+function preservesRecreatedRemoteSource(component: AdmissionComponent, rename: RenameEvidence): boolean {
+	if (rename.side !== "remote" || !rename.identityKey || rename.isFolder) return false;
+	const currentKeys = currentRemoteIdentityByPath(component);
+	const sourceKey = currentKeys.get(rename.oldPath);
+	if (!sourceKey || sourceKey === rename.identityKey || currentKeys.get(rename.newPath) !== rename.identityKey) {
+		return false;
+	}
+	const byPath = new Map(component.actions.map((action) => [action.path, action]));
+	if (byPath.size !== component.actions.length || byPath.size > 2 ||
+		component.actions.some((action) => action.path !== rename.oldPath && action.path !== rename.newPath)) {
+		return false;
+	}
+	const atDestination = byPath.get(rename.newPath);
+	if (!atDestination || !["pull", "match"].includes(atDestination.action)) return false;
+	const atSource = byPath.get(rename.oldPath);
+	return !atSource || ["pull", "match", "delete_local"].includes(atSource.action);
+}
+
+function folderMappingComplete(
+	action: Extract<SyncAction, { action: "rename_local" | "rename_remote" }>,
+	rename: RenameEvidence,
+	scope: ScopeProjection,
+): boolean {
+	if (!action.isFolder || !action.descendants || action.descendants.length === 0) return false;
+	const mapped = new Set<string>();
+	const oldPrefix = `${rename.oldPath}/`;
+	const newPrefix = `${rename.newPath}/`;
+	for (const pair of action.descendants) {
+		if (!pair.oldPath.startsWith(oldPrefix) || !pair.newPath.startsWith(newPrefix) ||
+			pair.oldPath.substring(oldPrefix.length) !== pair.newPath.substring(newPrefix.length) ||
+			scope.byEndpoint.get(pair.oldPath) !== "included" ||
+			scope.byEndpoint.get(pair.newPath) !== "included" ||
+			mapped.has(pair.oldPath) || mapped.has(pair.newPath)) return false;
+		mapped.add(pair.oldPath);
+		mapped.add(pair.newPath);
+	}
+	for (const path of scope.byEndpoint.keys()) {
+		if ((path.startsWith(oldPrefix) || path.startsWith(newPrefix)) && !mapped.has(path)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function hasOpposingDeletes(actions: readonly SyncAction[]): boolean {
+	return actions.some((action) => action.action === "delete_local") &&
+		actions.some((action) => action.action === "delete_remote");
+}
+
+function hasAliasTargetMutation(component: AdmissionComponent): boolean {
+	return component.evidence.some((evidence) => {
+		if (evidence.kind !== "alias") return false;
+		return component.actions.some((action) => !isMatchingAliasRename(component, action, evidence));
+	});
+}
+
+function isMatchingAliasRename(
+	component: AdmissionComponent,
+	action: SyncAction,
+	alias: Extract<IdentityEvidence, { kind: "alias" }>,
+): boolean {
+	const expected = alias.side === "local" ? "rename_remote" : "rename_local";
+	if (action.action !== expected || action.oldPath !== alias.requestedPath || action.path !== alias.resolvedPath) {
+		return false;
+	}
+	return component.evidence.some((evidence) => evidence.kind === "rename" &&
+		evidence.side === alias.side && evidence.oldPath === alias.requestedPath &&
+		evidence.newPath === alias.resolvedPath);
+}
+
+function hasConflictingIdentity(component: AdmissionComponent): boolean {
+	const keys = new Map<string, Set<string>>();
+	for (const evidence of component.evidence) {
+		if (evidence.kind === "stable_identity") {
+			for (const occurrence of evidence.occurrences) {
+				addIdentity(keys, occurrence.side, occurrence.phase, occurrence.path, evidence.identityKey);
+			}
+		} else if (evidence.kind === "rename" && evidence.side === "remote" && evidence.identityKey) {
+			addIdentity(keys, "remote", "baseline", evidence.oldPath, evidence.identityKey);
+			addIdentity(keys, "remote", "current", evidence.newPath, evidence.identityKey);
+		}
+	}
+	for (const observation of component.observations) {
+		if (observation.side !== "remote" ||
+			(observation.kind !== "exact" && observation.kind !== "alias")) continue;
+		const path = observation.kind === "alias" ? observation.resolvedPath : observation.requestedPath;
+		if (observation.entity.identityKey) {
+			addIdentity(keys, "remote", "current", path, observation.entity.identityKey);
+		}
+	}
+	for (const action of component.actions) {
+		if (action.remote?.identityKey) {
+			addIdentity(keys, "remote", "current", action.remote.path, action.remote.identityKey);
+		}
+		if (action.baseline?.remoteIdentityKey) {
+			addIdentity(keys, "remote", "baseline", action.baseline.path, action.baseline.remoteIdentityKey);
+		}
+	}
+	return [...keys.values()].some((values) => values.size > 1);
+}
+
+function addIdentity(
+	keys: Map<string, Set<string>>,
+	side: "local" | "remote",
+	phase: "baseline" | "current",
+	path: string,
+	identityKey: string,
+): void {
+	const slot = `${side}\0${phase}\0${path}`;
+	const values = keys.get(slot) ?? new Set<string>();
+	values.add(identityKey);
+	keys.set(slot, values);
+}
+
+function currentRemoteIdentityByPath(component: AdmissionComponent): Map<string, string> {
+	const result = new Map<string, string>();
+	for (const observation of component.observations) {
+		if (observation.side !== "remote" ||
+			(observation.kind !== "exact" && observation.kind !== "alias")) continue;
+		const path = observation.kind === "alias" ? observation.resolvedPath : observation.requestedPath;
+		if (observation.entity.identityKey) result.set(path, observation.entity.identityKey);
+	}
+	for (const action of component.actions) {
+		if (action.remote?.identityKey) result.set(action.remote.path, action.remote.identityKey);
+	}
+	return result;
+}
+
+function isOccupied(component: AdmissionComponent, side: "local" | "remote", path: string): boolean {
+	return component.observations.some((observation) => observation.side === side &&
+		((observation.kind === "exact" && observation.requestedPath === path) ||
+			(observation.kind === "alias" && observation.resolvedPath === path) ||
+			(observation.kind === "present_unresolved" && observation.returnedPath === path)));
+}
+
+function compareEvidence(left: IdentityEvidence, right: IdentityEvidence): number {
+	return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}

--- a/src/sync/plan-executor.test.ts
+++ b/src/sync/plan-executor.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import { executePlan, toConflictRecords, DESKTOP_TRANSFER_POOL, MOBILE_TRANSFER_POOL } from "./plan-executor";
 import type { ExecutionContext, ResolvedConflict } from "./plan-executor";
 import type { SyncAction, SyncPlan } from "./types";
-import { createMockFs, createMockStateStore, addFile, readText, deferred, flush } from "../__mocks__/sync-test-helpers";
+import { createMockLocalFs, createMockRemoteFs, type MockFileSystem, createMockStateStore, addFile, readText, deferred, flush } from "../__mocks__/sync-test-helpers";
 import { AuthError, classifyHttpError } from "../fs/errors";
 import { AdaptivePool } from "../queue/async-queue";
 
 function makeCtx(
 	overrides: Partial<ExecutionContext> = {},
 ): ExecutionContext {
-	const localFs = createMockFs("local");
-	const remoteFs = createMockFs("remote");
+	const localFs = createMockLocalFs();
+	const remoteFs = createMockRemoteFs();
 	const stateStore = createMockStateStore();
 	return {
 		localFs,
@@ -40,8 +40,8 @@ describe("executePlan", () => {
 	describe("push", () => {
 		it("uploads local file to remote and commits state", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "a.md", "content");
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 
@@ -63,8 +63,8 @@ describe("executePlan", () => {
 			const ctx = makeCtx({
 				isActionBlocked: (action) => action.path === "blocked.md" ? "known permanent failure" : null,
 			});
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "blocked.md", "content");
 			const writeSpy = vi.spyOn(remoteFs, "write");
 
@@ -85,7 +85,7 @@ describe("executePlan", () => {
 	describe("pull", () => {
 		it("downloads remote file to local and commits state", async () => {
 			const ctx = makeCtx();
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(remoteFs, "b.md", "remote content");
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 
@@ -99,7 +99,7 @@ describe("executePlan", () => {
 
 			expect(result.succeeded).toHaveLength(1);
 			expect(result.failed).toHaveLength(0);
-			expect((ctx.localFs as ReturnType<typeof createMockFs>).files.has("b.md")).toBe(true);
+			expect((ctx.localFs as MockFileSystem).files.has("b.md")).toBe(true);
 			expect(stateStore.records.has("b.md")).toBe(true);
 		});
 	});
@@ -123,7 +123,7 @@ describe("executePlan", () => {
 	describe("delete_remote", () => {
 		it("deletes remote file and removes state record", async () => {
 			const ctx = makeCtx();
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(remoteFs, "d.md", "to delete");
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 			stateStore.records.set("d.md", {
@@ -144,7 +144,7 @@ describe("executePlan", () => {
 	describe("delete_local", () => {
 		it("deletes local file and removes state record", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
 			addFile(localFs, "e.md", "to delete");
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 			stateStore.records.set("e.md", {
@@ -165,8 +165,8 @@ describe("executePlan", () => {
 	describe("rename_remote", () => {
 		it("renames remote file and commits state at new path", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "new.md", "content");
 			addFile(remoteFs, "old.md", "content");
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
@@ -199,8 +199,8 @@ describe("executePlan", () => {
 	describe("rename_remote with isFolder", () => {
 		it("renames folder on remote and rewrites descendant sync records", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 
 			// Set up: folder A with 2 files on remote, folder B with same files locally
@@ -266,8 +266,8 @@ describe("executePlan", () => {
 	describe("conflict", () => {
 		it("resolves conflict and records it in both succeeded and conflicts arrays", async () => {
 			const ctx = makeCtx({ conflictStrategy: "duplicate" });
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "g.md", "local version");
 			addFile(remoteFs, "g.md", "remote version");
 
@@ -287,8 +287,8 @@ describe("executePlan", () => {
 
 		it("records conflict in failed array when resolveConflict throws a non-Auth error", async () => {
 			const ctx = makeCtx({ conflictStrategy: "duplicate" });
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "err.md", "local version");
 			addFile(remoteFs, "err.md", "remote version");
 
@@ -316,7 +316,7 @@ describe("executePlan", () => {
 	describe("error isolation", () => {
 		it("records failed action and continues processing remaining actions", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
 			addFile(localFs, "good.md", "good content");
 
 			const plan = makePlan([
@@ -344,7 +344,7 @@ describe("executePlan", () => {
 			const ctx = makeCtx();
 			const authErr = new AuthError("Unauthorized", 401);
 
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
 			// Use path-based logic so the correct file triggers AuthError regardless of concurrency order
 			vi.spyOn(localFs, "read").mockImplementation((path: string) => {
 				if (path === "auth-fail.md") return Promise.reject(authErr);
@@ -370,7 +370,7 @@ describe("executePlan", () => {
 		it("aborts the cycle on AuthError during a remote delete (structural phase)", async () => {
 			const ctx = makeCtx();
 			const authErr = new AuthError("Unauthorized", 401);
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(remoteFs, "del1.md", "content");
 			addFile(remoteFs, "del2.md", "content");
 			// Path-based so the AuthError is deterministic regardless of pool order.
@@ -393,7 +393,7 @@ describe("executePlan", () => {
 		it("aborts the cycle on AuthError during a local delete (structural phase)", async () => {
 			const ctx = makeCtx();
 			const authErr = new AuthError("Unauthorized", 401);
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
 			addFile(localFs, "del1.md", "content");
 			addFile(localFs, "del2.md", "content");
 			const origDelete = localFs.delete.bind(localFs);
@@ -413,8 +413,8 @@ describe("executePlan", () => {
 		it("aborts the cycle on AuthError during a conflict (conflict phase)", async () => {
 			const ctx = makeCtx();
 			const authErr = new AuthError("Unauthorized", 401);
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "c1.md", "local");
 			addFile(remoteFs, "c1.md", "remote");
 			addFile(localFs, "c2.md", "local2");
@@ -467,8 +467,8 @@ describe("executePlan", () => {
 		it("runs transfers, then conflict, then structural (renames before deletes per lane)", async () => {
 			const order: string[] = [];
 			const ctx = makeCtx({ conflictStrategy: "duplicate" });
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 
 			addFile(localFs, "push.md", "push");
@@ -554,8 +554,8 @@ describe("executePlan", () => {
 
 		it("does not start structural ops until transfers finish (Phase 1 barrier)", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(localFs, "p.md", "x");
 			addFile(remoteFs, "d.md", "y");
 
@@ -585,15 +585,15 @@ describe("executePlan", () => {
 	describe("concurrency", () => {
 		it("runs the remote and local structural lanes concurrently", async () => {
 			const ctx = makeCtx();
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(remoteFs, "r.md", "x");
 			addFile(localFs, "l.md", "y");
 
 			let running = 0;
 			let maxRunning = 0;
 			const gate = deferred();
-			const gateDelete = (fs: ReturnType<typeof createMockFs>) => {
+			const gateDelete = (fs: MockFileSystem) => {
 				const orig = fs.delete.bind(fs);
 				vi.spyOn(fs, "delete").mockImplementation(async (path: string) => {
 					running++;
@@ -622,7 +622,7 @@ describe("executePlan", () => {
 		it("bounds concurrent deletes to the delete-pool size (per lane)", async () => {
 			const POOL = 5; // must match DELETE_CONCURRENCY in plan-executor.ts
 			const ctx = makeCtx();
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			const paths = Array.from({ length: POOL + 1 }, (_, k) => `del${k}.md`);
 			for (const path of paths) addFile(remoteFs, path, "x");
 
@@ -652,7 +652,7 @@ describe("executePlan", () => {
 	describe("concurrent delete safety", () => {
 		it("handles an overlapping folder + child delete_remote without failures (idempotent)", async () => {
 			const ctx = makeCtx();
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			addFile(remoteFs, "A/child.md", "x"); // seeds folder A + the child
 
 			// The folder and its descendant are both deleted in one plan (the decision
@@ -675,8 +675,8 @@ describe("executePlan", () => {
 	describe("conflict runs in its own phase (not pooled with transfers)", () => {
 		it("a pushed `.conflict` sidecar is not clobbered by a same-cycle conflict's duplicate", async () => {
 			const ctx = makeCtx({ conflictStrategy: "duplicate" });
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			// A genuine conflict on foo.md (both sides, different content).
 			addFile(localFs, "foo.md", "local-foo");
 			addFile(remoteFs, "foo.md", "remote-foo");
@@ -710,8 +710,8 @@ describe("executePlan", () => {
 				conflictStrategy: "duplicate",
 				onProgress: (completed, total) => calls.push([completed, total]),
 			});
-			const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-			const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+			const localFs = ctx.localFs as MockFileSystem;
+			const remoteFs = ctx.remoteFs as MockFileSystem;
 			const stateStore = ctx.committer.stateStore as unknown as ReturnType<typeof createMockStateStore>;
 			addFile(localFs, "p.md", "p");
 			addFile(localFs, "cf.md", "l");
@@ -772,8 +772,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("retries a rate-limited (429) transfer, then succeeds", async () => {
 		const ctx = makeCtx();
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const orig = remoteFs.write.bind(remoteFs);
 		let n = 0;
@@ -789,8 +789,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("retries a transient (503) transfer, then succeeds", async () => {
 		const ctx = makeCtx();
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const orig = remoteFs.write.bind(remoteFs);
 		let n = 0;
@@ -805,8 +805,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("does NOT retry a permission (403) error — records failed, does not abort the cycle", async () => {
 		const ctx = makeCtx();
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const writeSpy = vi.spyOn(remoteFs, "write").mockRejectedValue(httpErr(403));
 
@@ -819,8 +819,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("does NOT retry a notFound (404) error", async () => {
 		const ctx = makeCtx();
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const writeSpy = vi.spyOn(remoteFs, "write").mockRejectedValue(httpErr(404));
 
@@ -832,8 +832,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("aborts (no retry) on AuthError", async () => {
 		const ctx = makeCtx();
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const writeSpy = vi.spyOn(remoteFs, "write").mockRejectedValue(new AuthError("unauthorized", 401));
 
@@ -843,8 +843,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("gives up after MAX_ACTION_RETRIES (3) → failed, without a cycle abort", async () => {
 		const ctx = makeCtx();
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const writeSpy = vi.spyOn(remoteFs, "write").mockRejectedValue(httpErr(429));
 
@@ -856,8 +856,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("uses ctx.classifyError (Google 403 = rate-limit), so a 403 retries", async () => {
 		const ctx = makeCtx({ classifyError: () => ({ kind: "rateLimit", retryAfterMs: 1 }) });
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const orig = remoteFs.write.bind(remoteFs);
 		let n = 0;
@@ -874,8 +874,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 		const order: string[] = [];
 		const noteSpy = vi.spyOn(AdaptivePool.prototype, "noteRateLimit").mockImplementation(() => { order.push("noteRateLimit"); });
 		const ctx = makeCtx({ sleep: (ms) => { order.push(`sleep:${ms}`); return Promise.resolve(); } });
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "x.md", "content");
 		const orig = remoteFs.write.bind(remoteFs);
 		let n = 0;
@@ -892,8 +892,8 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 	it("does NOT retry a rate-limited conflict (not idempotent) and never signals the transfer pool (D1)", async () => {
 		const noteSpy = vi.spyOn(AdaptivePool.prototype, "noteRateLimit");
 		const ctx = makeCtx({ conflictStrategy: "duplicate" });
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		addFile(localFs, "g.md", "local version");
 		addFile(remoteFs, "g.md", "remote version");
 		const readSpy = vi.spyOn(remoteFs, "read").mockRejectedValue(httpErr(429));
@@ -916,7 +916,7 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 
 	it("does NOT retry a rename (not idempotent on replay)", async () => {
 		const ctx = makeCtx();
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		const renameSpy = vi.spyOn(remoteFs, "rename").mockRejectedValue(httpErr(429));
 
 		const result = await executePlan(makePlan([{
@@ -934,7 +934,7 @@ describe("withIoRetry (per-action in-cycle retry)", () => {
 });
 
 describe("adaptive transfer pool (Phase 1)", () => {
-	function gatedWrites(remoteFs: ReturnType<typeof createMockFs>) {
+	function gatedWrites(remoteFs: MockFileSystem) {
 		const gate = deferred();
 		let running = 0;
 		const counter = { max: 0 };
@@ -950,7 +950,7 @@ describe("adaptive transfer pool (Phase 1)", () => {
 	}
 
 	function manyPushes(n: number, ctx: ExecutionContext, size = 7): SyncPlan {
-		const localFs = ctx.localFs as ReturnType<typeof createMockFs>;
+		const localFs = ctx.localFs as MockFileSystem;
 		const actions: SyncAction[] = [];
 		for (let i = 0; i < n; i++) {
 			addFile(localFs, `f${i}.md`, "content");
@@ -961,7 +961,7 @@ describe("adaptive transfer pool (Phase 1)", () => {
 
 	it("starts transfers at the desktop pool's start concurrency (5)", async () => {
 		const ctx = makeCtx(); // DESKTOP_TRANSFER_POOL (start 5)
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		const { gate, counter } = gatedWrites(remoteFs);
 
 		const p = executePlan(manyPushes(8, ctx), ctx);
@@ -973,7 +973,7 @@ describe("adaptive transfer pool (Phase 1)", () => {
 
 	it("caps mobile transfers at the mobile pool's start concurrency (3)", async () => {
 		const ctx = makeCtx({ transferPool: MOBILE_TRANSFER_POOL });
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		const { gate, counter } = gatedWrites(remoteFs);
 
 		const p = executePlan(manyPushes(8, ctx), ctx);
@@ -988,7 +988,7 @@ describe("adaptive transfer pool (Phase 1)", () => {
 		const ctx = makeCtx({
 			transferPool: { min: 1, start: 10, max: 10, rampAfter: 100, byteBudget: 30 },
 		});
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		const { gate, counter } = gatedWrites(remoteFs);
 
 		const p = executePlan(manyPushes(8, ctx, 10), ctx);
@@ -1002,7 +1002,7 @@ describe("adaptive transfer pool (Phase 1)", () => {
 		const ctx = makeCtx({
 			transferPool: { min: 1, start: 4, max: 4, rampAfter: 100, byteBudget: 48 * 1024 * 1024 },
 		});
-		const remoteFs = ctx.remoteFs as ReturnType<typeof createMockFs>;
+		const remoteFs = ctx.remoteFs as MockFileSystem;
 		const { gate, counter } = gatedWrites(remoteFs);
 
 		const p = executePlan(manyPushes(8, ctx, 7), ctx);

--- a/src/sync/plan-executor.test.ts
+++ b/src/sync/plan-executor.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { executePlan, toConflictRecords, DESKTOP_TRANSFER_POOL, MOBILE_TRANSFER_POOL } from "./plan-executor";
 import type { ExecutionContext, ResolvedConflict } from "./plan-executor";
-import type { SyncAction, SyncPlan } from "./types";
+import type { PathObservation, SyncAction } from "./types";
 import { createMockLocalFs, createMockRemoteFs, type MockFileSystem, createMockStateStore, addFile, readText, deferred, flush } from "../__mocks__/sync-test-helpers";
 import { AuthError, classifyHttpError } from "../fs/errors";
 import { AdaptivePool } from "../queue/async-queue";
+import {
+	admitDestructivePlan,
+	captureCycleAdmissionSnapshot,
+	type AuthorizedSyncPlan,
+} from "./plan-admission";
 
 function makeCtx(
 	overrides: Partial<ExecutionContext> = {},
@@ -28,8 +33,22 @@ function makeCtx(
 	};
 }
 
-function makePlan(actions: SyncAction[]): SyncPlan {
-	return { actions };
+function makePlan(actions: SyncAction[]): AuthorizedSyncPlan {
+	const observations: PathObservation[] = [];
+	for (const action of actions) {
+		if (action.action === "delete_local") {
+			observations.push({ kind: "absent", side: "remote",
+				requestedPath: action.path, authority: "checkpoint_deleted" });
+		}
+		if (action.action === "delete_remote") {
+			observations.push({ kind: "absent", side: "local",
+				requestedPath: action.path, authority: "stat" });
+		}
+	}
+	const scope = { byEndpoint: new Map(actions.map((action) => [action.path, "included" as const])) };
+	return admitDestructivePlan(captureCycleAdmissionSnapshot(
+		{ actions }, [], observations, scope, "executor-test",
+	)).executable;
 }
 
 // Some suites spy on AdaptivePool.prototype (a global) — restore after each test
@@ -767,7 +786,7 @@ describe("executePlan", () => {
 
 describe("withIoRetry (per-action in-cycle retry)", () => {
 	const httpErr = (status: number) => Object.assign(new Error(`HTTP ${status}`), { status });
-	const pushPlan = (path = "x.md"): SyncPlan =>
+	const pushPlan = (path = "x.md"): AuthorizedSyncPlan =>
 		makePlan([{ path, action: "push", local: { path, isDirectory: false, size: 7, mtime: 1000, hash: "" } }]);
 
 	it("retries a rate-limited (429) transfer, then succeeds", async () => {
@@ -949,7 +968,7 @@ describe("adaptive transfer pool (Phase 1)", () => {
 		return { gate, counter };
 	}
 
-	function manyPushes(n: number, ctx: ExecutionContext, size = 7): SyncPlan {
+	function manyPushes(n: number, ctx: ExecutionContext, size = 7): AuthorizedSyncPlan {
 		const localFs = ctx.localFs as MockFileSystem;
 		const actions: SyncAction[] = [];
 		for (let i = 0; i < n; i++) {

--- a/src/sync/plan-executor.ts
+++ b/src/sync/plan-executor.ts
@@ -1,6 +1,7 @@
 import type { IFileSystem } from "../fs/interface";
 import type { FileEntity } from "../fs/types";
-import type { ConflictStrategy, SyncAction, SyncActionType, SyncPlan } from "./types";
+import type { ConflictStrategy, SyncAction, SyncActionType } from "./types";
+import type { AuthorizedSyncPlan } from "./plan-admission";
 import type { StateCommitterContext } from "./state-committer";
 import type { ConflictResolverContext } from "./conflict-resolver";
 import type { Logger } from "../logging/logger";
@@ -140,7 +141,7 @@ function transferSize(action: SyncAction): number {
  * cycle); all other per-action errors are caught into `result.failed`.
  */
 export async function executePlan(
-	plan: SyncPlan,
+	plan: AuthorizedSyncPlan,
 	ctx: ExecutionContext,
 ): Promise<ExecutionResult> {
 	const result: ExecutionResult = {

--- a/src/sync/plan-executor.ts
+++ b/src/sync/plan-executor.ts
@@ -148,6 +148,7 @@ export async function executePlan(
 		failed: [],
 		blocked: [],
 		conflicts: [],
+		deferred: [],
 	};
 
 	const total = plan.actions.length;

--- a/src/sync/remote-change-source.ts
+++ b/src/sync/remote-change-source.ts
@@ -21,11 +21,15 @@ export async function remoteSnapshotAfterDelta(remoteFs: IFileSystem): Promise<F
 	return checkpoint.listCurrentSnapshot();
 }
 
-export async function getRemoteChanges(remoteFs: IFileSystem): Promise<RemoteChanges> {
+export async function getRemoteChanges(
+	remoteFs: IFileSystem,
+	onIdentityEvidence?: (evidence: readonly RenameEvidence[]) => void,
+): Promise<RemoteChanges> {
 	if (!remoteFs.checkpoint) return emptyRemoteChanges();
 	const result = await remoteFs.checkpoint.getChangedPaths();
 	if (!result) return emptyRemoteChanges();
 	const renameEvidence = collectRemoteRenameEvidence(result.renamed ?? []);
+	onIdentityEvidence?.(renameEvidence);
 	return {
 		paths: [
 			...result.modified,

--- a/src/sync/remote-change-source.ts
+++ b/src/sync/remote-change-source.ts
@@ -1,0 +1,42 @@
+import type { IFileSystem } from "../fs/interface";
+import type { FileEntity } from "../fs/types";
+import type { RenameEvidence } from "./types";
+import { collectRemoteRenameEvidence } from "./identity-evidence";
+
+export interface RemoteChanges {
+	paths: string[];
+	deletedPaths: ReadonlySet<string>;
+	renameEvidence: RenameEvidence[];
+}
+
+export function hasFolderRename(changes: RemoteChanges): boolean {
+	return changes.renameEvidence.some((evidence) => evidence.isFolder);
+}
+
+export async function remoteSnapshotAfterDelta(remoteFs: IFileSystem): Promise<FileEntity[]> {
+	const checkpoint = remoteFs.checkpoint;
+	if (!checkpoint?.listCurrentSnapshot) {
+		throw new Error("Remote folder rename requires a replay-free checkpoint snapshot");
+	}
+	return checkpoint.listCurrentSnapshot();
+}
+
+export async function getRemoteChanges(remoteFs: IFileSystem): Promise<RemoteChanges> {
+	if (!remoteFs.checkpoint) return emptyRemoteChanges();
+	const result = await remoteFs.checkpoint.getChangedPaths();
+	if (!result) return emptyRemoteChanges();
+	const renameEvidence = collectRemoteRenameEvidence(result.renamed ?? []);
+	return {
+		paths: [
+			...result.modified,
+			...result.deleted,
+			...renameEvidence.flatMap(({ oldPath, newPath }) => [oldPath, newPath]),
+		],
+		deletedPaths: new Set(result.deleted),
+		renameEvidence,
+	};
+}
+
+function emptyRemoteChanges(): RemoteChanges {
+	return { paths: [], deletedPaths: new Set(), renameEvidence: [] };
+}

--- a/src/sync/rename-debt.test.ts
+++ b/src/sync/rename-debt.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutionResult } from "./execution-result";
+import {
+	applyRenameDebtScope,
+	collectLocalRenameDebts,
+	mergeRenameDebtEvidence,
+	resolvedRenameDebts,
+	unresolvedRenameEvidence,
+} from "./rename-debt";
+import type { RenameDebt } from "./state";
+import type { IdentityEvidence, ScopeProjection, SyncAction } from "./types";
+
+function debt(overrides: Partial<RenameDebt> = {}): RenameDebt {
+	return {
+		namespace: "onedrive:root", side: "local", oldPath: "A.md", newPath: "a.md",
+		isFolder: false, oldDisposition: "included", newDisposition: "included", ...overrides,
+	};
+}
+
+function rename(): IdentityEvidence {
+	return {
+		kind: "rename", side: "local", oldPath: "A.md", newPath: "a.md",
+		isFolder: false, authority: "reported",
+	};
+}
+
+function projection(entries: Record<string, "included" | "policy_out" | "mobile_deferred" | "unknown">): ScopeProjection {
+	return { byEndpoint: new Map(Object.entries(entries)) };
+}
+
+function result(overrides: Partial<ExecutionResult> = {}): ExecutionResult {
+	return { succeeded: [], failed: [], blocked: [], conflicts: [], deferred: [], ...overrides };
+}
+
+describe("rename debt orchestration helpers", () => {
+	it("unions persisted debt with fresh evidence without duplicating the same edge", () => {
+		const merged = mergeRenameDebtEvidence([rename()], [debt()]);
+
+		expect(merged).toEqual([rename()]);
+	});
+
+	it("restores stored endpoint dispositions only where fresh projection is unknown", () => {
+		const restored = applyRenameDebtScope(
+			projection({ "A.md": "unknown", "a.md": "policy_out" }),
+			[debt({ oldDisposition: "included", newDisposition: "included" })],
+		);
+
+		expect([...restored.byEndpoint]).toEqual([
+			["A.md", "included"], ["a.md", "policy_out"],
+		]);
+	});
+
+	it("keeps unknown when persisted edges disagree about one endpoint", () => {
+		const restored = applyRenameDebtScope(projection({ "A.md": "unknown" }), [
+			debt({ oldDisposition: "included" }),
+			debt({ newPath: "B.md", oldDisposition: "policy_out" }),
+		]);
+
+		expect(restored.byEndpoint.get("A.md")).toBe("unknown");
+	});
+
+	it("persists local rename constraints except an explicit out-to-out no-op", () => {
+		expect(collectLocalRenameDebts(
+			"onedrive:root", [rename()], projection({ "A.md": "included", "a.md": "included" }),
+		)).toEqual([debt()]);
+		expect(collectLocalRenameDebts(
+			"onedrive:root", [rename()], projection({ "A.md": "policy_out", "a.md": "policy_out" }),
+		)).toEqual([]);
+	});
+
+	it("deletes debt only after its admitted action succeeds or it projects to no-op", () => {
+		const action: SyncAction = { path: "a.md", oldPath: "A.md", action: "rename_remote" };
+
+		expect(resolvedRenameDebts(
+			[debt()], result({ succeeded: [{ action }] }),
+			projection({ "A.md": "included", "a.md": "included" }),
+		)).toEqual([debt()]);
+		expect(resolvedRenameDebts(
+			[debt()], result(), projection({ "A.md": "policy_out", "a.md": "policy_out" }),
+		)).toEqual([debt()]);
+	});
+
+	it("retains debt for deferred, failed, or blocked actions", () => {
+		const action: SyncAction = { path: "a.md", oldPath: "A.md", action: "rename_remote" };
+		const scope = projection({ "A.md": "included", "a.md": "included" });
+		const deferred = {
+			paths: ["A.md", "a.md"], actions: [action], evidence: [rename()], reasons: ["rename_mismatch" as const],
+		};
+
+		expect(resolvedRenameDebts([debt()], result({ deferred: [deferred] }), scope)).toEqual([]);
+		expect(resolvedRenameDebts(
+			[debt()], result({ failed: [{ action, error: new Error("failed") }] }), scope,
+		)).toEqual([]);
+		expect(resolvedRenameDebts(
+			[debt()], result({ blocked: [{ action, reason: "blocked" }] }), scope,
+		)).toEqual([]);
+	});
+
+	it("retains session evidence when its connected action is blocked", () => {
+		const edge = { ...rename(), side: "remote" as const };
+		const action: SyncAction = { path: "a.md", oldPath: "A.md", action: "rename_local" };
+
+		expect(unresolvedRenameEvidence(
+			[edge], result({ blocked: [{ action, reason: "blocked" }] }),
+			projection({ "A.md": "included", "a.md": "included" }),
+		)).toEqual([edge]);
+	});
+});

--- a/src/sync/rename-debt.test.ts
+++ b/src/sync/rename-debt.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { ExecutionResult } from "./execution-result";
 import {
 	applyRenameDebtScope,
 	collectLocalRenameDebts,
 	mergeRenameDebtEvidence,
-	resolvedRenameDebts,
-	unresolvedRenameEvidence,
+	renameDebtsBoundToEvidence,
+	unreleasedIdentityEvidence,
 } from "./rename-debt";
 import type { RenameDebt } from "./state";
-import type { IdentityEvidence, ScopeProjection, SyncAction } from "./types";
+import type { RenameEvidence, ScopeProjection } from "./types";
 
 function debt(overrides: Partial<RenameDebt> = {}): RenameDebt {
 	return {
@@ -17,7 +16,7 @@ function debt(overrides: Partial<RenameDebt> = {}): RenameDebt {
 	};
 }
 
-function rename(): IdentityEvidence {
+function rename(): RenameEvidence {
 	return {
 		kind: "rename", side: "local", oldPath: "A.md", newPath: "a.md",
 		isFolder: false, authority: "reported",
@@ -26,10 +25,6 @@ function rename(): IdentityEvidence {
 
 function projection(entries: Record<string, "included" | "policy_out" | "mobile_deferred" | "unknown">): ScopeProjection {
 	return { byEndpoint: new Map(Object.entries(entries)) };
-}
-
-function result(overrides: Partial<ExecutionResult> = {}): ExecutionResult {
-	return { succeeded: [], failed: [], blocked: [], conflicts: [], deferred: [], ...overrides };
 }
 
 describe("rename debt orchestration helpers", () => {
@@ -68,41 +63,20 @@ describe("rename debt orchestration helpers", () => {
 		)).toEqual([]);
 	});
 
-	it("deletes debt only after its admitted action succeeds or it projects to no-op", () => {
-		const action: SyncAction = { path: "a.md", oldPath: "A.md", action: "rename_remote" };
-
-		expect(resolvedRenameDebts(
-			[debt()], result({ succeeded: [{ action }] }),
-			projection({ "A.md": "included", "a.md": "included" }),
+	it("selects only namespace-local debts bound to released evidence", () => {
+		expect(renameDebtsBoundToEvidence(
+			[debt(), debt({ namespace: "other:root" })], [rename()], "onedrive:root",
 		)).toEqual([debt()]);
-		expect(resolvedRenameDebts(
-			[debt()], result(), projection({ "A.md": "policy_out", "a.md": "policy_out" }),
-		)).toEqual([debt()]);
+		expect(renameDebtsBoundToEvidence([debt()], [], "onedrive:root")).toEqual([]);
 	});
 
-	it("retains debt for deferred, failed, or blocked actions", () => {
-		const action: SyncAction = { path: "a.md", oldPath: "A.md", action: "rename_remote" };
-		const scope = projection({ "A.md": "included", "a.md": "included" });
-		const deferred = {
-			paths: ["A.md", "a.md"], actions: [action], evidence: [rename()], reasons: ["rename_mismatch" as const],
-		};
-
-		expect(resolvedRenameDebts([debt()], result({ deferred: [deferred] }), scope)).toEqual([]);
-		expect(resolvedRenameDebts(
-			[debt()], result({ failed: [{ action, error: new Error("failed") }] }), scope,
-		)).toEqual([]);
-		expect(resolvedRenameDebts(
-			[debt()], result({ blocked: [{ action, reason: "blocked" }] }), scope,
-		)).toEqual([]);
-	});
-
-	it("retains session evidence when its connected action is blocked", () => {
+	it("retains session evidence outside released membership", () => {
 		const edge = { ...rename(), side: "remote" as const };
-		const action: SyncAction = { path: "a.md", oldPath: "A.md", action: "rename_local" };
 
-		expect(unresolvedRenameEvidence(
-			[edge], result({ blocked: [{ action, reason: "blocked" }] }),
-			projection({ "A.md": "included", "a.md": "included" }),
-		)).toEqual([edge]);
+		expect(unreleasedIdentityEvidence([edge], [])).toEqual([edge]);
+		expect(unreleasedIdentityEvidence([edge], [edge])).toEqual([]);
+		expect(unreleasedIdentityEvidence(
+			[edge], [{ ...edge, identityKey: "remote-id" }],
+		)).toEqual([]);
 	});
 });

--- a/src/sync/rename-debt.ts
+++ b/src/sync/rename-debt.ts
@@ -1,5 +1,3 @@
-import type { ExecutionResult } from "./execution-result";
-import type { DeferredComponent } from "./plan-admission";
 import { projectRenameScope } from "./scope-projection";
 import type { RenameDebt } from "./state";
 import type {
@@ -7,8 +5,6 @@ import type {
 	RenameEvidence,
 	ScopeDisposition,
 	ScopeProjection,
-	PathObservation,
-	SyncAction,
 } from "./types";
 
 export function mergeRenameDebtEvidence(
@@ -69,59 +65,29 @@ export function collectLocalRenameDebts(
 	});
 }
 
-/** Debts may be removed only after a clean checkpoint and proven resolution/projection. */
-export function resolvedRenameDebts(
+/** Select namespace-local debts whose exact evidence membership Admission released. */
+export function renameDebtsBoundToEvidence(
 	debts: readonly RenameDebt[],
-	result: ExecutionResult,
-	projection: ScopeProjection,
-	observations: readonly PathObservation[] = [],
+	releasedEvidence: readonly IdentityEvidence[],
+	namespace: string,
 ): RenameDebt[] {
-	return debts.filter((debt) => {
-		const edge = renameDebtEvidence(debt);
-		return renameEvidenceResolved(edge, result, projection, observations);
-	});
+	const released = new Set(releasedEvidence.flatMap((item) =>
+		item.kind === "rename" ? [renameEvidenceKey(item)] : []));
+	return debts.filter((debt) => debt.namespace === namespace &&
+		released.has(renameEvidenceKey(renameDebtEvidence(debt))));
 }
 
-/** Keep reported edges until connected work succeeds, converges, or is a scope no-op. */
-export function unresolvedRenameEvidence(
+/** Retain evidence not included in Admission's mechanically releasable membership. */
+export function unreleasedIdentityEvidence(
 	evidence: readonly IdentityEvidence[],
-	result: ExecutionResult,
-	projection: ScopeProjection,
-	observations: readonly PathObservation[] = [],
+	releasedEvidence: readonly IdentityEvidence[],
 ): IdentityEvidence[] {
-	return evidence.filter((item) => item.kind !== "rename" ||
-		!renameEvidenceResolved(item, result, projection, observations));
-}
-
-function renameEvidenceResolved(
-	edge: RenameEvidence,
-	result: ExecutionResult,
-	projection: ScopeProjection,
-	observations: readonly PathObservation[],
-): boolean {
-	if (result.deferred.some((component) => componentContainsRename(component, edge))) return false;
-	if (result.failed.some(({ action }) => actionTouchesRename(action, edge))) return false;
-	if (result.blocked.some(({ action }) => actionTouchesRename(action, edge))) return false;
-	if (result.succeeded.some(({ action }) => actionTouchesRename(action, edge))) return true;
-	if (resolvedAtBothSides(edge, observations)) return true;
-	return projectRenameScope(edge, projection).consequence === "none";
-}
-
-function resolvedAtBothSides(
-	edge: RenameEvidence,
-	observations: readonly PathObservation[],
-): boolean {
-	return (["local", "remote"] as const).every((side) => {
-		const oldObservation = observations.find((item) =>
-			item.side === side && item.requestedPath === edge.oldPath);
-		const newObservation = observations.find((item) =>
-			item.side === side && item.requestedPath === edge.newPath);
-		const oldResolved = oldObservation?.kind === "absent" ||
-			(oldObservation?.kind === "alias" && oldObservation.resolvedPath === edge.newPath);
-		const newResolved = newObservation?.kind === "exact" ||
-			(newObservation?.kind === "alias" && newObservation.resolvedPath === edge.newPath);
-		return oldResolved && newResolved;
-	});
+	const released = new Set(releasedEvidence);
+	const releasedRenames = new Set(releasedEvidence.flatMap((item) =>
+		item.kind === "rename" ? [renameEvidenceKey(item)] : []));
+	return evidence.filter((item) => item.kind === "rename"
+		? !releasedRenames.has(renameEvidenceKey(item))
+		: !released.has(item));
 }
 
 export function renameDebtEvidence(debt: RenameDebt): RenameEvidence {
@@ -135,21 +101,8 @@ export function renameDebtEvidence(debt: RenameDebt): RenameEvidence {
 	};
 }
 
-function componentContainsRename(component: DeferredComponent, edge: RenameEvidence): boolean {
-	return component.evidence.some((item) => item.kind === "rename" &&
-		item.side === edge.side && item.oldPath === edge.oldPath && item.newPath === edge.newPath &&
-		item.isFolder === edge.isFolder);
-}
-
-function actionTouchesRename(action: SyncAction, edge: RenameEvidence): boolean {
-	if (action.path === edge.oldPath || action.path === edge.newPath) return true;
-	if ((action.action === "rename_local" || action.action === "rename_remote") &&
-		(action.oldPath === edge.oldPath || action.oldPath === edge.newPath)) return true;
-	return action.action === "rename_local" || action.action === "rename_remote"
-		? action.descendants?.some((pair) =>
-			pair.oldPath === edge.oldPath || pair.oldPath === edge.newPath ||
-			pair.newPath === edge.oldPath || pair.newPath === edge.newPath) === true
-		: false;
+function renameEvidenceKey(evidence: RenameEvidence): string {
+	return `${evidence.side}\0${evidence.oldPath}\0${evidence.newPath}\0${evidence.isFolder}`;
 }
 
 function rememberDisposition(

--- a/src/sync/rename-debt.ts
+++ b/src/sync/rename-debt.ts
@@ -65,7 +65,6 @@ export function collectLocalRenameDebts(
 			isFolder: item.isFolder,
 			oldDisposition: rule.oldDisposition,
 			newDisposition: rule.newDisposition,
-			identityKey: item.identityKey,
 		}];
 	});
 }
@@ -133,7 +132,6 @@ export function renameDebtEvidence(debt: RenameDebt): RenameEvidence {
 		newPath: debt.newPath,
 		isFolder: debt.isFolder,
 		authority: "reported",
-		identityKey: debt.identityKey,
 	};
 }
 

--- a/src/sync/rename-debt.ts
+++ b/src/sync/rename-debt.ts
@@ -1,0 +1,166 @@
+import type { ExecutionResult } from "./execution-result";
+import type { DeferredComponent } from "./plan-admission";
+import { projectRenameScope } from "./scope-projection";
+import type { RenameDebt } from "./state";
+import type {
+	IdentityEvidence,
+	RenameEvidence,
+	ScopeDisposition,
+	ScopeProjection,
+	PathObservation,
+	SyncAction,
+} from "./types";
+
+export function mergeRenameDebtEvidence(
+	evidence: readonly IdentityEvidence[],
+	debts: readonly RenameDebt[],
+): IdentityEvidence[] {
+	return mergeIdentityEvidence(evidence, debts.map(renameDebtEvidence));
+}
+
+export function mergeIdentityEvidence(
+	...collections: ReadonlyArray<readonly IdentityEvidence[]>
+): IdentityEvidence[] {
+	const merged = new Map<string, IdentityEvidence>();
+	for (const item of collections.flat()) {
+		merged.set(JSON.stringify(item), item);
+	}
+	return [...merged.values()];
+}
+
+/** Fill only unknown endpoints; current explicit policy/mobile classifications win. */
+export function applyRenameDebtScope(
+	projection: ScopeProjection,
+	debts: readonly RenameDebt[],
+): ScopeProjection {
+	const candidates = new Map<string, ScopeDisposition>();
+	const conflicts = new Set<string>();
+	for (const debt of debts) {
+		rememberDisposition(candidates, conflicts, debt.oldPath, debt.oldDisposition);
+		rememberDisposition(candidates, conflicts, debt.newPath, debt.newDisposition);
+	}
+	const byEndpoint = new Map(projection.byEndpoint);
+	for (const [path, disposition] of candidates) {
+		if (!conflicts.has(path) && byEndpoint.get(path) === "unknown") {
+			byEndpoint.set(path, disposition);
+		}
+	}
+	return { byEndpoint };
+}
+
+export function collectLocalRenameDebts(
+	namespace: string,
+	evidence: readonly IdentityEvidence[],
+	projection: ScopeProjection,
+): RenameDebt[] {
+	return evidence.flatMap((item): RenameDebt[] => {
+		if (item.kind !== "rename" || item.side !== "local") return [];
+		const rule = projectRenameScope(item, projection);
+		if (rule.consequence === "none") return [];
+		return [{
+			namespace,
+			side: item.side,
+			oldPath: item.oldPath,
+			newPath: item.newPath,
+			isFolder: item.isFolder,
+			oldDisposition: rule.oldDisposition,
+			newDisposition: rule.newDisposition,
+			identityKey: item.identityKey,
+		}];
+	});
+}
+
+/** Debts may be removed only after a clean checkpoint and proven resolution/projection. */
+export function resolvedRenameDebts(
+	debts: readonly RenameDebt[],
+	result: ExecutionResult,
+	projection: ScopeProjection,
+	observations: readonly PathObservation[] = [],
+): RenameDebt[] {
+	return debts.filter((debt) => {
+		const edge = renameDebtEvidence(debt);
+		return renameEvidenceResolved(edge, result, projection, observations);
+	});
+}
+
+/** Keep reported edges until connected work succeeds, converges, or is a scope no-op. */
+export function unresolvedRenameEvidence(
+	evidence: readonly IdentityEvidence[],
+	result: ExecutionResult,
+	projection: ScopeProjection,
+	observations: readonly PathObservation[] = [],
+): IdentityEvidence[] {
+	return evidence.filter((item) => item.kind !== "rename" ||
+		!renameEvidenceResolved(item, result, projection, observations));
+}
+
+function renameEvidenceResolved(
+	edge: RenameEvidence,
+	result: ExecutionResult,
+	projection: ScopeProjection,
+	observations: readonly PathObservation[],
+): boolean {
+	if (result.deferred.some((component) => componentContainsRename(component, edge))) return false;
+	if (result.failed.some(({ action }) => actionTouchesRename(action, edge))) return false;
+	if (result.blocked.some(({ action }) => actionTouchesRename(action, edge))) return false;
+	if (result.succeeded.some(({ action }) => actionTouchesRename(action, edge))) return true;
+	if (resolvedAtBothSides(edge, observations)) return true;
+	return projectRenameScope(edge, projection).consequence === "none";
+}
+
+function resolvedAtBothSides(
+	edge: RenameEvidence,
+	observations: readonly PathObservation[],
+): boolean {
+	return (["local", "remote"] as const).every((side) => {
+		const oldObservation = observations.find((item) =>
+			item.side === side && item.requestedPath === edge.oldPath);
+		const newObservation = observations.find((item) =>
+			item.side === side && item.requestedPath === edge.newPath);
+		const oldResolved = oldObservation?.kind === "absent" ||
+			(oldObservation?.kind === "alias" && oldObservation.resolvedPath === edge.newPath);
+		const newResolved = newObservation?.kind === "exact" ||
+			(newObservation?.kind === "alias" && newObservation.resolvedPath === edge.newPath);
+		return oldResolved && newResolved;
+	});
+}
+
+export function renameDebtEvidence(debt: RenameDebt): RenameEvidence {
+	return {
+		kind: "rename",
+		side: debt.side,
+		oldPath: debt.oldPath,
+		newPath: debt.newPath,
+		isFolder: debt.isFolder,
+		authority: "reported",
+		identityKey: debt.identityKey,
+	};
+}
+
+function componentContainsRename(component: DeferredComponent, edge: RenameEvidence): boolean {
+	return component.evidence.some((item) => item.kind === "rename" &&
+		item.side === edge.side && item.oldPath === edge.oldPath && item.newPath === edge.newPath &&
+		item.isFolder === edge.isFolder);
+}
+
+function actionTouchesRename(action: SyncAction, edge: RenameEvidence): boolean {
+	if (action.path === edge.oldPath || action.path === edge.newPath) return true;
+	if ((action.action === "rename_local" || action.action === "rename_remote") &&
+		(action.oldPath === edge.oldPath || action.oldPath === edge.newPath)) return true;
+	return action.action === "rename_local" || action.action === "rename_remote"
+		? action.descendants?.some((pair) =>
+			pair.oldPath === edge.oldPath || pair.oldPath === edge.newPath ||
+			pair.newPath === edge.oldPath || pair.newPath === edge.newPath) === true
+		: false;
+}
+
+function rememberDisposition(
+	candidates: Map<string, ScopeDisposition>,
+	conflicts: Set<string>,
+	path: string,
+	disposition: ScopeDisposition,
+): void {
+	const current = candidates.get(path);
+	if (current !== undefined && current !== disposition) conflicts.add(path);
+	else candidates.set(path, disposition);
+}

--- a/src/sync/rename-optimizer.test.ts
+++ b/src/sync/rename-optimizer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { refinePlan } from "./rename-optimizer";
-import type { SyncAction, SyncRecord, SyncPlan } from "./types";
-import type { FileEntity } from "../fs/types";
+import type { IdentityEvidence, SyncAction, SyncRecord, SyncPlan } from "./types";
+import type { FileEntity, RenamePair } from "../fs/types";
 
 function entity(path: string, hash: string): FileEntity {
 	return { path, isDirectory: false, size: 100, mtime: 1000, hash };
@@ -23,13 +23,49 @@ function plan(actions: SyncAction[]): SyncPlan {
 	return { actions };
 }
 
+function refine(
+	input: SyncPlan,
+	localFiles: ReadonlyMap<string, string>,
+	localFolders: ReadonlyMap<string, string>,
+	remote: RenamePair[],
+) {
+	const identityEvidence: IdentityEvidence[] = [
+		...[...localFiles].map(([newPath, oldPath]) => ({
+			kind: "rename" as const, side: "local" as const, oldPath, newPath,
+			isFolder: false, authority: "reported" as const,
+		})),
+		...[...localFolders].map(([newPath, oldPath]) => ({
+			kind: "rename" as const, side: "local" as const, oldPath, newPath,
+			isFolder: true, authority: "reported" as const,
+		})),
+		...remote.map(({ oldPath, newPath, isFolder }) => ({
+			kind: "rename" as const, side: "remote" as const, oldPath, newPath,
+			isFolder: isFolder === true, authority: "reported" as const,
+		})),
+	];
+	return refinePlan(input, identityEvidence);
+}
+
 describe("refinePlan", () => {
+	it("preserves the exact identity-evidence collection beside the refined plan", () => {
+		const p = plan([{ path: "a.md", action: "push", local: entity("a.md", "h1") }]);
+		const identityEvidence: IdentityEvidence[] = [{
+			kind: "rename", side: "local", oldPath: "old.md", newPath: "new.md",
+			isFolder: false, authority: "reported",
+		}];
+
+		const result = refinePlan(p, identityEvidence);
+
+		expect(result.identityEvidence).toBe(identityEvidence);
+	});
+
 	it("returns plan unchanged when no rename pairs exist", () => {
 		const p = plan([
 			{ path: "a.md", action: "push", local: entity("a.md", "h1") },
 		]);
-		const result = refinePlan(p, new Map(), new Map(), []);
-		expect(result).toBe(p);
+		const result = refine(p, new Map(), new Map(), []);
+		expect(result.actions).toBe(p.actions);
+		expect(result.identityEvidence).toEqual([]);
 	});
 
 	it("optimizes local file rename into rename_remote", () => {
@@ -43,7 +79,7 @@ describe("refinePlan", () => {
 			{ path: "new.md", action: "push", local: entity("new.md", "h1") },
 		]);
 		const renamePairs = new Map([["new.md", "old.md"]]);
-		const result = refinePlan(p, renamePairs, new Map(), []);
+		const result = refine(p, renamePairs, new Map(), []);
 
 		expect(result.actions).toHaveLength(1);
 		expect(result.actions[0]).toMatchObject({
@@ -63,7 +99,7 @@ describe("refinePlan", () => {
 			{ path: "new.md", action: "pull", remote: entity("new.md", "h1") },
 		]);
 		const remotePairs = [{ oldPath: "old.md", newPath: "new.md" }];
-		const result = refinePlan(p, new Map(), new Map(), remotePairs);
+		const result = refine(p, new Map(), new Map(), remotePairs);
 
 		expect(result.actions).toHaveLength(1);
 		expect(result.actions[0]).toMatchObject({
@@ -101,7 +137,7 @@ describe("refinePlan", () => {
 		const remotePairs = [
 			{ oldPath: "remote-old.md", newPath: "remote-new.md" },
 		];
-		const result = refinePlan(p, localPairs, new Map(), remotePairs);
+		const result = refine(p, localPairs, new Map(), remotePairs);
 
 		expect(result.actions).toHaveLength(2);
 		const types = result.actions.map((a) => a.action).sort();
@@ -140,7 +176,7 @@ describe("refinePlan", () => {
 		]);
 		const localPairs = new Map([["x-new.md", "x-old.md"]]);
 		const remotePairs = [{ oldPath: "y-old.md", newPath: "y-new.md" }];
-		const result = refinePlan(p, localPairs, new Map(), remotePairs);
+		const result = refine(p, localPairs, new Map(), remotePairs);
 
 		expect(result.actions).toHaveLength(3);
 		expect(result.actions.map((a) => a.action).sort()).toEqual([
@@ -176,7 +212,7 @@ describe("refinePlan", () => {
 			["B/f1.md", "A/f1.md"],
 			["other-new.md", "other-old.md"],
 		]);
-		const result = refinePlan(p, filePairs, folderPairs, []);
+		const result = refine(p, filePairs, folderPairs, []);
 
 		expect(result.actions).toHaveLength(2);
 		const types = result.actions.map((a) => a.action).sort();
@@ -202,7 +238,7 @@ describe("refinePlan", () => {
 			{ path: "new.md", action: "push", local: entity("new.md", "h1") },
 		]);
 		const localPairs = new Map([["new.md", "old.md"]]);
-		const result = refinePlan(p, localPairs, new Map(), []);
+		const result = refine(p, localPairs, new Map(), []);
 
 		expect(result).not.toBe(p);
 		// refinePlan is a pure stage — the input plan must not be mutated.
@@ -233,7 +269,7 @@ describe("refinePlan", () => {
 			{ path: "img.png", action: "pull", remote: entity("img.png", "h5") },
 		]);
 		const remotePairs = [{ oldPath: "A", newPath: "B", isFolder: true }];
-		const result = refinePlan(p, new Map(), new Map(), remotePairs);
+		const result = refine(p, new Map(), new Map(), remotePairs);
 
 		const groupA = result.actions.filter((a) =>
 			["push", "pull", "match", "cleanup"].includes(a.action),
@@ -274,7 +310,7 @@ describe("refinePlan", () => {
 			},
 		]);
 		const remotePairs = [{ oldPath: "A", newPath: "B", isFolder: true }];
-		const result = refinePlan(p, new Map(), new Map(), remotePairs);
+		const result = refine(p, new Map(), new Map(), remotePairs);
 
 		expect(result.actions).toHaveLength(1);
 		expect(result.actions[0]).toMatchObject({

--- a/src/sync/rename-optimizer.test.ts
+++ b/src/sync/rename-optimizer.test.ts
@@ -47,25 +47,12 @@ function refine(
 }
 
 describe("refinePlan", () => {
-	it("preserves the exact identity-evidence collection beside the refined plan", () => {
-		const p = plan([{ path: "a.md", action: "push", local: entity("a.md", "h1") }]);
-		const identityEvidence: IdentityEvidence[] = [{
-			kind: "rename", side: "local", oldPath: "old.md", newPath: "new.md",
-			isFolder: false, authority: "reported",
-		}];
-
-		const result = refinePlan(p, identityEvidence);
-
-		expect(result.identityEvidence).toBe(identityEvidence);
-	});
-
 	it("returns plan unchanged when no rename pairs exist", () => {
 		const p = plan([
 			{ path: "a.md", action: "push", local: entity("a.md", "h1") },
 		]);
 		const result = refine(p, new Map(), new Map(), []);
 		expect(result.actions).toBe(p.actions);
-		expect(result.identityEvidence).toEqual([]);
 	});
 
 	it("optimizes local file rename into rename_remote", () => {

--- a/src/sync/rename-optimizer.ts
+++ b/src/sync/rename-optimizer.ts
@@ -1,4 +1,4 @@
-import type { RenamePair, SyncAction, SyncPlan } from "./types";
+import type { IdentityEvidence, SyncAction, SyncPlan } from "./types";
 import type { Logger } from "../logging/logger";
 import {
 	optimizeLocalFileRenames,
@@ -8,6 +8,11 @@ import {
 	optimizeRemoteFileRenames,
 	coalesceRemoteFolderRenames,
 } from "./optimize-remote-renames";
+import { renameOptimizerView } from "./identity-evidence";
+
+export interface RefinedSyncPlan extends SyncPlan {
+	identityEvidence: readonly IdentityEvidence[];
+}
 
 /** Filter out consumed actions and append replacements. */
 export function replaceConsumed(
@@ -28,11 +33,11 @@ export function replaceConsumed(
  */
 export function refinePlan(
 	plan: SyncPlan,
-	localRenamePairs: ReadonlyMap<string, string>,
-	localFolderRenamePairs: ReadonlyMap<string, string>,
-	remoteRenamePairs: RenamePair[],
+	identityEvidence: readonly IdentityEvidence[],
 	logger?: Logger,
-): SyncPlan {
+): RefinedSyncPlan {
+	const { localFiles: localRenamePairs, localFolders: localFolderRenamePairs, remote: remoteRenamePairs } =
+		renameOptimizerView(identityEvidence);
 	let actions = plan.actions;
 
 	if (localFolderRenamePairs.size > 0) {
@@ -94,6 +99,5 @@ export function refinePlan(
 		}
 	}
 
-	if (actions === plan.actions) return plan;
-	return { actions };
+	return { actions, identityEvidence };
 }

--- a/src/sync/rename-optimizer.ts
+++ b/src/sync/rename-optimizer.ts
@@ -10,10 +10,6 @@ import {
 } from "./optimize-remote-renames";
 import { renameOptimizerView } from "./identity-evidence";
 
-export interface RefinedSyncPlan extends SyncPlan {
-	identityEvidence: readonly IdentityEvidence[];
-}
-
 /** Filter out consumed actions and append replacements. */
 export function replaceConsumed(
 	actions: SyncAction[],
@@ -35,7 +31,7 @@ export function refinePlan(
 	plan: SyncPlan,
 	identityEvidence: readonly IdentityEvidence[],
 	logger?: Logger,
-): RefinedSyncPlan {
+): SyncPlan {
 	const { localFiles: localRenamePairs, localFolders: localFolderRenamePairs, remote: remoteRenamePairs } =
 		renameOptimizerView(identityEvidence);
 	let actions = plan.actions;
@@ -99,5 +95,5 @@ export function refinePlan(
 		}
 	}
 
-	return { actions, identityEvidence };
+	return { actions };
 }

--- a/src/sync/scheduler.test.ts
+++ b/src/sync/scheduler.test.ts
@@ -14,7 +14,7 @@ import type { TAbstractFile } from "obsidian";
 import { TFolder } from "../platform/obsidian";
 import { LocalChangeTracker } from "./local-tracker";
 import {
-	createMockFs,
+	createMockLocalFs, createMockRemoteFs,
 	createMockStateStore,
 } from "../__mocks__/sync-test-helpers";
 import { sha256 } from "../utils/hash";
@@ -72,8 +72,8 @@ function createDeps(
 				return {};
 			}),
 		} as unknown as SyncSchedulerDeps["vault"],
-		localFs: () => createMockFs("local"),
-		remoteFs: () => createMockFs("remote"),
+		localFs: () => createMockLocalFs(),
+		remoteFs: () => createMockRemoteFs(),
 		stateStore: createMockStateStore(),
 		localTracker: new LocalChangeTracker(),
 		orchestrator: { runSync, pullSingle, isSyncing: () => false },
@@ -351,8 +351,8 @@ describe("SyncScheduler", () => {
 			};
 			await deps.stateStore.put(record);
 
-			const localFs = createMockFs("local");
-			const remoteFs = createMockFs("remote");
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
 			localFs.files.set("note.md", {
 				content: localContent,
 				entity: {

--- a/src/sync/scheduler.test.ts
+++ b/src/sync/scheduler.test.ts
@@ -11,6 +11,7 @@ vi.stubGlobal("document", { visibilityState: "visible" as string });
 import { SyncScheduler } from "./scheduler";
 import type { SyncSchedulerDeps } from "./scheduler";
 import type { TAbstractFile } from "obsidian";
+import { TFolder } from "../platform/obsidian";
 import { LocalChangeTracker } from "./local-tracker";
 import {
 	createMockFs,
@@ -22,6 +23,9 @@ import type { SyncRecord } from "./types";
 type VaultHandler = (file: TAbstractFile) => void;
 type RenameHandler = (file: TAbstractFile, oldPath: string) => void;
 type WorkspaceHandler = (...args: unknown[]) => Promise<void> | void;
+type TestFolder = TAbstractFile & { children: TAbstractFile[] };
+
+const TestFolderConstructor = TFolder as unknown as new (path: string) => TestFolder;
 
 function createDeps(
 	overrides: Partial<SyncSchedulerDeps> = {},
@@ -93,6 +97,12 @@ function createDeps(
 
 function makeFile(path: string): TAbstractFile {
 	return { path } as TAbstractFile;
+}
+
+function makeFolder(path: string, children: Array<string | TAbstractFile> = []): TAbstractFile {
+	const folder = new TestFolderConstructor(path);
+	folder.children = children.map((child) => typeof child === "string" ? makeFile(child) : child);
+	return folder;
 }
 
 describe("SyncScheduler", () => {
@@ -168,7 +178,7 @@ describe("SyncScheduler", () => {
 			);
 		});
 
-		it("falls back to markDirty when one side of rename is excluded", () => {
+		it("preserves rename evidence when the old endpoint is excluded", () => {
 			scheduler.destroy();
 			deps = createDeps({ isExcluded: (p: string) => p === "old.md" });
 			scheduler = new SyncScheduler(deps);
@@ -177,8 +187,94 @@ describe("SyncScheduler", () => {
 			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
 			handler(makeFile("new.md"), "old.md");
 			expect(deps.localTracker.getDirtyPaths().has("new.md")).toBe(true);
-			expect(deps.localTracker.getDirtyPaths().has("old.md")).toBe(false);
+			expect(deps.localTracker.getDirtyPaths().has("old.md")).toBe(true);
+			expect(deps.localTracker.getRenamePairs().get("new.md")).toBe("old.md");
+		});
+
+		it("preserves rename evidence when the new endpoint is excluded", () => {
+			scheduler.destroy();
+			deps = createDeps({ isExcluded: (p: string) => p === "new.md" });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFile("new.md"), "old.md");
+			expect(deps.localTracker.getDirtyPaths()).toEqual(new Set(["old.md", "new.md"]));
+			expect(deps.localTracker.getRenamePairs().get("new.md")).toBe("old.md");
+		});
+
+		it("ignores a rename when both endpoints are excluded", () => {
+			scheduler.destroy();
+			deps = createDeps({ isExcluded: () => true });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFile("new.md"), "old.md");
+			vi.advanceTimersByTime(5000);
+
+			expect(deps.localTracker.getDirtyPaths().size).toBe(0);
 			expect(deps.localTracker.getRenamePairs().size).toBe(0);
+			expect(deps.runSync).not.toHaveBeenCalled();
+		});
+
+		it.each(["old", "new"] as const)(
+			"preserves a folder edge when only %s root is excluded",
+			(excluded) => {
+			scheduler.destroy();
+			deps = createDeps({ isExcluded: (path) => path === excluded });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFolder("new"), "old");
+
+			expect(deps.localTracker.getFolderRenamePairs().get("new")).toBe("old");
+			expect(deps.localTracker.getDirtyPaths().size).toBe(0);
+			},
+		);
+
+		it("preserves a folder edge when excluded roots contain an included descendant", () => {
+			scheduler.destroy();
+			deps = createDeps({
+				isExcluded: (path) => path === "old" || path === "new",
+			});
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFolder("new", ["new/a.md"]), "old");
+
+			expect(deps.localTracker.getFolderRenamePairs().get("new")).toBe("old");
+			expect(deps.localTracker.getDirtyPaths().size).toBe(0);
+		});
+
+		it("finds an included descendant below an excluded nested folder", () => {
+			scheduler.destroy();
+			deps = createDeps({
+				isExcluded: (path) => !path.endsWith("a.md"),
+			});
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const nested = makeFolder("new/nested", ["new/nested/a.md"]);
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFolder("new", [nested]), "old");
+
+			expect(deps.localTracker.getFolderRenamePairs().get("new")).toBe("old");
+		});
+
+		it("ignores a folder edge only when roots and descendants are all excluded", () => {
+			scheduler.destroy();
+			deps = createDeps({ isExcluded: () => true });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFolder("new", ["new/a.md"]), "old");
+
+			expect(deps.localTracker.getFolderRenamePairs().size).toBe(0);
+			expect(deps.localTracker.getDirtyPaths().size).toBe(0);
 		});
 
 		it("skips excluded paths", () => {

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -7,6 +7,24 @@ import { hasChanged, hasRemoteChanged } from "./change-compare";
 
 const DEBOUNCE_MS = 5000;
 
+function folderDescendantTouchesScope(
+	folder: TFolder,
+	oldRoot: string,
+	isExcluded: (path: string) => boolean,
+): boolean {
+	const newPrefix = `${folder.path}/`;
+	const pending = [...folder.children];
+	while (pending.length > 0) {
+		const child = pending.pop()!;
+		if (!child.path.startsWith(newPrefix)) return true;
+		const relative = child.path.substring(newPrefix.length);
+		const oldPath = relative ? `${oldRoot}/${relative}` : oldRoot;
+		if (!isExcluded(child.path) || !isExcluded(oldPath)) return true;
+		if (child instanceof TFolder) pending.push(...child.children);
+	}
+	return false;
+}
+
 export interface SyncOrchestrator {
 	runSync(): Promise<void>;
 	pullSingle(path: string): Promise<void>;
@@ -138,17 +156,18 @@ export class SyncScheduler {
 		};
 
 		const onRename = (file: TAbstractFile, oldPath: string) => {
-			if (!isExcluded(file.path) && !isExcluded(oldPath)) {
+			const newExcluded = isExcluded(file.path);
+			const oldExcluded = isExcluded(oldPath);
+			// Preserve one normative rename edge whenever either endpoint participates
+			// in sync. Scope projection owns the direction-specific consequence; losing
+			// the edge here would turn a cross-scope move into unrelated create/delete.
+			if (!newExcluded || !oldExcluded ||
+				(file instanceof TFolder && folderDescendantTouchesScope(file, oldPath, isExcluded))) {
 				if (file instanceof TFolder) {
 					localTracker.markFolderRenamed(file.path, oldPath);
 				} else {
 					localTracker.markRenamed(file.path, oldPath);
 				}
-			} else {
-				if (!isExcluded(file.path)) localTracker.markDirty(file.path);
-				if (!isExcluded(oldPath)) localTracker.markDirty(oldPath);
-			}
-			if (!isExcluded(file.path) || !isExcluded(oldPath)) {
 				this.debouncedSync();
 			}
 		};

--- a/src/sync/scope-projection.test.ts
+++ b/src/sync/scope-projection.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import type { ChangeSet } from "./change-detector";
+import type { FileEntity, PathAuthority } from "../fs/types";
+import type { RenameEvidence, ScopeDisposition, ScopeProjection } from "./types";
+import { projectRenameScope, projectScope } from "./scope-projection";
+
+function entity(path: string, size = 1, pathAuthority: PathAuthority = "actual_resolved"): FileEntity {
+	return { path, pathAuthority, isDirectory: false, size, mtime: 1, hash: "h" };
+}
+
+function directory(path: string): FileEntity {
+	return { path, pathAuthority: "actual_resolved", isDirectory: true, size: 0, mtime: 1, hash: "" };
+}
+
+function rename(side: "local" | "remote", oldPath = "old.md", newPath = "new.md"): RenameEvidence {
+	return { kind: "rename", side, oldPath, newPath, isFolder: false, authority: "reported" };
+}
+
+function projection(oldDisposition: ScopeDisposition, newDisposition: ScopeDisposition): ScopeProjection {
+	return { byEndpoint: new Map([
+		["old.md", oldDisposition],
+		["new.md", newDisposition],
+	]) };
+}
+
+function changeSet(overrides: Partial<ChangeSet> = {}): ChangeSet {
+	return {
+		entries: [], observations: [], identityEvidence: [], temperature: "hot", ...overrides,
+	};
+}
+
+describe("projectRenameScope", () => {
+	it.each([
+		["local", "included", "included", "rename_remote"],
+		["local", "included", "policy_out", "delete_remote"],
+		["local", "policy_out", "included", "push"],
+		["remote", "included", "included", "rename_local"],
+		["remote", "included", "policy_out", "delete_local"],
+		["remote", "policy_out", "included", "pull"],
+	] as const)("maps %s %s -> %s to %s only", (side, oldScope, newScope, consequence) => {
+		expect(projectRenameScope(rename(side), projection(oldScope, newScope))).toEqual({
+			consequence, oldDisposition: oldScope, newDisposition: newScope,
+		});
+	});
+
+	it.each(["unknown", "mobile_deferred"] as const)(
+		"defers the whole edge when either endpoint is %s",
+		(disposition) => {
+			for (const side of ["local", "remote"] as const) {
+				expect(projectRenameScope(rename(side), projection(disposition, "included")).consequence)
+					.toBe("defer");
+				expect(projectRenameScope(rename(side), projection("included", disposition)).consequence)
+					.toBe("defer");
+			}
+		},
+	);
+
+	it("performs no work when both endpoints are outside configured policy", () => {
+		for (const side of ["local", "remote"] as const) {
+			expect(projectRenameScope(rename(side), projection("policy_out", "policy_out")).consequence)
+				.toBe("none");
+		}
+	});
+
+	it("defers an out-of-policy folder when a descendant is included", () => {
+		const folderRename: RenameEvidence = { ...rename("local", "old", "new"), isFolder: true };
+		const result = projectRenameScope(folderRename, {
+			byEndpoint: new Map([
+				["old", "policy_out"], ["new", "policy_out"],
+				["old/a.md", "included"], ["new/a.md", "included"],
+			]),
+		});
+
+		expect(result.consequence).toBe("defer");
+	});
+
+	it("defaults a filter-lost endpoint to unknown and defers", () => {
+		expect(projectRenameScope(rename("local"), {
+			byEndpoint: new Map([["old.md", "included"]]),
+		}).consequence).toBe("defer");
+	});
+});
+
+describe("projectScope", () => {
+	it("classifies rename endpoints before entries are filtered", () => {
+		const result = projectScope(changeSet({
+			entries: [{ path: "old.md", prevSync: {
+				path: "old.md", hash: "h", localMtime: 1, remoteMtime: 1,
+				localSize: 1, remoteSize: 1, syncedAt: 1,
+			} }],
+			observations: [{
+				kind: "absent", side: "local", requestedPath: "old.md", authority: "stat",
+			}],
+			identityEvidence: [rename("local")],
+		}), { classifyPath: (path) => path === "new.md" ? "policy_out" : "included" });
+
+		expect(result.byEndpoint).toEqual(new Map([
+			["old.md", "included"],
+			["new.md", "policy_out"],
+		]));
+	});
+
+	it("retains nested folder descendants and dot-path policy independently", () => {
+		const folderRename: RenameEvidence = {
+			...rename("local", "folder", ".archive"), isFolder: true,
+		};
+		const result = projectScope(changeSet({
+			entries: [
+				{ path: "folder/nested/a.md", local: entity("folder/nested/a.md") },
+				{ path: ".archive/nested/a.md", local: entity(".archive/nested/a.md") },
+			],
+			observations: [
+				{ kind: "absent", side: "local", requestedPath: "folder", authority: "stat" },
+				{ kind: "exact", side: "local", requestedPath: ".archive", entity: directory(".archive") },
+			],
+			identityEvidence: [folderRename],
+		}), { classifyPath: (path) => path.startsWith(".") ? "policy_out" : "included" });
+
+		expect(result.byEndpoint).toEqual(new Map([
+			["folder", "included"],
+			[".archive", "policy_out"],
+			["folder/nested/a.md", "included"],
+			[".archive/nested/a.md", "policy_out"],
+		]));
+	});
+
+	it("keeps a not-observed included endpoint unknown", () => {
+		const result = projectScope(changeSet({
+			identityEvidence: [rename("local")],
+			observations: [
+				{ kind: "absent", side: "local", requestedPath: "old.md", authority: "stat" },
+				{ kind: "unknown", side: "local", requestedPath: "new.md", reason: "not_observed" },
+			],
+		}), { classifyPath: () => "included" });
+
+		expect(result.byEndpoint.get("new.md")).toBe("unknown");
+		expect(projectRenameScope(rename("local"), result).consequence).toBe("defer");
+	});
+
+	it("does not treat an evidence-only included endpoint as classified", () => {
+		const result = projectScope(changeSet({ identityEvidence: [rename("remote")] }), {
+			classifyPath: () => "included",
+		});
+
+		expect(result.byEndpoint).toEqual(new Map([
+			["old.md", "unknown"],
+			["new.md", "unknown"],
+		]));
+	});
+
+	it("retains a distinct unresolved returned path without treating it as exact", () => {
+		const result = projectScope(changeSet({
+			observations: [{
+				kind: "present_unresolved", side: "remote", requestedPath: "A.md",
+				returnedPath: ".hidden/A.md", entity: entity(".hidden/A.md", 20, "requested_echo"),
+				source: "stat",
+			}],
+		}), {
+			classifyPath: (path) => path.startsWith(".") ? "policy_out" : "included",
+			mobileMaxBytes: 10,
+		});
+
+		expect(result.byEndpoint.get("A.md")).toBe("mobile_deferred");
+		expect(result.byEndpoint.get(".hidden/A.md")).toBe("policy_out");
+	});
+
+	it("keeps an included unresolved returned path unknown", () => {
+		const result = projectScope(changeSet({
+			observations: [{
+				kind: "present_unresolved", side: "remote", requestedPath: "A.md",
+				returnedPath: "a.md", entity: entity("a.md", 1, "requested_echo"), source: "stat",
+			}],
+		}), { classifyPath: () => "included" });
+
+		expect(result.byEndpoint.get("a.md")).toBe("unknown");
+	});
+
+	it("marks only oversized included endpoints mobile-deferred", () => {
+		const result = projectScope(changeSet({
+			entries: [
+				{ path: "large.md", local: entity("large.md", 11) },
+				{ path: "small.md", remote: entity("small.md", 10) },
+				{ path: "excluded.md", local: entity("excluded.md", 20) },
+			],
+		}), {
+			classifyPath: (path) => path === "excluded.md" ? "policy_out" : "included",
+			mobileMaxBytes: 10,
+		});
+
+		expect(result.byEndpoint).toEqual(new Map([
+			["large.md", "mobile_deferred"],
+			["small.md", "included"],
+			["excluded.md", "policy_out"],
+		]));
+	});
+
+	it("treats a remote outside-root observation as policy-out authority", () => {
+		const result = projectScope(changeSet({
+			identityEvidence: [rename("remote")],
+			observations: [
+				{
+					kind: "absent", side: "remote", requestedPath: "old.md",
+					authority: "checkpoint_deleted",
+				},
+				{
+					kind: "unknown", side: "remote", requestedPath: "new.md",
+					reason: "outside_tracked_root",
+				},
+			],
+		}), { classifyPath: () => "included" });
+
+		expect(result.byEndpoint.get("new.md")).toBe("policy_out");
+		expect(projectRenameScope(rename("remote"), result).consequence).toBe("delete_local");
+	});
+
+	it("preserves an explicit unknown policy classification", () => {
+		const result = projectScope(changeSet({ identityEvidence: [rename("local")] }), {
+			classifyPath: (path) => path === "new.md" ? "unknown" : "included",
+		});
+
+		expect(result.byEndpoint.get("new.md")).toBe("unknown");
+		expect(projectRenameScope(rename("local"), result).consequence).toBe("defer");
+	});
+
+	it("defers a folder rename when descendant scope consequences differ", () => {
+		const folderRename: RenameEvidence = { ...rename("local", "old", "new"), isFolder: true };
+		const result = projectRenameScope(folderRename, {
+			byEndpoint: new Map([
+				["old", "included"], ["new", "included"],
+				["old/a.md", "included"], ["new/a.md", "policy_out"],
+			]),
+		});
+
+		expect(result.consequence).toBe("defer");
+	});
+
+	it("defers a folder rename when one descendant endpoint is missing", () => {
+		const folderRename: RenameEvidence = { ...rename("remote", "old", "new"), isFolder: true };
+		const result = projectRenameScope(folderRename, {
+			byEndpoint: new Map([
+				["old", "included"], ["new", "included"], ["new/a.md", "included"],
+			]),
+		});
+
+		expect(result.consequence).toBe("defer");
+	});
+
+	it("permits a folder rename when every observed descendant has the same consequence", () => {
+		const folderRename: RenameEvidence = { ...rename("remote", "old", "new"), isFolder: true };
+		const result = projectRenameScope(folderRename, {
+			byEndpoint: new Map([
+				["old", "included"], ["new", "included"],
+				["old/a.md", "included"], ["new/a.md", "included"],
+			]),
+		});
+
+		expect(result.consequence).toBe("rename_local");
+	});
+});

--- a/src/sync/scope-projection.test.ts
+++ b/src/sync/scope-projection.test.ts
@@ -124,6 +124,29 @@ describe("projectScope", () => {
 		]));
 	});
 
+	it("does not require incidental directory observations as folder-rename descendants", () => {
+		const folderRename: RenameEvidence = {
+			...rename("local", "old", "new"), isFolder: true,
+		};
+		const result = projectScope(changeSet({
+			entries: [
+				{ path: "old/nested/a.md", local: entity("old/nested/a.md") },
+				{ path: "new/nested/a.md", local: entity("new/nested/a.md") },
+			],
+			observations: [
+				{ kind: "exact", side: "local", requestedPath: "old", entity: directory("old") },
+				{ kind: "exact", side: "local", requestedPath: "new", entity: directory("new") },
+				{ kind: "exact", side: "local", requestedPath: "old/nested", entity: directory("old/nested") },
+				{ kind: "exact", side: "local", requestedPath: "new/nested", entity: directory("new/nested") },
+			],
+			identityEvidence: [folderRename],
+		}), { classifyPath: () => "included" });
+
+		expect(result.byEndpoint.has("old/nested")).toBe(false);
+		expect(result.byEndpoint.has("new/nested")).toBe(false);
+		expect(projectRenameScope(folderRename, result).consequence).toBe("rename_remote");
+	});
+
 	it("keeps a not-observed included endpoint unknown", () => {
 		const result = projectScope(changeSet({
 			identityEvidence: [rename("local")],

--- a/src/sync/scope-projection.ts
+++ b/src/sync/scope-projection.ts
@@ -1,0 +1,193 @@
+import type { ChangeSet } from "./change-detector";
+import type {
+	IdentityEvidence,
+	RenameEvidence,
+	ScopeDisposition,
+	ScopeProjection,
+} from "./types";
+
+export type RenameScopeConsequence =
+	| "rename_remote"
+	| "delete_remote"
+	| "push"
+	| "rename_local"
+	| "delete_local"
+	| "pull"
+	| "none"
+	| "defer";
+
+export interface RenameScopeRule {
+	consequence: RenameScopeConsequence;
+	oldDisposition: ScopeDisposition;
+	newDisposition: ScopeDisposition;
+}
+
+export interface ScopeProjectionPolicy {
+	classifyPath: (path: string) => "included" | "policy_out" | "unknown";
+	mobileMaxBytes?: number;
+}
+
+/**
+ * Classify the complete pre-filter change surface. Rename and alias endpoints
+ * are included even when no exact MixedEntity exists for them.
+ */
+export function projectScope(
+	changeSet: Pick<ChangeSet, "entries" | "observations" | "identityEvidence">,
+	policy: ScopeProjectionPolicy,
+): ScopeProjection {
+	const paths = collectScopePaths(changeSet.identityEvidence);
+	const knownPaths = new Set<string>();
+	const unknownPaths = new Set<string>();
+	for (const entry of changeSet.entries) {
+		paths.add(entry.path);
+		if (entry.local || entry.remote) knownPaths.add(entry.path);
+	}
+	for (const observation of changeSet.observations) {
+		paths.add(observation.requestedPath);
+		if (observation.kind === "unknown") {
+			unknownPaths.add(observation.requestedPath);
+		} else {
+			knownPaths.add(observation.requestedPath);
+		}
+		if (observation.kind === "alias") {
+			paths.add(observation.resolvedPath);
+			knownPaths.add(observation.resolvedPath);
+		} else if (observation.kind === "present_unresolved" &&
+			observation.returnedPath !== observation.requestedPath) {
+			paths.add(observation.returnedPath);
+			unknownPaths.add(observation.returnedPath);
+		}
+	}
+
+	const sizes = new Map<string, number>();
+	for (const entry of changeSet.entries) {
+		for (const entity of [entry.local, entry.remote]) {
+			if (entity) rememberLargestSize(sizes, entry.path, entity.size);
+		}
+	}
+	for (const observation of changeSet.observations) {
+		if (observation.kind === "exact" || observation.kind === "present_unresolved") {
+			rememberLargestSize(sizes, observation.requestedPath, observation.entity.size);
+		} else if (observation.kind === "alias") {
+			rememberLargestSize(sizes, observation.resolvedPath, observation.entity.size);
+		}
+	}
+
+	const outsideRoot = new Set(changeSet.observations.flatMap((observation) =>
+		observation.side === "remote" && observation.kind === "unknown" &&
+		observation.reason === "outside_tracked_root"
+			? [observation.requestedPath]
+			: []));
+	const byEndpoint = new Map<string, ScopeDisposition>();
+	for (const path of paths) {
+		const configured = outsideRoot.has(path) ? "policy_out" : policy.classifyPath(path);
+		if (configured !== "included") {
+			byEndpoint.set(path, configured);
+			continue;
+		}
+		if (unknownPaths.has(path) || !knownPaths.has(path)) {
+			byEndpoint.set(path, "unknown");
+			continue;
+		}
+		const size = sizes.get(path);
+		byEndpoint.set(
+			path,
+			policy.mobileMaxBytes !== undefined && size !== undefined && size > policy.mobileMaxBytes
+				? "mobile_deferred"
+				: "included",
+		);
+	}
+	return { byEndpoint };
+}
+
+/** The only action kind scope permits for one normative reported rename. */
+export function projectRenameScope(
+	rename: RenameEvidence,
+	projection: ScopeProjection,
+): RenameScopeRule {
+	const oldDisposition = projection.byEndpoint.get(rename.oldPath) ?? "unknown";
+	const newDisposition = projection.byEndpoint.get(rename.newPath) ?? "unknown";
+	const consequence = consequenceFor(rename.side, oldDisposition, newDisposition);
+	if (rename.isFolder && !descendantsMatch(rename, projection, consequence)) {
+		return { consequence: "defer", oldDisposition, newDisposition };
+	}
+	return { consequence, oldDisposition, newDisposition };
+}
+
+function collectScopePaths(evidence: readonly IdentityEvidence[]): Set<string> {
+	const paths = new Set<string>();
+	for (const item of evidence) {
+		if (item.kind === "rename") {
+			paths.add(item.oldPath);
+			paths.add(item.newPath);
+		} else if (item.kind === "alias") {
+			paths.add(item.requestedPath);
+			paths.add(item.resolvedPath);
+		} else {
+			for (const occurrence of item.occurrences) paths.add(occurrence.path);
+		}
+	}
+	return paths;
+}
+
+function rememberLargestSize(sizes: Map<string, number>, path: string, size: number): void {
+	sizes.set(path, Math.max(sizes.get(path) ?? 0, size));
+}
+
+function isIndeterminate(
+	disposition: ScopeDisposition,
+): disposition is "unknown" | "mobile_deferred" {
+	return disposition === "unknown" || disposition === "mobile_deferred";
+}
+
+function consequenceFor(
+	side: "local" | "remote",
+	oldDisposition: ScopeDisposition,
+	newDisposition: ScopeDisposition,
+): RenameScopeConsequence {
+	if (isIndeterminate(oldDisposition) || isIndeterminate(newDisposition)) return "defer";
+	if (oldDisposition === "policy_out" && newDisposition === "policy_out") return "none";
+	return side === "local"
+		? localConsequence(oldDisposition, newDisposition)
+		: remoteConsequence(oldDisposition, newDisposition);
+}
+
+function descendantsMatch(
+	rename: RenameEvidence,
+	projection: ScopeProjection,
+	expected: RenameScopeConsequence,
+): boolean {
+	const oldPrefix = `${rename.oldPath}/`;
+	const newPrefix = `${rename.newPath}/`;
+	const relatives = new Set<string>();
+	for (const path of projection.byEndpoint.keys()) {
+		if (path.startsWith(oldPrefix)) relatives.add(path.substring(oldPrefix.length));
+		if (path.startsWith(newPrefix)) relatives.add(path.substring(newPrefix.length));
+	}
+	for (const relative of relatives) {
+		const oldDisposition = projection.byEndpoint.get(`${oldPrefix}${relative}`) ?? "unknown";
+		const newDisposition = projection.byEndpoint.get(`${newPrefix}${relative}`) ?? "unknown";
+		if (consequenceFor(rename.side, oldDisposition, newDisposition) !== expected) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function localConsequence(
+	oldDisposition: "included" | "policy_out",
+	newDisposition: "included" | "policy_out",
+): RenameScopeConsequence {
+	if (oldDisposition === "included" && newDisposition === "included") return "rename_remote";
+	if (oldDisposition === "included") return "delete_remote";
+	return "push";
+}
+
+function remoteConsequence(
+	oldDisposition: "included" | "policy_out",
+	newDisposition: "included" | "policy_out",
+): RenameScopeConsequence {
+	if (oldDisposition === "included" && newDisposition === "included") return "rename_local";
+	if (oldDisposition === "included") return "delete_local";
+	return "pull";
+}

--- a/src/sync/scope-projection.ts
+++ b/src/sync/scope-projection.ts
@@ -17,7 +17,7 @@ export type RenameScopeConsequence =
 	| "none"
 	| "defer";
 
-export interface RenameScopeRule {
+interface RenameScopeRule {
 	consequence: RenameScopeConsequence;
 	oldDisposition: ScopeDisposition;
 	newDisposition: ScopeDisposition;

--- a/src/sync/scope-projection.ts
+++ b/src/sync/scope-projection.ts
@@ -1,6 +1,7 @@
 import type { ChangeSet } from "./change-detector";
 import type {
 	IdentityEvidence,
+	PathObservation,
 	RenameEvidence,
 	ScopeDisposition,
 	ScopeProjection,
@@ -35,14 +36,16 @@ export function projectScope(
 	changeSet: Pick<ChangeSet, "entries" | "observations" | "identityEvidence">,
 	policy: ScopeProjectionPolicy,
 ): ScopeProjection {
-	const paths = collectScopePaths(changeSet.identityEvidence);
+	const requiredPaths = collectScopePaths(changeSet.identityEvidence);
+	for (const entry of changeSet.entries) requiredPaths.add(entry.path);
+	const paths = new Set(requiredPaths);
 	const knownPaths = new Set<string>();
 	const unknownPaths = new Set<string>();
 	for (const entry of changeSet.entries) {
-		paths.add(entry.path);
 		if (entry.local || entry.remote) knownPaths.add(entry.path);
 	}
 	for (const observation of changeSet.observations) {
+		if (isIncidentalDirectory(observation, requiredPaths)) continue;
 		paths.add(observation.requestedPath);
 		if (observation.kind === "unknown") {
 			unknownPaths.add(observation.requestedPath);
@@ -66,6 +69,7 @@ export function projectScope(
 		}
 	}
 	for (const observation of changeSet.observations) {
+		if (isIncidentalDirectory(observation, requiredPaths)) continue;
 		if (observation.kind === "exact" || observation.kind === "present_unresolved") {
 			rememberLargestSize(sizes, observation.requestedPath, observation.entity.size);
 		} else if (observation.kind === "alias") {
@@ -98,6 +102,21 @@ export function projectScope(
 		);
 	}
 	return { byEndpoint };
+}
+
+function isIncidentalDirectory(
+	observation: PathObservation,
+	requiredPaths: ReadonlySet<string>,
+): boolean {
+	if (observation.kind !== "exact" && observation.kind !== "alias" &&
+		observation.kind !== "present_unresolved") return false;
+	if (!observation.entity.isDirectory) return false;
+	const endpointPaths = observation.kind === "alias"
+		? [observation.requestedPath, observation.resolvedPath]
+		: observation.kind === "present_unresolved"
+			? [observation.requestedPath, observation.returnedPath]
+			: [observation.requestedPath];
+	return endpointPaths.every((path) => !requiredPaths.has(path));
 }
 
 /** The only action kind scope permits for one normative reported rename. */

--- a/src/sync/state-committer.test.ts
+++ b/src/sync/state-committer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { commitAction, buildSyncRecord } from "./state-committer";
 import type { SyncAction } from "./types";
-import { createMockFs, createMockStateStore, makeFile } from "../__mocks__/sync-test-helpers";
+import { createMockLocalFs, type MockFileSystem, createMockStateStore, makeFile } from "../__mocks__/sync-test-helpers";
 import type { SyncStateStore } from "./state";
 import type { Logger } from "../logging/logger";
 
@@ -46,11 +46,11 @@ describe("buildSyncRecord", () => {
 
 describe("commitAction", () => {
 	let stateStore: ReturnType<typeof createMockStateStore>;
-	let localFs: ReturnType<typeof createMockFs>;
+	let localFs: MockFileSystem;
 
 	beforeEach(() => {
 		stateStore = createMockStateStore();
-		localFs = createMockFs("local");
+		localFs = createMockLocalFs();
 	});
 
 	function makeCtx(enableThreeWayMerge = false) {

--- a/src/sync/state-committer.test.ts
+++ b/src/sync/state-committer.test.ts
@@ -10,6 +10,7 @@ describe("buildSyncRecord", () => {
 		const local = makeFile("a.md", "hello", 1000).entity;
 		const remote = makeFile("a.md", "hello", 2000).entity;
 		remote.backendMeta = { id: "drive-id" };
+		remote.identityKey = "native-id";
 
 		const record = buildSyncRecord(local, remote, "a.md");
 
@@ -19,6 +20,7 @@ describe("buildSyncRecord", () => {
 		expect(record.localSize).toBe(local.size);
 		expect(record.remoteSize).toBe(remote.size);
 		expect(record.backendMeta).toEqual({ id: "drive-id" });
+		expect(record.remoteIdentityKey).toBe("native-id");
 		expect(record.syncedAt).toBeGreaterThan(0);
 	});
 

--- a/src/sync/state-committer.ts
+++ b/src/sync/state-committer.ts
@@ -24,6 +24,7 @@ export function buildSyncRecord(local: FileEntity | undefined, remote: FileEntit
 		localSize: local?.size ?? 0,
 		remoteSize: remote?.size ?? 0,
 		remoteChecksum: remote?.remoteChecksum,
+		remoteIdentityKey: remote?.identityKey,
 		backendMeta: remote?.backendMeta,
 		syncedAt: Date.now(),
 	};

--- a/src/sync/state.test.ts
+++ b/src/sync/state.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "fake-indexeddb/auto";
 import { SyncStateStore } from "./state";
+import type { RenameDebt } from "./state";
 import type { SyncRecord } from "./types";
+import { sanitizeDbName } from "../store/idb-helper";
 
 function makeRecord(path: string, overrides: Partial<SyncRecord> = {}): SyncRecord {
 	return {
@@ -14,6 +16,38 @@ function makeRecord(path: string, overrides: Partial<SyncRecord> = {}): SyncReco
 		syncedAt: 900,
 		...overrides,
 	};
+}
+
+function makeDebt(overrides: Partial<RenameDebt> = {}): RenameDebt {
+	return {
+		namespace: "onedrive:vault-1",
+		side: "local",
+		oldPath: "A.md",
+		newPath: "a.md",
+		isFolder: false,
+		oldDisposition: "included",
+		newDisposition: "included",
+		...overrides,
+	};
+}
+
+async function seedVersion5Database(vaultId: string): Promise<void> {
+	const dbName = `air-sync-${sanitizeDbName(vaultId)}`;
+	await new Promise<void>((resolve, reject) => {
+		const request = indexedDB.open(dbName, 5);
+		request.onupgradeneeded = () => {
+			const db = request.result;
+			const records = db.createObjectStore("sync-records", { keyPath: "path" });
+			records.put(makeRecord("legacy.md"));
+			const contents = db.createObjectStore("sync-content", { keyPath: "path" });
+			contents.put({ path: "legacy.md", content: new Uint8Array([1, 2, 3]).buffer });
+		};
+		request.onerror = () => reject(request.error ?? new Error("Failed to seed version 5 database"));
+		request.onsuccess = () => {
+			request.result.close();
+			resolve();
+		};
+	});
 }
 
 describe("SyncStateStore", () => {
@@ -33,7 +67,7 @@ describe("SyncStateStore", () => {
 	});
 
 	it("put + get: round-trips a sync record", async () => {
-		const record = makeRecord("notes/hello.md");
+		const record = makeRecord("notes/hello.md", { remoteIdentityKey: "remote-id-1" });
 		await store.put(record);
 		const result = await store.get("notes/hello.md");
 		expect(result).toEqual(record);
@@ -125,6 +159,74 @@ describe("SyncStateStore", () => {
 
 		expect(await store.getAll()).toHaveLength(0);
 		expect(await store.getContent("a.md")).toBeUndefined();
+	});
+
+	it("schema upgrade cold-starts legacy records and merge bases", async () => {
+		await store.close();
+		const vaultId = `upgrade-vault-${Math.random()}`;
+		await seedVersion5Database(vaultId);
+		store = new SyncStateStore(vaultId);
+
+		await store.open();
+
+		expect(await store.getAll()).toEqual([]);
+		expect(await store.getContent("legacy.md")).toBeUndefined();
+		expect(await store.getRenameDebts("onedrive:vault-1")).toEqual([]);
+	});
+
+	it("rename debt upsert replaces the same edge and retains distinct unresolved edges", async () => {
+		await store.upsertRenameDebts([makeDebt({ oldDisposition: "unknown" })]);
+		await store.upsertRenameDebts([
+			makeDebt({ oldDisposition: "included" }),
+			makeDebt({ oldPath: "B.md", newPath: "b.md" }),
+		]);
+
+		const debts = await store.getRenameDebts("onedrive:vault-1");
+		expect(debts).toHaveLength(2);
+		expect(debts).toContainEqual(makeDebt({ oldDisposition: "included" }));
+		expect(debts).toContainEqual(makeDebt({ oldPath: "B.md", newPath: "b.md" }));
+	});
+
+	it("rename debt grows by unique unresolved edges across cycles and decreases on resolution", async () => {
+		await store.upsertRenameDebts([makeDebt()]);
+		await store.upsertRenameDebts([
+			makeDebt({ oldPath: "B.md", newPath: "b.md" }),
+			makeDebt({ oldPath: "C.md", newPath: "c.md" }),
+		]);
+		expect(await store.getRenameDebts("onedrive:vault-1")).toHaveLength(3);
+
+		await store.deleteRenameDebts([makeDebt({ oldPath: "B.md", newPath: "b.md" })]);
+		expect(await store.getRenameDebts("onedrive:vault-1")).toEqual([
+			makeDebt(),
+			makeDebt({ oldPath: "C.md", newPath: "c.md" }),
+		]);
+	});
+
+	it("clearRenameDebts removes only the selected backend/root namespace", async () => {
+		await store.upsertRenameDebts([
+			makeDebt(),
+			makeDebt({ namespace: "dropbox:vault-2" }),
+		]);
+
+		await store.clearRenameDebts("onedrive:vault-1");
+
+		expect(await store.getRenameDebts("onedrive:vault-1")).toEqual([]);
+		expect(await store.getRenameDebts("dropbox:vault-2")).toEqual([
+			makeDebt({ namespace: "dropbox:vault-2" }),
+		]);
+	});
+
+	it("clear removes authoritative rename debt with records and content", async () => {
+		const content = new TextEncoder().encode("merge base").buffer.slice(0);
+		await store.put(makeRecord("A.md"));
+		await store.putContent("A.md", content);
+		await store.upsertRenameDebts([makeDebt()]);
+
+		await store.clear();
+
+		expect(await store.getAll()).toEqual([]);
+		expect(await store.getContent("A.md")).toBeUndefined();
+		expect(await store.getRenameDebts("onedrive:vault-1")).toEqual([]);
 	});
 
 	it("putContent + getContent: round-trips content", async () => {

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -1,4 +1,4 @@
-import type { RenamePair, SyncRecord } from "./types";
+import type { RenamePair, ScopeDisposition, SyncRecord } from "./types";
 import { IDBHelper, sanitizeDbName } from "../store/idb-helper";
 import { encodeContent, decodeContent } from "../store/content-codec";
 
@@ -15,7 +15,7 @@ const RENAME_DEBT_STORE_NAME = "rename-debt";
 const DB_VERSION = 6;
 
 export type RenameDebtSide = "local" | "remote";
-export type RenameDebtDisposition = "included" | "policy_out" | "mobile_deferred" | "unknown";
+export type RenameDebtDisposition = ScopeDisposition;
 
 /** One unresolved reported rename, scoped to a configured backend/root. */
 export interface RenameDebt {

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -14,8 +14,8 @@ const RENAME_DEBT_STORE_NAME = "rename-debt";
 // is created. Cold-start prevents old baselines from being treated as identity-aware.
 const DB_VERSION = 6;
 
-export type RenameDebtSide = "local" | "remote";
-export type RenameDebtDisposition = ScopeDisposition;
+type RenameDebtSide = "local";
+type RenameDebtDisposition = ScopeDisposition;
 
 /** One unresolved reported rename, scoped to a configured backend/root. */
 export interface RenameDebt {
@@ -26,7 +26,6 @@ export interface RenameDebt {
 	isFolder: boolean;
 	oldDisposition: RenameDebtDisposition;
 	newDisposition: RenameDebtDisposition;
-	identityKey?: string;
 }
 
 interface StoredRenameDebt extends RenameDebt {

--- a/src/sync/state.ts
+++ b/src/sync/state.ts
@@ -5,11 +5,51 @@ import { encodeContent, decodeContent } from "../store/content-codec";
 const DB_NAME_PREFIX = "air-sync";
 const STORE_NAME = "sync-records";
 const CONTENT_STORE_NAME = "sync-content";
+const RENAME_DEBT_STORE_NAME = "rename-debt";
 // v4: SyncRecord checksum moved from backendMeta.contentChecksum to a typed
 // remoteChecksum field — cold-start drops old records so they re-baseline.
 // v5: content store now holds codec-prefixed bytes (see content-codec.ts);
 // cold-start drops old un-prefixed entries so they re-baseline compressed.
-const DB_VERSION = 5;
+// v6: SyncRecord gains remoteIdentityKey and the authoritative rename-debt store
+// is created. Cold-start prevents old baselines from being treated as identity-aware.
+const DB_VERSION = 6;
+
+export type RenameDebtSide = "local" | "remote";
+export type RenameDebtDisposition = "included" | "policy_out" | "mobile_deferred" | "unknown";
+
+/** One unresolved reported rename, scoped to a configured backend/root. */
+export interface RenameDebt {
+	namespace: string;
+	side: RenameDebtSide;
+	oldPath: string;
+	newPath: string;
+	isFolder: boolean;
+	oldDisposition: RenameDebtDisposition;
+	newDisposition: RenameDebtDisposition;
+	identityKey?: string;
+}
+
+interface StoredRenameDebt extends RenameDebt {
+	key: string;
+}
+
+function renameDebtKey(debt: RenameDebt): string {
+	return JSON.stringify([
+		debt.namespace,
+		debt.side,
+		debt.oldPath,
+		debt.newPath,
+		debt.isFolder,
+	]);
+}
+
+function toStoredRenameDebt(debt: RenameDebt): StoredRenameDebt {
+	return { ...debt, key: renameDebtKey(debt) };
+}
+
+function fromStoredRenameDebt({ key: _key, ...debt }: StoredRenameDebt): RenameDebt {
+	return debt;
+}
 
 /** Persistent store for sync records using IndexedDB */
 export class SyncStateStore {
@@ -31,6 +71,9 @@ export class SyncStateStore {
 				}
 				if (!db.objectStoreNames.contains(CONTENT_STORE_NAME)) {
 					db.createObjectStore(CONTENT_STORE_NAME, { keyPath: "path" });
+				}
+				if (!db.objectStoreNames.contains(RENAME_DEBT_STORE_NAME)) {
+					db.createObjectStore(RENAME_DEBT_STORE_NAME, { keyPath: "key" });
 				}
 			},
 		});
@@ -75,6 +118,54 @@ export class SyncStateStore {
 		return this.helper.runTransaction(STORE_NAME, "readonly", (tx) => {
 			const req = tx.objectStore(STORE_NAME).getAll();
 			return () => req.result as SyncRecord[];
+		});
+	}
+
+	/** Atomically add or replace unresolved rename edges. One record is stored per unique edge. */
+	async upsertRenameDebts(debts: RenameDebt[]): Promise<void> {
+		if (debts.length === 0) return;
+		await this.helper.runTransaction(RENAME_DEBT_STORE_NAME, "readwrite", (tx) => {
+			const store = tx.objectStore(RENAME_DEBT_STORE_NAME);
+			for (const debt of debts) {
+				store.put(toStoredRenameDebt(debt));
+			}
+			return () => {};
+		});
+	}
+
+	/** Read unresolved rename edges for one configured backend/root namespace. */
+	async getRenameDebts(namespace: string): Promise<RenameDebt[]> {
+		return this.helper.runTransaction(RENAME_DEBT_STORE_NAME, "readonly", (tx) => {
+			const req = tx.objectStore(RENAME_DEBT_STORE_NAME).getAll();
+			return () => (req.result as StoredRenameDebt[])
+				.filter((debt) => debt.namespace === namespace)
+				.map(fromStoredRenameDebt);
+		});
+	}
+
+	/** Atomically remove rename edges after their components resolve in a clean cycle. */
+	async deleteRenameDebts(debts: RenameDebt[]): Promise<void> {
+		if (debts.length === 0) return;
+		await this.helper.runTransaction(RENAME_DEBT_STORE_NAME, "readwrite", (tx) => {
+			const store = tx.objectStore(RENAME_DEBT_STORE_NAME);
+			for (const debt of debts) {
+				store.delete(renameDebtKey(debt));
+			}
+			return () => {};
+		});
+	}
+
+	/** Clear debt for a disconnected or replaced backend/root namespace. */
+	async clearRenameDebts(namespace: string): Promise<void> {
+		await this.helper.runTransaction(RENAME_DEBT_STORE_NAME, "readwrite", (tx) => {
+			const store = tx.objectStore(RENAME_DEBT_STORE_NAME);
+			const req = store.getAll();
+			req.onsuccess = () => {
+				for (const debt of req.result as StoredRenameDebt[]) {
+					if (debt.namespace === namespace) store.delete(debt.key);
+				}
+			};
+			return () => {};
 		});
 	}
 
@@ -128,13 +219,18 @@ export class SyncStateStore {
 		});
 	}
 
-	/** Clear all sync records and content */
+	/** Clear all sync records, content, and authoritative rename debt. */
 	async clear(): Promise<void> {
-		await this.helper.runTransaction([STORE_NAME, CONTENT_STORE_NAME], "readwrite", (tx) => {
+		await this.helper.runTransaction(
+			[STORE_NAME, CONTENT_STORE_NAME, RENAME_DEBT_STORE_NAME],
+			"readwrite",
+			(tx) => {
 			tx.objectStore(STORE_NAME).clear();
 			tx.objectStore(CONTENT_STORE_NAME).clear();
+			tx.objectStore(RENAME_DEBT_STORE_NAME).clear();
 			return () => {};
-		});
+			},
+		);
 	}
 
 	/** Store prevSyncContent separately for a path (compressed via content-codec) */

--- a/src/sync/sync-cycle-finalization.test.ts
+++ b/src/sync/sync-cycle-finalization.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IncrementalCheckpoint } from "../fs/interface";
+import type { ExecutionResult } from "./execution-result";
+import { finalizeSyncCycle } from "./sync-cycle-finalization";
+import type { SyncStateStore } from "./state";
+import type { IdentityEvidence, SyncAction } from "./types";
+
+function checkpoint(commitCheckpoint: IncrementalCheckpoint["commitCheckpoint"]): IncrementalCheckpoint {
+	return {
+		getChangedPaths: vi.fn().mockResolvedValue(null),
+		hasCheckpoint: vi.fn().mockResolvedValue(true),
+		resetCheckpoint: vi.fn().mockResolvedValue(undefined),
+		commitCheckpoint,
+	};
+}
+
+describe("finalizeSyncCycle", () => {
+	it("holds the cursor and remote evidence when connected work is blocked", async () => {
+		const edge: IdentityEvidence = {
+			kind: "rename", side: "remote", oldPath: "A.md", newPath: "a.md",
+			isFolder: false, authority: "reported",
+		};
+		const action: SyncAction = { action: "rename_local", oldPath: "A.md", path: "a.md" };
+		const result: ExecutionResult = {
+			succeeded: [], failed: [], conflicts: [], deferred: [],
+			blocked: [{ action, reason: "quarantined" }],
+		};
+		const commitCheckpoint = vi.fn<IncrementalCheckpoint["commitCheckpoint"]>()
+			.mockResolvedValue(undefined);
+		const deleteRenameDebts = vi.fn().mockResolvedValue(undefined);
+
+		const retained = await finalizeSyncCycle({
+			result, pendingEvidence: [edge], persistedDebts: [], localRenameDebts: [],
+			scopeProjection: { byEndpoint: new Map([["A.md", "included"], ["a.md", "included"]]) },
+			observations: [], checkpoint: checkpoint(commitCheckpoint), scopeFingerprint: "scope",
+			stateStore: { deleteRenameDebts } as unknown as SyncStateStore,
+		});
+
+		expect(retained).toEqual([edge]);
+		expect(commitCheckpoint).not.toHaveBeenCalled();
+		expect(deleteRenameDebts).not.toHaveBeenCalled();
+	});
+});

--- a/src/sync/sync-cycle-finalization.test.ts
+++ b/src/sync/sync-cycle-finalization.test.ts
@@ -3,7 +3,12 @@ import type { IncrementalCheckpoint } from "../fs/interface";
 import type { ExecutionResult } from "./execution-result";
 import { finalizeSyncCycle } from "./sync-cycle-finalization";
 import type { SyncStateStore } from "./state";
-import type { IdentityEvidence, SyncAction } from "./types";
+import type { IdentityEvidence, PathObservation, ScopeProjection, SyncAction } from "./types";
+import {
+	admitDestructivePlan,
+	captureCycleAdmissionSnapshot,
+	type AdmissionResult,
+} from "./plan-admission";
 
 function checkpoint(commitCheckpoint: IncrementalCheckpoint["commitCheckpoint"]): IncrementalCheckpoint {
 	return {
@@ -14,13 +19,53 @@ function checkpoint(commitCheckpoint: IncrementalCheckpoint["commitCheckpoint"])
 	};
 }
 
+function admission(
+	actions: SyncAction[],
+	evidence: IdentityEvidence[],
+	scope: ScopeProjection,
+	observations: PathObservation[] = [],
+): AdmissionResult {
+	return admitDestructivePlan(captureCycleAdmissionSnapshot(
+		{ actions }, evidence, observations, scope, "onedrive:root",
+	));
+}
+
+function edge(side: "local" | "remote" = "remote"): IdentityEvidence {
+	return {
+		kind: "rename", side, oldPath: "A.md", newPath: "a.md",
+		isFolder: false, authority: "reported",
+	};
+}
+
 describe("finalizeSyncCycle", () => {
+	it("does not infer an actionless rename no-op from scope during finalization", async () => {
+		const pending = edge();
+		const commitCheckpoint = vi.fn<IncrementalCheckpoint["commitCheckpoint"]>()
+			.mockResolvedValue(undefined);
+		const deleteRenameDebts = vi.fn().mockResolvedValue(undefined);
+		const admitted = admission([], [pending], { byEndpoint: new Map([
+			["A.md", "unknown"], ["a.md", "unknown"],
+		]) });
+
+		const retained = await finalizeSyncCycle({
+			admission: admitted,
+			result: { succeeded: [], failed: [], blocked: [], conflicts: [], deferred: [] },
+			pendingEvidence: [pending], persistedDebts: [], localRenameDebts: [],
+			checkpoint: checkpoint(commitCheckpoint), scopeFingerprint: "scope",
+			stateStore: { deleteRenameDebts } as unknown as SyncStateStore,
+		});
+
+		expect(retained).toEqual([pending]);
+		expect(commitCheckpoint).not.toHaveBeenCalled();
+		expect(deleteRenameDebts).not.toHaveBeenCalled();
+	});
+
 	it("holds the cursor and remote evidence when connected work is blocked", async () => {
-		const edge: IdentityEvidence = {
-			kind: "rename", side: "remote", oldPath: "A.md", newPath: "a.md",
-			isFolder: false, authority: "reported",
-		};
+		const pending = edge();
 		const action: SyncAction = { action: "rename_local", oldPath: "A.md", path: "a.md" };
+		const admitted = admission([action], [pending], { byEndpoint: new Map([
+			["A.md", "included"], ["a.md", "included"],
+		]) });
 		const result: ExecutionResult = {
 			succeeded: [], failed: [], conflicts: [], deferred: [],
 			blocked: [{ action, reason: "quarantined" }],
@@ -30,14 +75,56 @@ describe("finalizeSyncCycle", () => {
 		const deleteRenameDebts = vi.fn().mockResolvedValue(undefined);
 
 		const retained = await finalizeSyncCycle({
-			result, pendingEvidence: [edge], persistedDebts: [], localRenameDebts: [],
-			scopeProjection: { byEndpoint: new Map([["A.md", "included"], ["a.md", "included"]]) },
-			observations: [], checkpoint: checkpoint(commitCheckpoint), scopeFingerprint: "scope",
+			admission: admitted, result, pendingEvidence: [pending], persistedDebts: [], localRenameDebts: [],
+			checkpoint: checkpoint(commitCheckpoint), scopeFingerprint: "scope",
 			stateStore: { deleteRenameDebts } as unknown as SyncStateStore,
 		});
 
-		expect(retained).toEqual([edge]);
+		expect(retained).toEqual([pending]);
 		expect(commitCheckpoint).not.toHaveBeenCalled();
+		expect(deleteRenameDebts).not.toHaveBeenCalled();
+	});
+
+	it("commits the checkpoint before retiring resolved-no-action evidence", async () => {
+		const pending = edge();
+		const admitted = admission([], [pending], { byEndpoint: new Map([
+			["A.md", "policy_out"], ["a.md", "policy_out"],
+		]) });
+		const order: string[] = [];
+		const commitCheckpoint = vi.fn<IncrementalCheckpoint["commitCheckpoint"]>()
+			.mockImplementation(() => { order.push("checkpoint"); return Promise.resolve(); });
+		const deleteRenameDebts = vi.fn().mockImplementation(() => {
+			order.push("retire");
+			return Promise.resolve();
+		});
+
+		const retained = await finalizeSyncCycle({
+			admission: admitted,
+			result: { succeeded: [], failed: [], blocked: [], conflicts: [], deferred: [] },
+			pendingEvidence: [pending], persistedDebts: [], localRenameDebts: [],
+			checkpoint: checkpoint(commitCheckpoint), scopeFingerprint: "scope",
+			stateStore: { deleteRenameDebts } as unknown as SyncStateStore,
+		});
+
+		expect(retained).toEqual([]);
+		expect(order).toEqual(["checkpoint", "retire"]);
+	});
+
+	it("leaves evidence and debt untouched when checkpoint persistence fails", async () => {
+		const pending = edge();
+		const admitted = admission([], [pending], { byEndpoint: new Map([
+			["A.md", "policy_out"], ["a.md", "policy_out"],
+		]) });
+		const deleteRenameDebts = vi.fn().mockResolvedValue(undefined);
+
+		await expect(finalizeSyncCycle({
+			admission: admitted,
+			result: { succeeded: [], failed: [], blocked: [], conflicts: [], deferred: [] },
+			pendingEvidence: [pending], persistedDebts: [], localRenameDebts: [],
+			checkpoint: checkpoint(vi.fn().mockRejectedValue(new Error("checkpoint failed"))),
+			scopeFingerprint: "scope",
+			stateStore: { deleteRenameDebts } as unknown as SyncStateStore,
+		})).rejects.toThrow("checkpoint failed");
 		expect(deleteRenameDebts).not.toHaveBeenCalled();
 	});
 });

--- a/src/sync/sync-cycle-finalization.ts
+++ b/src/sync/sync-cycle-finalization.ts
@@ -1,19 +1,19 @@
 import type { IFileSystem } from "../fs/interface";
 import type { ExecutionResult } from "./execution-result";
 import {
-	resolvedRenameDebts,
-	unresolvedRenameEvidence,
+	renameDebtsBoundToEvidence,
+	unreleasedIdentityEvidence,
 } from "./rename-debt";
+import type { AdmissionResult } from "./plan-admission";
 import type { RenameDebt, SyncStateStore } from "./state";
-import type { IdentityEvidence, PathObservation, ScopeProjection } from "./types";
+import type { IdentityEvidence } from "./types";
 
 interface SyncCycleFinalizationInput {
+	admission: AdmissionResult;
 	result: ExecutionResult;
 	pendingEvidence: readonly IdentityEvidence[];
 	persistedDebts: readonly RenameDebt[];
 	localRenameDebts: readonly RenameDebt[];
-	scopeProjection: ScopeProjection;
-	observations: readonly PathObservation[];
 	checkpoint: IFileSystem["checkpoint"];
 	scopeFingerprint: string;
 	stateStore: SyncStateStore;
@@ -24,22 +24,26 @@ interface SyncCycleFinalizationInput {
  * local debt retired only when the corresponding cursor is safe to advance.
  */
 export async function finalizeSyncCycle(input: SyncCycleFinalizationInput): Promise<IdentityEvidence[]> {
-	const unresolved = unresolvedRenameEvidence(
-		input.pendingEvidence, input.result, input.scopeProjection, input.observations,
-	);
-	const clean = input.result.failed.length === 0 && input.result.deferred.length === 0;
-	// Remote edges are session-local, so holding the cursor is their restart replay.
-	const checkpointSafe = clean && !unresolved.some((item) =>
-		item.kind === "rename" && item.side === "remote");
+	const succeeded = new Set(input.result.succeeded.map(({ action }) => action));
+	const releasable = input.admission.dispositions.flatMap((disposition) => {
+		if (disposition.kind === "deferred") return [];
+		if (disposition.kind === "authorized" &&
+			!disposition.actions.every((action) => succeeded.has(action))) return [];
+		return disposition.evidence;
+	});
+	const checkpointSafe = input.result.failed.length === 0 && input.result.blocked.length === 0 &&
+		input.admission.dispositions.every((disposition) =>
+			disposition.kind !== "deferred" &&
+			(disposition.kind !== "authorized" ||
+				disposition.actions.every((action) => succeeded.has(action))));
 	if (!checkpointSafe) return [...input.pendingEvidence];
 
 	await input.checkpoint?.commitCheckpoint({ scopeFingerprint: input.scopeFingerprint });
-	const resolvedDebts = resolvedRenameDebts(
+	const resolvedDebts = renameDebtsBoundToEvidence(
 		[...input.persistedDebts, ...input.localRenameDebts],
-		input.result,
-		input.scopeProjection,
-		input.observations,
+		releasable,
+		input.admission.snapshot.namespace,
 	);
 	await input.stateStore.deleteRenameDebts(resolvedDebts);
-	return unresolved;
+	return unreleasedIdentityEvidence(input.pendingEvidence, releasable);
 }

--- a/src/sync/sync-cycle-finalization.ts
+++ b/src/sync/sync-cycle-finalization.ts
@@ -7,7 +7,7 @@ import {
 import type { RenameDebt, SyncStateStore } from "./state";
 import type { IdentityEvidence, PathObservation, ScopeProjection } from "./types";
 
-export interface SyncCycleFinalizationInput {
+interface SyncCycleFinalizationInput {
 	result: ExecutionResult;
 	pendingEvidence: readonly IdentityEvidence[];
 	persistedDebts: readonly RenameDebt[];

--- a/src/sync/sync-cycle-finalization.ts
+++ b/src/sync/sync-cycle-finalization.ts
@@ -1,0 +1,45 @@
+import type { IFileSystem } from "../fs/interface";
+import type { ExecutionResult } from "./execution-result";
+import {
+	resolvedRenameDebts,
+	unresolvedRenameEvidence,
+} from "./rename-debt";
+import type { RenameDebt, SyncStateStore } from "./state";
+import type { IdentityEvidence, PathObservation, ScopeProjection } from "./types";
+
+export interface SyncCycleFinalizationInput {
+	result: ExecutionResult;
+	pendingEvidence: readonly IdentityEvidence[];
+	persistedDebts: readonly RenameDebt[];
+	localRenameDebts: readonly RenameDebt[];
+	scopeProjection: ScopeProjection;
+	observations: readonly PathObservation[];
+	checkpoint: IFileSystem["checkpoint"];
+	scopeFingerprint: string;
+	stateStore: SyncStateStore;
+}
+
+/**
+ * Owns the commit-last boundary: remote evidence may be forgotten and durable
+ * local debt retired only when the corresponding cursor is safe to advance.
+ */
+export async function finalizeSyncCycle(input: SyncCycleFinalizationInput): Promise<IdentityEvidence[]> {
+	const unresolved = unresolvedRenameEvidence(
+		input.pendingEvidence, input.result, input.scopeProjection, input.observations,
+	);
+	const clean = input.result.failed.length === 0 && input.result.deferred.length === 0;
+	// Remote edges are session-local, so holding the cursor is their restart replay.
+	const checkpointSafe = clean && !unresolved.some((item) =>
+		item.kind === "rename" && item.side === "remote");
+	if (!checkpointSafe) return [...input.pendingEvidence];
+
+	await input.checkpoint?.commitCheckpoint({ scopeFingerprint: input.scopeFingerprint });
+	const resolvedDebts = resolvedRenameDebts(
+		[...input.persistedDebts, ...input.localRenameDebts],
+		input.result,
+		input.scopeProjection,
+		input.observations,
+	);
+	await input.stateStore.deleteRenameDebts(resolvedDebts);
+	return unresolved;
+}

--- a/src/sync/sync-cycle-planning.ts
+++ b/src/sync/sync-cycle-planning.ts
@@ -1,0 +1,115 @@
+import type { Logger } from "../logging/logger";
+import type { ChangeSet } from "./change-detector";
+import { planSync } from "./decision-engine";
+import type { AdmissionResult } from "./plan-admission";
+import { admitDestructivePlan } from "./plan-admission";
+import {
+	applyRenameDebtScope,
+	collectLocalRenameDebts,
+	mergeRenameDebtEvidence,
+} from "./rename-debt";
+import { refinePlan } from "./rename-optimizer";
+import { projectScope, type ScopeProjectionPolicy } from "./scope-projection";
+import type { RenameDebt } from "./state";
+import type { ScopeProjection } from "./types";
+
+export interface SyncCyclePlanningResult {
+	admission: AdmissionResult;
+	localRenameDebts: RenameDebt[];
+	plannedCount: number;
+	scopeProjection: ScopeProjection;
+}
+
+export function logChangeDetection(
+	changeSet: ChangeSet,
+	renamePairs: ReadonlyMap<string, string>,
+	logger?: Logger,
+): void {
+	const remoteOnlyPaths = changeSet.entries.filter((entry) => !entry.local && entry.remote)
+		.map((entry) => entry.path);
+	logger?.info("Change detection completed", {
+		temperature: changeSet.temperature,
+		entries: changeSet.entries.length,
+		localOnly: changeSet.entries.filter((entry) => entry.local && !entry.remote).length,
+		remoteOnly: remoteOnlyPaths.length,
+		both: changeSet.entries.filter((entry) => entry.local && entry.remote).length,
+		enriched: changeSet.entries.filter((entry) => entry.local?.hash && !entry.prevSync).length,
+		renamePairs: renamePairs.size,
+	});
+	if (remoteOnlyPaths.length > 0) logger?.debug("Remote-only paths", { paths: remoteOnlyPaths });
+	if (renamePairs.size === 0) return;
+
+	const paths = new Set([...renamePairs.keys(), ...renamePairs.values()]);
+	logger?.debug("Rename entry details", {
+		entries: changeSet.entries.filter((entry) => paths.has(entry.path)).map((entry) => ({
+			path: entry.path,
+			local: !!entry.local,
+			remote: !!entry.remote,
+			prevSync: !!entry.prevSync,
+			hash: (entry.local?.hash || entry.prevSync?.hash || "").substring(0, 8) || undefined,
+		})),
+	});
+}
+
+/** Pure cycle planning plus structured diagnostics; no state or filesystem writes. */
+export function prepareSyncCyclePlan(
+	changeSet: ChangeSet,
+	persistedDebts: readonly RenameDebt[],
+	namespace: string,
+	policy: ScopeProjectionPolicy,
+	logger?: Logger,
+): SyncCyclePlanningResult {
+	const completeChangeSet: ChangeSet = {
+		...changeSet,
+		identityEvidence: mergeRenameDebtEvidence(changeSet.identityEvidence, persistedDebts),
+	};
+	const scopeProjection = applyRenameDebtScope(projectScope(completeChangeSet, policy), persistedDebts);
+	const filtered = completeChangeSet.entries.filter((entry) =>
+		scopeProjection.byEndpoint.get(entry.path) === "included");
+	if (filtered.length !== completeChangeSet.entries.length) {
+		logger?.debug("Files filtered", {
+			total: completeChangeSet.entries.length,
+			afterFilter: filtered.length,
+			excluded: completeChangeSet.entries.length - filtered.length,
+		});
+	}
+	const plan = refinePlan(
+		planSync(filtered),
+		completeChangeSet.identityEvidence,
+		logger,
+	);
+	const admission = admitDestructivePlan(plan, completeChangeSet.observations, scopeProjection);
+	const localRenameDebts = collectLocalRenameDebts(
+		namespace,
+		completeChangeSet.identityEvidence,
+		scopeProjection,
+	);
+	logPlan(logger, plan.actions.map((action) => action.action), admission, scopeProjection);
+	return { admission, localRenameDebts, plannedCount: plan.actions.length, scopeProjection };
+}
+
+function logPlan(
+	logger: Logger | undefined,
+	actionTypes: string[],
+	admission: AdmissionResult,
+	scopeProjection: ScopeProjection,
+): void {
+	const actionBreakdown: Record<string, number> = {};
+	for (const action of actionTypes) actionBreakdown[action] = (actionBreakdown[action] ?? 0) + 1;
+	logger?.info("Sync plan created", { total: actionTypes.length, ...actionBreakdown });
+	for (const component of admission.deferred) {
+		logger?.warn("Sync plan component deferred", {
+			reasons: component.reasons,
+			paths: component.paths,
+			evidence: component.evidence.map((item) => ({
+				kind: item.kind,
+				side: item.side,
+				authority: item.kind === "rename" ? item.authority : undefined,
+			})),
+			scope: component.paths.map((path) => ({
+				path,
+				disposition: scopeProjection.byEndpoint.get(path) ?? "unknown",
+			})),
+		});
+	}
+}

--- a/src/sync/sync-cycle-planning.ts
+++ b/src/sync/sync-cycle-planning.ts
@@ -78,7 +78,12 @@ export function prepareSyncCyclePlan(
 		completeChangeSet.identityEvidence,
 		logger,
 	);
-	const admission = admitDestructivePlan(plan, completeChangeSet.observations, scopeProjection);
+	const admission = admitDestructivePlan(
+		plan,
+		completeChangeSet.identityEvidence,
+		completeChangeSet.observations,
+		scopeProjection,
+	);
 	const localRenameDebts = collectLocalRenameDebts(
 		namespace,
 		completeChangeSet.identityEvidence,

--- a/src/sync/sync-cycle-planning.ts
+++ b/src/sync/sync-cycle-planning.ts
@@ -13,13 +13,6 @@ import { projectScope, type ScopeProjectionPolicy } from "./scope-projection";
 import type { RenameDebt } from "./state";
 import type { ScopeProjection } from "./types";
 
-export interface SyncCyclePlanningResult {
-	admission: AdmissionResult;
-	localRenameDebts: RenameDebt[];
-	plannedCount: number;
-	scopeProjection: ScopeProjection;
-}
-
 export function logChangeDetection(
 	changeSet: ChangeSet,
 	renamePairs: ReadonlyMap<string, string>,
@@ -58,7 +51,7 @@ export function prepareSyncCyclePlan(
 	namespace: string,
 	policy: ScopeProjectionPolicy,
 	logger?: Logger,
-): SyncCyclePlanningResult {
+) {
 	const completeChangeSet: ChangeSet = {
 		...changeSet,
 		identityEvidence: mergeRenameDebtEvidence(changeSet.identityEvidence, persistedDebts),
@@ -90,7 +83,7 @@ export function prepareSyncCyclePlan(
 		scopeProjection,
 	);
 	logPlan(logger, plan.actions.map((action) => action.action), admission, scopeProjection);
-	return { admission, localRenameDebts, plannedCount: plan.actions.length, scopeProjection };
+	return { admission, localRenameDebts, scopeProjection };
 }
 
 function logPlan(

--- a/src/sync/sync-cycle-planning.ts
+++ b/src/sync/sync-cycle-planning.ts
@@ -2,7 +2,7 @@ import type { Logger } from "../logging/logger";
 import type { ChangeSet } from "./change-detector";
 import { planSync } from "./decision-engine";
 import type { AdmissionResult } from "./plan-admission";
-import { admitDestructivePlan } from "./plan-admission";
+import { captureCycleAdmissionSnapshot } from "./plan-admission";
 import {
 	applyRenameDebtScope,
 	collectLocalRenameDebts,
@@ -11,7 +11,6 @@ import {
 import { refinePlan } from "./rename-optimizer";
 import { projectScope, type ScopeProjectionPolicy } from "./scope-projection";
 import type { RenameDebt } from "./state";
-import type { ScopeProjection } from "./types";
 
 export function logChangeDetection(
 	changeSet: ChangeSet,
@@ -45,7 +44,7 @@ export function logChangeDetection(
 }
 
 /** Pure cycle planning plus structured diagnostics; no state or filesystem writes. */
-export function prepareSyncCyclePlan(
+export function prepareSyncCycleSnapshot(
 	changeSet: ChangeSet,
 	persistedDebts: readonly RenameDebt[],
 	namespace: string,
@@ -71,30 +70,36 @@ export function prepareSyncCyclePlan(
 		completeChangeSet.identityEvidence,
 		logger,
 	);
-	const admission = admitDestructivePlan(
+	const snapshot = captureCycleAdmissionSnapshot(
 		plan,
 		completeChangeSet.identityEvidence,
 		completeChangeSet.observations,
 		scopeProjection,
+		namespace,
 	);
 	const localRenameDebts = collectLocalRenameDebts(
 		namespace,
 		completeChangeSet.identityEvidence,
 		scopeProjection,
 	);
-	logPlan(logger, plan.actions.map((action) => action.action), admission, scopeProjection);
-	return { admission, localRenameDebts, scopeProjection };
+	return {
+		snapshot,
+		localRenameDebts,
+	};
 }
 
-function logPlan(
+export function logSyncCyclePlan(
 	logger: Logger | undefined,
-	actionTypes: string[],
 	admission: AdmissionResult,
-	scopeProjection: ScopeProjection,
 ): void {
 	const actionBreakdown: Record<string, number> = {};
-	for (const action of actionTypes) actionBreakdown[action] = (actionBreakdown[action] ?? 0) + 1;
-	logger?.info("Sync plan created", { total: actionTypes.length, ...actionBreakdown });
+	for (const { action } of admission.snapshot.plan.actions) {
+		actionBreakdown[action] = (actionBreakdown[action] ?? 0) + 1;
+	}
+	logger?.info("Sync plan created", {
+		total: admission.snapshot.plan.actions.length,
+		...actionBreakdown,
+	});
 	for (const component of admission.deferred) {
 		logger?.warn("Sync plan component deferred", {
 			reasons: component.reasons,
@@ -106,7 +111,7 @@ function logPlan(
 			})),
 			scope: component.paths.map((path) => ({
 				path,
-				disposition: scopeProjection.byEndpoint.get(path) ?? "unknown",
+				disposition: admission.snapshot.scope.byEndpoint.get(path) ?? "unknown",
 			})),
 		});
 	}

--- a/src/sync/sync-notification.test.ts
+++ b/src/sync/sync-notification.test.ts
@@ -6,7 +6,8 @@ function result(deferred = 0): ExecutionResult {
 	return {
 		succeeded: [], failed: [], blocked: [], conflicts: [],
 		deferred: Array.from({ length: deferred }, (_, index) => ({
-			paths: [`path-${index}.md`], actions: [], evidence: [], reasons: ["rename_mismatch"],
+			kind: "deferred", paths: [`path-${index}.md`], actions: [], evidence: [],
+			reasons: ["rename_mismatch"],
 		})),
 	};
 }

--- a/src/sync/sync-notification.test.ts
+++ b/src/sync/sync-notification.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { buildNotificationMessage, CycleSummary } from "./sync-notification";
+import type { ExecutionResult } from "./execution-result";
+
+function result(deferred = 0): ExecutionResult {
+	return {
+		succeeded: [], failed: [], blocked: [], conflicts: [],
+		deferred: Array.from({ length: deferred }, (_, index) => ({
+			paths: [`path-${index}.md`], actions: [], evidence: [], reasons: ["rename_mismatch"],
+		})),
+	};
+}
+
+describe("sync notification deferred visibility", () => {
+	it("includes the number of deferred components", () => {
+		expect(buildNotificationMessage(result(2))).toBe("Sync: 2 deferred");
+	});
+
+	it("coalesces deferred components across cycles", () => {
+		const summary = new CycleSummary();
+		summary.add(result(1));
+		summary.add(result(2));
+
+		expect(summary.message).toBe("Sync: 3 deferred");
+	});
+});

--- a/src/sync/sync-notification.ts
+++ b/src/sync/sync-notification.ts
@@ -7,6 +7,7 @@ export interface SyncCycleResult {
 	failed: number;
 	blocked: number;
 	conflicts: number;
+	deferred: number;
 }
 
 /** Build the human-readable summary shown after a sync cycle completes. */
@@ -28,6 +29,7 @@ export function buildNotificationMessage(result: ExecutionResult): string {
 	if (result.conflicts.length > 0) parts.push(`${result.conflicts.length} conflicts`);
 	if (result.failed.length > 0) parts.push(`${result.failed.length} errors`);
 	if (result.blocked.length > 0) parts.push(`${result.blocked.length} blocked`);
+	if (result.deferred.length > 0) parts.push(`${result.deferred.length} deferred`);
 	return parts.length === 0 ? "Everything up to date" : `Sync: ${parts.join(", ")}`;
 }
 
@@ -39,7 +41,9 @@ export function buildNotificationMessage(result: ExecutionResult): string {
  * while collapsing repeated "Everything up to date" cycles into one message.
  */
 export class CycleSummary {
-	private readonly merged: ExecutionResult = { succeeded: [], failed: [], blocked: [], conflicts: [] };
+	private readonly merged: ExecutionResult = {
+		succeeded: [], failed: [], blocked: [], conflicts: [], deferred: [],
+	};
 
 	add(cycle: ExecutionResult): void {
 		// Append element-by-element, not `push(...arr)`: a cold full-scan cycle can
@@ -49,6 +53,7 @@ export class CycleSummary {
 		for (const f of cycle.failed) this.merged.failed.push(f);
 		for (const b of cycle.blocked) this.merged.blocked.push(b);
 		for (const c of cycle.conflicts) this.merged.conflicts.push(c);
+		for (const d of cycle.deferred) this.merged.deferred.push(d);
 	}
 
 	get message(): string {

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -32,6 +32,44 @@ export interface MixedEntity {
 	prevSync?: SyncRecord;
 }
 
+export type SyncSide = "local" | "remote";
+
+export type PathObservation =
+	| { kind: "exact"; side: SyncSide; requestedPath: string; entity: FileEntity }
+	| { kind: "alias"; side: SyncSide; requestedPath: string; resolvedPath: string; entity: FileEntity }
+	| {
+		kind: "present_unresolved";
+		side: SyncSide;
+		requestedPath: string;
+		returnedPath: string;
+		entity: FileEntity;
+		source: "list" | "stat";
+	}
+	| { kind: "absent"; side: SyncSide; requestedPath: string; authority: "stat" | "checkpoint_deleted" }
+	| { kind: "unknown"; side: SyncSide; requestedPath: string; reason: "not_observed" | "outside_tracked_root" };
+
+export interface EntityOccurrence {
+	side: SyncSide;
+	phase: "baseline" | "current";
+	path: string;
+	identityKey?: string;
+}
+
+export interface RenameEvidence {
+	kind: "rename";
+	side: SyncSide;
+	oldPath: string;
+	newPath: string;
+	isFolder: boolean;
+	authority: "reported";
+	identityKey?: string;
+}
+
+export type IdentityEvidence =
+	| RenameEvidence
+	| { kind: "alias"; side: SyncSide; requestedPath: string; resolvedPath: string }
+	| { kind: "stable_identity"; side: "remote"; identityKey: string; occurrences: EntityOccurrence[] };
+
 /** User-facing strategy for resolving conflicts */
 export type ConflictStrategy = "auto_merge" | "duplicate";
 

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -16,6 +16,8 @@ export interface SyncRecord {
 	remoteSize: number;
 	/** Remote-provided content checksum at last successful sync (for change detection) */
 	remoteChecksum?: RemoteChecksum;
+	/** Opaque remote identity observed at last sync; comparable only within one configured remote root */
+	remoteIdentityKey?: string;
 	/** Backend-specific metadata snapshot the sync engine does not interpret (e.g. Google Drive/pCloud file ID) */
 	backendMeta?: Record<string, unknown>;
 	/** Timestamp when this sync completed (Unix epoch ms) */

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -34,6 +34,12 @@ export interface MixedEntity {
 
 export type SyncSide = "local" | "remote";
 
+export type ScopeDisposition = "included" | "policy_out" | "mobile_deferred" | "unknown";
+
+export interface ScopeProjection {
+	byEndpoint: ReadonlyMap<string, ScopeDisposition>;
+}
+
 export type PathObservation =
 	| { kind: "exact"; side: SyncSide; requestedPath: string; entity: FileEntity }
 	| { kind: "alias"; side: SyncSide; requestedPath: string; resolvedPath: string; entity: FileEntity }

--- a/src/ui/app-folder-picker.ts
+++ b/src/ui/app-folder-picker.ts
@@ -50,8 +50,15 @@ export class AppFolderPickerModal extends Modal {
 		try {
 			const client = this.provider.createUiClient(this.settings);
 			folders = (await client.listAppRootFolders()).map((f) => f.name);
-		} catch {
-			contentEl.createEl("p", { text: "Could not list existing folders. You can still create a new one below." });
+		} catch (err) {
+			// Show WHY, not just that it failed: the backend's own message is what
+			// distinguishes "nothing there yet" from a service-side denial, and a bare
+			// "could not list" reads like the former even when it is the latter. The full
+			// response body is already in the log (see fs/backend-error-log.ts).
+			const reason = err instanceof Error ? err.message : String(err);
+			contentEl.createEl("p", {
+				text: `Could not list existing folders: ${reason}. You can still create a new one below.`,
+			});
 		}
 
 		if (folders.length > 0) {


### PR DESCRIPTION
## Summary

- prevent ambiguous rename/deletion evidence from authorizing destructive actions
- make Admission the single final permission boundary and require its nominal `AuthorizedSyncPlan` at execution
- retain actionless uncertainty, hold checkpoints, and recover through a later COLD cycle without a tight retry
- preserve authoritative HOT deletions, case-only rename evidence, and bijective backend identity mappings
- cover rename safety against Google Drive, Dropbox, and OneDrive with shared live E2E scenarios

## Design

Decision Engine and rename refinement remain proposal producers. A single immutable cycle snapshot carries the proposal, identity evidence, path observations, scope projection, and backend namespace into Admission. Admission emits an exhaustive component disposition (`authorized`, `resolved_no_action`, or `deferred`) and is the only constructor of the executable nominal plan.

Finalization no longer re-evaluates scope, identity, aliases, or action shapes. It mechanically folds Admission dispositions with execution completion, commits the remote checkpoint first, and only then retires released evidence and rename debt. Evidence acquired before a pre-Admission failure is retained for a later forced COLD cycle; it is not converted into a fabricated disposition or immediately retried.

The branch-wide minimality audit covered the complete diff from `bc83e3262b05d9a02b7f6c4b6259a9f3f99ef319`. It found no second destructive-authorization path. One redundant planning/logging carrier was removed so diagnostics consume the same Admission snapshot.

## Verification

- `npm run lint`
- `npm run lint:bot-repro`
- `npm run build`
- `npm test` — 95 files, 1,595 tests
- focused deletion/rename safety suite — 6 files, 169 tests
- `npm run test:e2e` — Google Drive, Dropbox, and OneDrive; 3 files, 151 tests
- dev-evidence scope and closure-readiness checks — PASS, no findings

Closes #43
Closes #44
Closes #45
Closes #46
