### PR TITLE
Repair rename evidence lifecycle for deferred sync

### DIFF
--- a/docs/adr/adr-20260831-admission-owned-local-rename-constraint-lifecycle.md
+++ b/docs/adr/adr-20260831-admission-owned-local-rename-constraint-lifecycle.md
@@ -1,0 +1,143 @@
+---
+id: adr-20260831-admission-owned-local-rename-constraint-lifecycle
+kind: adr
+title: Admission-owned local rename constraint lifecycle
+summary: Persist only Admission-classified local safety constraints and retire exact
+  membership only after its successful consequence and checkpoint.
+status: accepted
+created: '2026-08-31'
+decision_makers:
+- user
+tags:
+- sync
+- rename
+- safety
+owners: []
+relations:
+- {type: partOf, target: change-20260831-issue51-rename-evidence-lifecycle}
+- {type: references, target: adr-20260825-issue43-destructive-authorization}
+source_paths:
+- src/sync/plan-admission.ts
+- src/sync/rename-debt.ts
+- src/sync/sync-cycle-finalization.ts
+consequences:
+  positive:
+  - Admission becomes the single owner of executable and durable local rename safety
+    classification.
+  - False v6 debt can converge from fresh authoritative facts without a reset while
+    genuine or ambiguous debt remains fail closed.
+  - Persistence failure and successful retirement have explicit pre-I/O and post-checkpoint
+    boundaries.
+  negative:
+  - The immutable Admission snapshot and result must evolve together across acquisition,
+    orchestration, persistence, and finalization.
+  - Positive additive classification requires complete observations and therefore
+    may retain or defer folder or chain cases whose completeness cannot be proven.
+  neutral:
+  - RenameEvidence tuple and RenameDebt SyncState v6 wire shape remain unchanged.
+  - Remote rename authority, backend delta semantics, and the unproven blank-file
+    symptom are not changed.
+confirmation: Focused Admission, orchestrator, state, and finalization tests prove
+  the positive additive witness, fail-closed counterexamples, upsert-before-I/O abort,
+  current-scope authority, and consequence-bound post-checkpoint retirement.
+updated: '2026-08-31'
+---
+
+# Admission-owned local rename constraint lifecycle
+
+## Context
+
+ADR 0008 section 6 requires unresolved local reported rename edges to be persisted
+before plan I/O and tracker acknowledgement. That protects the only crash-replay source
+for a genuine synchronized rename. The 0.1.42 implementation interpreted the trigger as
+every in-scope tracker report, before Admission had established synchronized-resource or
+destructive relevance.
+
+For a never-synchronized local file renamed from `old` to `new`, the safe proposal can
+be only `push(new)`. Scope-only debt promotion nevertheless turns the report into a
+durable obligation to prove a native rename. Admission then emits `rename_mismatch`,
+Finalization retains the deferred debt, and restart replays it indefinitely. Existing
+v6 rows lack provenance that can distinguish this false debt from a genuine unresolved
+rename.
+
+Issue 43 separately establishes that Admission consumes one immutable cycle snapshot,
+is the exclusive owner of destructive executable authority, and Finalization cannot
+re-evaluate safety. Any correction must keep that owner and ADR 0008's fail-closed and
+commit-last guarantees.
+
+## Decision
+
+Amend only ADR 0008 section 6's local persistence trigger:
+
+- A raw local tracker report or replayed v6 row is a rename candidate, not an
+  already-authorized durable safety constraint.
+- Admission is the sole owner that promotes a candidate to a safety-binding local
+  constraint. Promotion uses an immutable proof projection containing edge identity,
+  authoritative endpoint observations, baseline membership, identity/conflict facts,
+  folder/chain completeness, current scope, proposal, origin, and namespace.
+- Current scope is freshly projected from current settings and is authoritative. Scope
+  dispositions stored in a v6 row are historical diagnostics and conservative hints;
+  they never fill or override current `unknown`.
+- A candidate is non-binding only when the entire connected component positively proves
+  an additive unbaselined interpretation: no baseline or remote identity, authoritative
+  old/intermediate absence, exact current local terminal presence, authoritative remote
+  terminal absence, complete coverage, known compatible scope, and terminal pushes only.
+  Missing, conflicting, destructive, synchronized, or incomplete evidence is
+  safety-binding or inconclusive and remains fail closed.
+- Admission emits exact `persistBeforeExecution` and
+  `releaseAfterSafeCheckpoint` memberships associated with component dispositions. A
+  successful safety-binding native rename belongs to both. A deferred edge is
+  persist-only. A fresh non-binding report is in neither. A loaded false v6 row is
+  release-only.
+- The orchestrator durably upserts all persistence membership before executor I/O or
+  tracker acknowledgement. One failed upsert aborts the cycle visibly before either
+  side effect and preserves loaded debt and pending evidence for retry.
+- Finalization mechanically retires an exact release member only when its associated
+  disposition is `resolved_no_action`, or is `authorized` with all actions successful,
+  and the checkpoint commits. Deferral, failed/blocked action, missing association, or
+  checkpoint failure retains it.
+- Structured diagnostics distinguish fresh, replayed, promoted, non-binding, retained,
+  released, and persistence-failed stages without content or credentials.
+
+The existing `RenameEvidence` tuple and SyncState v6 `RenameDebt` wire shape are reused.
+No schema migration, blanket deletion, general identity graph, or persistent lifecycle
+state machine is introduced.
+
+This ADR replaces only the phrase-level persistence trigger in ADR 0008
+section 6: “unresolved local reported edge” means “unresolved local constraint that
+Admission classified safety-binding.” All other ADR 0008 decisions remain accepted and
+unchanged. Issue 43's exclusive Admission authority remains unchanged and is extended to
+the durable rename lifecycle membership consumed by the orchestrator and Finalization.
+
+## Rejected alternatives
+
+- Persist whenever `prevSync` exists in planning. This keeps authority outside Admission
+  and misses remote identity, scope, and destructive relevance.
+- Delete every old row whose plan is push-only. Push spelling does not prove absence of
+  a synchronized resource when observations or scope are incomplete.
+- Add provenance fields in SyncState v7. New fields cannot truthfully reconstruct old
+  0.1.42 provenance, and this project's schema policy would cold-start all stores.
+- Remove durable rename debt and rely on tracker replay. Tracker acknowledgement or a
+  process restart can erase the only genuine rename edge before a safe checkpoint.
+- Add a general identity graph or persistent lifecycle state machine. The existing
+  bounded edge carrier plus cycle-local component graph is sufficient.
+
+## Consequences
+
+{% consequence kind="positive" %} Admission becomes the single owner of executable and durable local rename safety classification. {% /consequence %}
+
+{% consequence kind="positive" %} Existing false v6 debt can converge from fresh facts without a reset while ambiguous debt remains fail closed. {% /consequence %}
+
+{% consequence kind="negative" %} Snapshot and result contracts must evolve atomically across acquisition, orchestration, persistence, and finalization. {% /consequence %}
+
+{% consequence kind="negative" %} Folder and chain candidates remain retained when complete positive proof is unavailable. {% /consequence %}
+
+{% consequence kind="neutral" %} RenameEvidence, RenameDebt v6, remote rename authority, and backend delta semantics remain unchanged. {% /consequence %}
+
+{% consequence kind="neutral" %} This decision does not claim or implement a fix for the unproven blank-file symptom. {% /consequence %}
+
+## Confirmation
+
+Focused tests must prove the positive additive witness, current-scope authority over
+stale v6 hints, fail-closed counterexamples, upsert failure with zero executor/tracker
+side effects, and exact post-checkpoint retirement.

--- a/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/change.md
+++ b/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/change.md
@@ -1,0 +1,123 @@
+---
+id: change-20260831-issue51-rename-evidence-lifecycle
+kind: change
+title: Repair rename evidence ownership and lifecycle
+summary: Move local rename durability decisions into Admission and safely converge
+  existing false v6 debt without weakening fail-closed sync.
+status: active
+created: '2026-08-31'
+profile: sdd@1
+intent: Restore convergence for never-synchronized local renames by moving durable
+  rename-constraint promotion into Admission without weakening fail-closed destructive
+  authorization.
+outcomes:
+- Fresh unbaselined local renames can execute their terminal additive push without
+  permanent rename_mismatch deferral or new debt.
+- Existing false SyncState v6 debt converges without manual reset and is retired only
+  after successful admitted progress and a clean checkpoint.
+- Genuine or ambiguous synchronized-resource renames retain pre-I/O crash evidence
+  and fail closed.
+scope:
+- src/sync/change-detector.ts — local rename candidate acquisition.
+- src/sync/path-observation.ts — authoritative opposite-side endpoint confirmation.
+- src/sync/identity-evidence.ts — immutable Admission proof projection.
+- src/sync/types.ts — local rename candidate type contract.
+- src/sync/sync-cycle-planning.ts — cycle snapshot and lifecycle membership wiring.
+- src/sync/cycle-admission-snapshot.ts — immutable Admission input capture.
+- src/sync/plan-admission.ts — Admission-owned classification and lifecycle output.
+- src/sync/plan-admission-graph.ts — fail-closed component evaluation.
+- src/sync/local-rename-admission.ts — pure additive proof and lifecycle partition.
+- src/sync/rename-debt.ts — unchanged v6 persistence carrier.
+- src/sync/state.ts — v6 debt storage contract.
+- src/sync/orchestrator.ts — pre-I/O persistence ordering.
+- src/sync/sync-cycle-finalization.ts — mechanical consequence-bound retirement.
+- src/sync/orchestrator.test.ts — lifecycle ordering and false-debt convergence regressions.
+- src/sync/plan-admission.test.ts — additive whitelist and fail-closed counterexamples.
+- src/sync/rename-debt.test.ts — mechanical persistence-carrier contract tests.
+- docs/code-enforcement.md — documented orchestrator cap matching the cohesive pre-I/O cut point.
+- eslint.config.mts — ratcheted orchestrator line cap for the visible pre-I/O cut point.
+- docs/adr/adr-20260831-admission-owned-local-rename-constraint-lifecycle.md — accepted responsibility decision.
+non_goals:
+- Proving or fixing the Issue 51 blank-file symptom without second-device runtime
+  evidence.
+- Rolling back or redesigning unrelated files from ff87f7d.
+- Adding a general identity graph, persistent lifecycle state machine, schema migration,
+  or manual reset.
+change_classes:
+- behavior
+- responsibility
+- boundary
+- invariant
+- internal_design
+governance:
+  gate: auto
+  reasons: []
+members:
+- role: requirements
+  path: changes/change-20260831-issue51-rename-evidence-lifecycle/requirements.md
+  required: true
+- role: implementation
+  path: changes/change-20260831-issue51-rename-evidence-lifecycle/implementation.md
+  required: true
+- role: verification
+  path: changes/change-20260831-issue51-rename-evidence-lifecycle/verification.md
+  required: true
+promotion:
+- target: none
+  section: none
+  action: none
+  item: {}
+  reason: The stable cross-component decision is owned by the accepted ADR; no separate
+    top-level design document is introduced.
+unresolved_decisions: []
+tags:
+- sync
+- rename
+- safety
+owners: []
+relations:
+- {type: references, target: adr-20260825-issue43-destructive-authorization}
+- {type: introduces, target: adr-20260831-admission-owned-local-rename-constraint-lifecycle}
+source_paths:
+- src/sync/change-detector.ts
+- src/sync/path-observation.ts
+- src/sync/identity-evidence.ts
+- src/sync/types.ts
+- src/sync/sync-cycle-planning.ts
+- src/sync/cycle-admission-snapshot.ts
+- src/sync/plan-admission.ts
+- src/sync/plan-admission-graph.ts
+- src/sync/local-rename-admission.ts
+- src/sync/rename-debt.ts
+- src/sync/state.ts
+- src/sync/orchestrator.ts
+- src/sync/sync-cycle-finalization.ts
+- src/sync/orchestrator.test.ts
+- src/sync/plan-admission.test.ts
+- src/sync/rename-debt.test.ts
+- eslint.config.mts
+- docs/code-enforcement.md
+updated: '2026-08-31'
+---
+
+## Summary
+
+Issue #51 exposed a responsibility split introduced in 0.1.42: planning converts every
+local rename report into durable debt before Admission has established that the edge
+can affect a synchronized resource. Admission then correctly rejects the push-only plan
+as a rename mismatch, and commit-last Finalization correctly retains the deferred debt,
+creating a permanent loop.
+
+This change makes Admission the sole promotion owner. Collection supplies one fixed
+immutable proof projection; the orchestrator persists exactly Admission's retained
+membership before I/O; Finalization retires exact release membership only after its
+corresponding consequence and checkpoint succeed. Existing v6 rows are replayed as
+candidates and re-evaluated from fresh authoritative facts. The stored wire shape and
+schema remain unchanged.
+
+## Closure Notes
+
+Implementation now follows the accepted Admission-owned lifecycle boundary. Focused
+red/green and mutation witnesses distinguish the false additive case from remote
+occupancy, baseline, unknown-scope, folder, and destructive counterexamples. The full
+repository gate passes; the separate blank-file symptom remains outside this change.

--- a/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/design-plan/design.md
+++ b/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/design-plan/design.md
@@ -1,0 +1,164 @@
+# Issue #51 — Admission-owned local rename constraint lifecycle
+
+<!-- anchor: goal -->
+## Goal and scope
+
+Restore convergence when a never-synchronized local file is renamed, while preserving fail-closed handling for any rename that might affect a synchronized resource. The structural correction is to make Admission the sole owner of promotion from a transient local rename report to a durable safety constraint. Collection owns facts, the orchestrator owns ordering, persistence owns crash carriage, and Finalization owns only mechanical commit-last retirement.
+
+In scope are the local rename fact channel, the immutable proof projection shared with Admission, Admission lifecycle output, pre-I/O persistence, safe-checkpoint retirement, compatibility with existing SyncState v6 debts, structured lifecycle diagnostics, and discriminating tests. Out of scope are the unproven blank-file symptom, rollback of unrelated `ff87f7d` work, remote rename authority, a general identity graph, a persistent lifecycle state machine, and any IndexedDB schema migration or manual reset.
+
+<!-- anchor: approach -->
+## Root cause and selected boundary
+
+The defect is not a missing retry or a single rename matcher condition. `collectLocalRenameDebts` currently decides before Admission that every projected local rename is durable debt. That scope-only decision collapses four meanings into one `RenameEvidence`: tracker event, optimizer hint, destructive safety constraint, and cross-cycle obligation. An unbaselined `old -> new` report whose only safe proposal is `push(new)` is therefore treated as a requirement to prove a native rename, deferred as `rename_mismatch`, replayed forever, and never reaches Finalization's valid release boundary.
+
+The selected design keeps the existing `RenameEvidence` path tuple and v6 `RenameDebt` wire shape, but separates their semantic channels:
+
+1. Fresh tracker reports and replayed v6 rows enter the cycle as local rename candidates. Replay means “must be reconsidered after restart”, not “already proven to bind a synchronized resource”.
+2. Acquisition constructs one immutable candidate proof projection. The shared shape is fixed: edge identity, authoritative endpoint observations, baseline membership, identity/alias/conflict facts, folder and chain completeness, current-cycle scope, proposal membership, origin, and namespace. Admission does not consume mutable `MixedEntity` internals as an alternative wire contract.
+3. Current scope is reprojected from current settings in the cycle and is authoritative. The old/new scope dispositions stored in a v6 debt are historical diagnostics and conservative hints only; they never upgrade current `unknown` to included or otherwise authorize release.
+4. Admission classifies each connected candidate component. A candidate is non-binding only when the whole component positively proves an additive, unbaselined interpretation. Every missing, unknown, conflicting, destructive, synchronized, scope-transition, folder-incomplete, or mixed case is safety-binding and continues through the existing exact postcondition checks.
+5. Admission emits explicit lifecycle membership with two meanings: `persistBeforeExecution` and `releaseAfterSafeCheckpoint`. A safety-binding native rename belongs to both: it must survive before I/O, and it becomes eligible for exact-edge retirement only after its admitted consequence succeeds and the clean checkpoint commits. Deferred, failed, blocked, or checkpoint-failed membership remains retained. A proven additive fresh report is in neither persistence membership; a matching loaded v6 false debt is only in post-checkpoint release membership.
+6. The orchestrator mechanically upserts every `persistBeforeExecution` edge before executor I/O and tracker acknowledgement. If any upsert fails, the cycle ends visibly before either begins; loaded debt and pending in-memory evidence remain available for retry.
+7. Finalization does not inspect evidence or infer release from action names. It applies the Admission-provided exact membership only when the corresponding disposition is `authorized` with all actions successful, or `resolved_no_action`, and the checkpoint commits. Every other result retains the debt.
+
+This boundary avoids a second normative rename DTO, a migration, and a general graph/state-machine rewrite. The new ADR explicitly amends only the persistence trigger in ADR 0008 section 6: pre-I/O durability applies to an unresolved local constraint classified safety-relevant by Admission, not every raw local reported edge. ADR 0008's other fail-closed and commit-last decisions, and Issue 43's exclusive Admission authority, remain intact.
+
+<!-- anchor: fr-rename-001 -->
+## Requirements
+
+### FR-RENAME-001 — Admission owns promotion and lifecycle membership
+
+When a cycle contains a fresh or replayed local rename candidate, only Admission shall classify it as non-binding or safety-binding and emit the exact pre-I/O persistence and post-checkpoint release memberships consumed downstream.
+
+<!-- anchor: fr-rename-002 -->
+### FR-RENAME-002 — proven additive progress
+
+When a connected local rename component is positively proven to have no synchronized anchor or destructive consequence and proposes only additive pushes to current terminal paths, Admission shall authorize those pushes without `rename_mismatch`; a fresh report shall create no debt.
+
+<!-- anchor: fr-rename-003 -->
+### FR-RENAME-003 — genuine and ambiguous cases fail closed
+
+When a component has baseline membership, remote identity, a destructive or native consequence, current scope transition, unknown/conflicting observation, incomplete folder mapping, or mixed evidence, Admission shall retain it as safety-binding and use the existing exact authorization rules; unproved consequences defer with zero destructive I/O.
+
+<!-- anchor: fr-compat-001 -->
+### FR-COMPAT-001 — existing v6 false debt converges safely
+
+When a v6 debt is replayed, current authoritative facts shall reclassify it through the same Admission rule. A proven non-binding row may be retired only after successful admitted progress and a clean checkpoint; an ambiguous or genuine row remains stored. No schema migration or manual reset is permitted.
+
+<!-- anchor: fr-persist-001 -->
+### FR-PERSIST-001 — persistence is a pre-I/O prerequisite
+
+Every Admission-retained local constraint shall be durably upserted before executor I/O or tracker acknowledgement. If any upsert fails, neither operation shall start and the cycle shall return a visible failure while preserving retry evidence.
+
+<!-- anchor: fr-finalize-001 -->
+### FR-FINALIZE-001 — retirement is consequence-bound and commit-last
+
+Finalization shall retire an exact edge only when Admission marked it release-eligible, its corresponding admitted consequence completed successfully or resolved with no action, and the checkpoint committed. Deferral, failure, blocking, or checkpoint failure retains it.
+
+<!-- anchor: nfr-safety-001 -->
+### NFR-SAFETY-001 — authority and proof continuity
+
+Only Admission may issue executable authority; listing absence alone shall never prove endpoint absence; current-cycle scope shall be authoritative; stale v6 scope dispositions shall not fill current unknowns; incomplete or conflicting proof shall default to safety-binding retention.
+
+<!-- anchor: nfr-observe-001 -->
+### NFR-OBSERVE-001 — lifecycle diagnostics without sensitive data
+
+Structured diagnostics shall distinguish fresh report, replayed candidate, non-binding classification, safety-binding promotion, retained debt, released debt, and persistence failure, recording edge/path and reason metadata but never content or credentials.
+
+<!-- anchor: nfr-scope-001 -->
+### NFR-SCOPE-001 — bounded structural correction
+
+The change shall reuse the `RenameEvidence` tuple, add only a semantic candidate channel and Admission lifecycle output, keep SyncState v6, and shall not introduce a general identity graph, persistent state machine, blanket debt deletion, or unsupported blank-file claim.
+
+<!-- anchor: component-cycle-acquisition -->
+## Components and contracts
+
+### component-cycle-acquisition — immutable candidate proof producer
+
+Grounded in `src/sync/change-detector.ts`, `src/sync/identity-evidence.ts`, and `src/sync/sync-cycle-planning.ts`. It merges fresh and replayed candidates, explicitly observes required endpoints, and captures the fixed candidate proof projection. It owns facts but cannot classify relevance, persistence, or release.
+
+<!-- anchor: contract-candidate-proof -->
+### contract-candidate-proof — shared proof shape and authority
+
+The immutable projection contains edge identity, origin, namespace, authoritative local and remote endpoint observations, baseline membership for endpoints and covered descendants, identity/alias/conflict facts, folder/chain completeness, proposal membership, and current scope. Absence requires authoritative stat/delta evidence. Stored v6 scope dispositions are labeled historical and may preserve conservative context but cannot replace, strengthen, or authorize from current scope. If current scope or a required fact is unavailable, the projection stays unknown/inconclusive.
+
+Normal witness: an explicitly observed unbaselined `draft.md -> final.md` candidate has old endpoints absent, terminal local exact, terminal remote absent, no baseline/identity, complete file mapping, current included scope, and only `push(final.md)`. Adversarial witness: the v6 row says included but current projection is unknown; Admission must not use the old value to classify non-binding.
+
+<!-- anchor: component-plan-admission -->
+### component-plan-admission — executable and rename lifecycle authority
+
+Grounded in `src/sync/plan-admission.ts` and `src/sync/plan-admission-graph.ts`. It owns the positive additive proof, fail-closed promotion, `AuthorizedSyncPlan`, and exact persist/release membership. No helper before or after Admission may infer lifecycle membership from raw reports, scope alone, or action spelling.
+
+<!-- anchor: contract-admission-lifecycle -->
+### contract-admission-lifecycle — total candidate and lifecycle partition
+
+Admission applies a positive whitelist to an evidence-connected component. `additive_unbaselined` requires: local origin; current scope known and included without a structural transition; no baseline, remote identity, alias, conflict, or unresolved presence anywhere in the covered component; authoritative absence at old/intermediate endpoints on both sides; exact local presence and remote absence only at terminal destinations; complete file/folder/chain coverage; and actions limited to unbaselined terminal pushes. It contributes no destructive rename edge.
+
+All other components are `safety_binding` or `inconclusive`, enter the existing destructive graph, and retain the existing exact native/scope/no-action authorization rules. Inconclusive is fail-closed. The lifecycle output is fixed as exact edge memberships for `persistBeforeExecution` and `releaseAfterSafeCheckpoint`, associated with the component disposition that can satisfy release. A successful safety-binding native rename is in both memberships; a deferred edge is persist-only; a fresh additive report is in neither; a loaded additive v6 candidate is release-only.
+
+<!-- anchor: component-rename-debt-carrier -->
+### component-rename-debt-carrier — unchanged v6 crash carrier
+
+Grounded in `src/sync/rename-debt.ts`, `src/sync/state.ts`, and `src/sync/orchestrator.ts`. It serializes explicit Admission persistence membership to the unchanged v6 row/key, replays rows as candidates, and performs exact-key upsert/delete. It owns no relevance rule.
+
+<!-- anchor: contract-v6-persistence -->
+### contract-v6-persistence — compatibility and persistence failure boundary
+
+The current `RenameDebt` shape and namespace key remain unchanged. Loaded rows are candidate inputs, not self-authenticating obligations. Every retained membership is upserted after Admission and before plan I/O or tracker acknowledgement. One failed upsert aborts the cycle before both side effects; no best-effort continuation or eviction is allowed. Existing loaded rows remain stored during execution even when classified non-binding. Rollback to old code sees an unchanged v6 shape; rollout requires no migration or store clear.
+
+Diagnostics emit lifecycle stage and reason for raw/replayed/promoted/non-binding/retained/released/persist-failed outcomes without file content or credentials.
+
+<!-- anchor: component-cycle-finalization -->
+### component-cycle-finalization — mechanical commit-last consumer
+
+Grounded in `src/sync/sync-cycle-finalization.ts` and `src/sync/orchestrator.ts`. It consumes the same snapshot's dispositions, action completion, checkpoint result, and exact release membership. It performs no stat, scope, baseline, graph, or relevance evaluation.
+
+<!-- anchor: contract-commit-last-retirement -->
+### contract-commit-last-retirement — exact consequence-bound release
+
+For each release-eligible edge, Finalization requires its associated disposition to be `resolved_no_action`, or `authorized` with every action succeeded, and then requires the clean checkpoint commit. Only then may it delete the exact loaded/retained record and retire matching pending evidence. Any deferred disposition, failed/blocked action, missing membership association, or checkpoint failure retains all corresponding debt. Deletion is idempotent and happens after checkpoint commit.
+
+<!-- anchor: component-design-verification -->
+### component-design-verification — provenance and regression guard
+
+Grounded in focused sync tests, `ARCHITECTURE.md`, `docs/sync-pipeline.md`, accepted ADR 0008, the Issue 43 ADR, and the accepted Issue 51 ADR. It prevents regression to scope-only persistence and keeps the blank-file symptom outside this success claim.
+
+<!-- anchor: adr-0008-logical-identity-admission-fails-closed -->
+<!-- anchor: adr-20260825-issue43-destructive-authorization -->
+<!-- anchor: adr-20260831-admission-owned-local-rename-constraint-lifecycle -->
+## ADR disposition
+
+The accepted ADR `adr-20260831-admission-owned-local-rename-constraint-lifecycle` amends the persistence trigger in ADR 0008 section 6 from every unresolved raw local report to every unresolved local constraint that Admission classified safety-binding. It preserves all other ADR 0008 decisions and preserves Issue 43's rule that Admission alone owns executable safety classification.
+
+## Critique closure
+
+- `issue-persistence-failure-not-closed`: upsert failure is a typed pre-I/O abort; executor I/O and tracker acknowledgement remain zero and retry evidence is preserved.
+- `issue-retained-success-release-membership-ambiguous`: persist and post-checkpoint release memberships are separate and tied to exact disposition success.
+- `issue-legacy-scope-authority-ambiguous`: only fresh current-cycle scope is authoritative; v6 dispositions are historical conservative hints.
+- `issue-snapshot-carrier-delegates-shared-proof-shape`: the cross-component proof projection is fixed by contract and removed from private discretion.
+- `issue-adr-0008-amendment-not-governed`: the accepted ADR explicitly amends only ADR 0008 section 6's persistence trigger and preserves Issue 43 authority.
+
+## Dependency-ordered implementation units
+
+1. `unit-candidate-proof`: carry fresh and replayed candidates through the fixed immutable proof projection and test stat/current-scope authority.
+2. `unit-admission-lifecycle`: add the pure positive additive classifier plus explicit persist/release memberships and component tests.
+3. `unit-persistence-integration`: replace scope-only debt creation, enforce upsert-before-I/O abort semantics, wire v6 replay, and test fresh/legacy compatibility end to end.
+4. `unit-finalization`: consume consequence-bound release membership after clean checkpoint and test all failure paths.
+5. `unit-design-verification`: record the ADR/boundary and run focused plus full gates.
+
+## Acceptance and verification
+
+- Fresh unbaselined rename: exactly the terminal push is executable, `rename_mismatch` is absent, and no fresh debt is written.
+- Existing false v6 debt: the same push converges without reset; the row remains through execution and is deleted only after checkpoint.
+- Synchronized native rename: the edge is persisted before I/O, exact rename succeeds, and the row is released after checkpoint.
+- Ambiguous/destructive/folder-incomplete case: whole component defers, destructive I/O is zero, and debt remains.
+- Upsert failure: executor I/O and tracker acknowledgement are zero; the cycle fails visibly and retries the same candidate.
+- Execution failure, blocked action, and checkpoint failure: all associated debt remains.
+- Old v6 included scope plus current unknown: no additive release is authorized.
+- Diagnostics distinguish raw, replayed, promoted, non-binding, retained, released, and persist-failed lifecycle stages without sensitive payloads.
+- `npm run lint && npm run lint:bot-repro && npm run build && npm test` is green; docs lint is green; no blank-file fix is claimed.
+
+## Open questions
+
+None for this bounded design. The separate blank-file causality question remains outside this change and requires second-device runtime evidence before any claim or implementation.

--- a/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/design-plan/spine.yaml
+++ b/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/design-plan/spine.yaml
@@ -1,0 +1,292 @@
+artifact: design-plan-spine
+version: 2
+granularity_profile: boundary-complete
+
+scope_expansion_signals:
+  - id: scope-signal-admission-lifecycle-authority
+    kind: shared_boundary
+    target_ref: component-plan-admission
+    witness: AdmissionResult gains exact pre-I/O persistence and post-checkpoint release membership, replacing planning-owned scope-only debt promotion.
+    requirement_refs: [FR-RENAME-001, FR-PERSIST-001, FR-FINALIZE-001]
+    authority_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260825-issue43-destructive-authorization]
+  - id: scope-signal-v6-reclassification-operation
+    kind: compatibility_operation
+    target_ref: contract-v6-persistence
+    witness: Existing v6 debt is re-evaluated from current authoritative facts and may be selectively retired only after its admitted consequence and checkpoint succeed.
+    requirement_refs: [FR-COMPAT-001, FR-FINALIZE-001]
+    authority_refs: [adr-0008-logical-identity-admission-fails-closed]
+  - id: scope-signal-fixed-candidate-proof
+    kind: critic_induced_contract
+    target_ref: contract-candidate-proof
+    witness: Critique removed the cross-component snapshot carrier from private discretion and fixed the complete immutable proof projection and current-scope authority.
+    requirement_refs: [FR-RENAME-001, FR-RENAME-003, NFR-SAFETY-001]
+    authority_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260825-issue43-destructive-authorization]
+
+requirements:
+  - id: FR-RENAME-001
+    type: event_driven
+    priority: must
+    statement: Only Admission shall classify fresh or replayed local rename candidates and emit exact pre-I/O persistence and post-checkpoint release membership.
+  - id: FR-RENAME-002
+    type: event_driven
+    priority: must
+    statement: A positively proven additive unbaselined local rename component shall authorize terminal pushes without rename_mismatch and a fresh report shall create no debt.
+  - id: FR-RENAME-003
+    type: state_driven
+    priority: must
+    statement: Synchronized, destructive, scope-transitioning, unknown, conflicting, or incomplete rename components shall remain safety binding and fail closed unless their exact consequence is proven.
+  - id: FR-COMPAT-001
+    type: event_driven
+    priority: must
+    statement: Existing false SyncState v6 debt shall be reclassified from current authoritative facts and retired only after successful admitted progress and a safe checkpoint without reset or migration.
+  - id: FR-PERSIST-001
+    type: unwanted
+    priority: must
+    statement: If any retained rename constraint cannot be upserted, the cycle shall fail visibly before executor I/O or tracker acknowledgement and shall preserve retry evidence.
+  - id: FR-FINALIZE-001
+    type: state_driven
+    priority: must
+    statement: Finalization shall retire exact release membership only after its corresponding disposition succeeds or resolves with no action and the clean checkpoint commits.
+  - id: NFR-SAFETY-001
+    type: ubiquitous
+    priority: must
+    statement: Admission-only executable authority, stat-backed absence, fresh current-scope authority, and fail-closed handling of incomplete facts shall remain intact.
+  - id: NFR-OBSERVE-001
+    type: ubiquitous
+    priority: must
+    statement: Structured non-sensitive diagnostics shall distinguish report, replay, promotion, non-binding, retention, release, and persistence-failure lifecycle stages.
+  - id: NFR-SCOPE-001
+    type: ubiquitous
+    priority: must
+    statement: The correction shall reuse the RenameEvidence tuple and SyncState v6 and shall not add a general identity graph, persistent state machine, blanket deletion, or blank-file claim.
+
+components:
+  - id: component-cycle-acquisition
+    kind: existing
+    contract_refs: [contract-candidate-proof]
+    paths: [src/sync/change-detector.ts, src/sync/identity-evidence.ts, src/sync/sync-cycle-planning.ts]
+  - id: component-plan-admission
+    kind: existing
+    contract_refs: [contract-admission-lifecycle]
+    paths: [src/sync/plan-admission.ts, src/sync/plan-admission-graph.ts]
+  - id: component-rename-debt-carrier
+    kind: existing
+    contract_refs: [contract-v6-persistence]
+    paths: [src/sync/rename-debt.ts, src/sync/state.ts, src/sync/orchestrator.ts]
+  - id: component-cycle-finalization
+    kind: existing
+    contract_refs: [contract-commit-last-retirement]
+    paths: [src/sync/sync-cycle-finalization.ts, src/sync/orchestrator.ts]
+  - id: component-design-verification
+    kind: existing
+    contract_refs: [contract-candidate-proof, contract-admission-lifecycle, contract-v6-persistence, contract-commit-last-retirement]
+    paths: [src/sync/plan-admission.test.ts, src/sync/rename-debt.test.ts, src/sync/sync-cycle-finalization.test.ts, src/sync/orchestrator.test.ts, ARCHITECTURE.md, docs/sync-pipeline.md, docs/adr]
+
+contracts:
+  - id: contract-candidate-proof
+    dimension: integration_contract
+    owner: component-cycle-acquisition
+    requirement_refs: [FR-RENAME-001, FR-RENAME-003, FR-COMPAT-001, NFR-SAFETY-001]
+    unit_refs: [unit-candidate-proof]
+    adr_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260825-issue43-destructive-authorization, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    verification:
+      - id: verify-candidate-proof
+        tier: T1
+        command: npm test -- --run src/sync/change-detector.test.ts src/sync/sync-cycle-planning.test.ts
+    partition:
+      outcomes: [determinate, unknown, inconclusive, conflicting]
+      default_policy: The fixed immutable projection carries edge, authoritative observations, baseline, identity/conflict, completeness, current scope, proposal, origin, and namespace; missing facts remain explicit and old v6 scope cannot fill current unknown.
+
+  - id: contract-admission-lifecycle
+    dimension: security_boundary
+    owner: component-plan-admission
+    requirement_refs: [FR-RENAME-001, FR-RENAME-002, FR-RENAME-003, NFR-SAFETY-001]
+    unit_refs: [unit-admission-lifecycle]
+    adr_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260825-issue43-destructive-authorization, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    verification:
+      - id: verify-fresh-unbaselined
+        tier: T1
+        command: npm test -- --run src/sync/plan-admission.test.ts src/sync/orchestrator.test.ts
+      - id: verify-ambiguous-retention
+        tier: T1
+        command: npm test -- --run src/sync/plan-admission.test.ts
+      - id: verify-lifecycle-membership
+        tier: T1
+        command: npm test -- --run src/sync/plan-admission.test.ts src/sync/sync-cycle-finalization.test.ts
+    partition:
+      outcomes: [determinate, unknown, inconclusive, conflicting]
+      default_policy: Only the complete positive additive-unbaselined witness is non-binding; every other candidate is safety binding or inconclusive and retained fail closed.
+
+  - id: contract-v6-persistence
+    dimension: migration_compatibility
+    owner: component-rename-debt-carrier
+    requirement_refs: [FR-COMPAT-001, FR-PERSIST-001, NFR-OBSERVE-001, NFR-SCOPE-001]
+    unit_refs: [unit-persistence-integration]
+    adr_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    verification:
+      - id: verify-replayed-false-v6
+        tier: T1
+        command: npm test -- --run src/sync/orchestrator.test.ts src/sync/state.test.ts
+      - id: verify-persistence-abort
+        tier: T1
+        command: npm test -- --run src/sync/orchestrator.test.ts src/sync/rename-debt.test.ts
+      - id: verify-lifecycle-diagnostics
+        tier: T1
+        command: npm test -- --run src/sync/orchestrator.test.ts
+    partition:
+      outcomes: [determinate, unknown, inconclusive, conflicting]
+      default_policy: The unchanged v6 row is a replay candidate; retained membership must upsert before I/O and any upsert failure aborts before executor or tracker acknowledgement.
+
+  - id: contract-commit-last-retirement
+    dimension: state_lifecycle
+    owner: component-cycle-finalization
+    requirement_refs: [FR-COMPAT-001, FR-FINALIZE-001, NFR-SAFETY-001]
+    unit_refs: [unit-finalization, unit-persistence-integration]
+    adr_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260825-issue43-destructive-authorization, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    verification:
+      - id: verify-finalization-faults
+        tier: T1
+        command: npm test -- --run src/sync/sync-cycle-finalization.test.ts src/sync/orchestrator.test.ts
+      - id: verify-repository-gate
+        tier: T2
+        command: npm run lint && npm run lint:bot-repro && npm run build && npm test
+    partition:
+      outcomes: [determinate, unknown, inconclusive, conflicting]
+      default_policy: Release requires exact Admission membership, successful corresponding disposition, and committed checkpoint; deferred, failed, blocked, unassociated, or checkpoint-failed edges remain retained.
+
+adrs:
+  - id: adr-20260831-admission-owned-local-rename-constraint-lifecycle
+    status: accepted
+    decision_input_refs: [decision-input-admission-owner, decision-input-v6-shape, decision-input-false-runtime, decision-input-fail-closed, decision-input-finalization, decision-input-blank-unknown, decision-input-scope-bounded]
+  - id: adr-0008-logical-identity-admission-fails-closed
+    status: accepted
+    decision_input_refs: [decision-input-admission-owner, decision-input-fail-closed, decision-input-finalization]
+  - id: adr-20260825-issue43-destructive-authorization
+    status: accepted
+    decision_input_refs: [decision-input-admission-owner, decision-input-finalization]
+
+units:
+  - title: unit-candidate-proof
+    chunk: acquisition
+    contract_refs: [contract-candidate-proof]
+    files: [src/sync/change-detector.ts, src/sync/identity-evidence.ts, src/sync/sync-cycle-planning.ts, src/sync/change-detector.test.ts, src/sync/sync-cycle-planning.test.ts]
+    acceptance:
+      - Fresh and replayed candidates share the fixed immutable proof projection.
+      - Current scope is freshly projected and old v6 dispositions cannot fill unknown.
+      - Listing absence alone cannot establish additive safety.
+    objective: Supply Admission with complete immutable candidate facts without persistence policy.
+    output_format: TypeScript carrier/acquisition changes and focused Vitest coverage.
+    tool_guidance: Reuse RenameEvidence and existing observations; add only the semantic candidate channel.
+    task_boundaries: Do not classify relevance, authorize actions, persist debt, or add a general graph.
+    decision_closure_reason: Shared proof shape and authority are fixed with no cross-component carrier discretion.
+
+  - title: unit-admission-lifecycle
+    chunk: admission
+    contract_refs: [contract-admission-lifecycle]
+    files: [src/sync/plan-admission.ts, src/sync/plan-admission-graph.ts, src/sync/plan-admission.test.ts]
+    depends_on: [unit-candidate-proof]
+    acceptance:
+      - Proven additive components authorize only terminal pushes and produce no fresh persistence membership.
+      - Safety-binding successful rename produces both persist and release membership.
+      - Deferred or inconclusive components produce persist-only membership and no destructive I/O.
+    objective: Consolidate executable and durable local rename lifecycle authority in Admission.
+    output_format: TypeScript Admission result/policy changes and discriminating component tests.
+    tool_guidance: Extend the existing component evaluation; do not add a persisted graph or state machine.
+    task_boundaries: Do not perform persistence, checkpointing, filesystem I/O, or optimizer rewrites.
+    decision_closure_reason: Positive proof, fail-closed default, and both exact memberships are fully specified.
+
+  - title: unit-persistence-integration
+    chunk: persistence
+    contract_refs: [contract-candidate-proof, contract-admission-lifecycle, contract-v6-persistence, contract-commit-last-retirement]
+    files: [src/sync/rename-debt.ts, src/sync/state.ts, src/sync/orchestrator.ts, src/sync/rename-debt.test.ts, src/sync/state.test.ts, src/sync/orchestrator.test.ts]
+    depends_on: [unit-candidate-proof, unit-admission-lifecycle]
+    acceptance:
+      - Only explicit Admission retained membership is serialized to unchanged v6 rows.
+      - Failed upsert yields visible failure with zero executor I/O and zero tracker acknowledgement.
+      - Fresh and seeded false-v6 Issue 51 cases converge while genuine and ambiguous rows retain.
+      - Lifecycle diagnostics distinguish every contracted stage without content or credentials.
+    objective: Rewire pre-I/O persistence and existing v6 compatibility around Admission output.
+    output_format: TypeScript integration/store helper changes and orchestrator fault/compatibility tests.
+    tool_guidance: Use existing state, tracker, executor, observation, and checkpoint seams to assert ordering.
+    task_boundaries: Do not change SyncState version, delete rows in bulk, alter backends, or infer relevance.
+    decision_closure_reason: Wire shape, compatibility authority, failure abort, ordering, and diagnostics are fixed.
+
+  - title: unit-finalization
+    chunk: finalization
+    contract_refs: [contract-commit-last-retirement]
+    files: [src/sync/sync-cycle-finalization.ts, src/sync/sync-cycle-finalization.test.ts]
+    depends_on: [unit-admission-lifecycle]
+    acceptance:
+      - Exact release membership retires only after its successful disposition and checkpoint.
+      - Deferral, action failure, blocking, missing association, and checkpoint failure retain debt.
+      - Finalization performs no relevance, scope, baseline, or identity evaluation.
+    objective: Preserve commit-last semantics while consuming Admission lifecycle output mechanically.
+    output_format: TypeScript finalization changes and fault-path Vitest coverage.
+    tool_guidance: Keep checkpoint commit before exact debt deletion and reuse disposition completion data.
+    task_boundaries: Do not acquire facts or reconstruct membership from action names.
+    decision_closure_reason: Release membership, corresponding-success predicate, and failure retention are fixed.
+
+  - title: unit-design-verification
+    chunk: verification
+    contract_refs: [contract-candidate-proof, contract-admission-lifecycle, contract-v6-persistence, contract-commit-last-retirement]
+    files: [ARCHITECTURE.md, docs/sync-pipeline.md, docs/adr/adr-20260831-admission-owned-local-rename-constraint-lifecycle.md, docs/changes/change-20260831-issue51-rename-evidence-lifecycle]
+    depends_on: [unit-persistence-integration, unit-finalization]
+    acceptance:
+      - The accepted ADR explicitly amends only ADR 0008 section 6 persistence trigger and preserves Issue 43 authority.
+      - Focused tests, docs lint, and the full repository gate pass.
+      - Completion makes no blank-file causality claim.
+    objective: Persist the corrected authority boundary and verify its release contract.
+    output_format: ADR/change documentation and recorded mechanical verification.
+    tool_guidance: Use dev-docs lint and repository npm scripts after implementation.
+    task_boundaries: Do not broaden into unrelated ff87f7d changes or unsupported runtime claims.
+    decision_closure_reason: Stable cross-component ownership requires persistent rationale and full-gate evidence.
+
+acceptance:
+  - id: acceptance-fresh-progress
+    criteria: A fresh unbaselined rename executes only terminal additive pushes without rename_mismatch and creates no debt.
+    requirement_refs: [FR-RENAME-001, FR-RENAME-002]
+  - id: acceptance-v6-compatibility
+    criteria: A seeded false v6 row converges without reset and deletes only after its successful consequence and checkpoint while genuine or ambiguous rows retain.
+    requirement_refs: [FR-COMPAT-001, FR-FINALIZE-001]
+  - id: acceptance-safety-preserved
+    criteria: Synchronized native rename, destructive mismatch, current-scope unknown, chain conflict, and incomplete folder evidence preserve exact authorization or whole-component deferral.
+    requirement_refs: [FR-RENAME-003, NFR-SAFETY-001]
+  - id: acceptance-persistence-abort
+    criteria: Injected debt upsert failure causes visible failure with no executor I/O and no tracker acknowledgement while retry evidence remains.
+    requirement_refs: [FR-PERSIST-001]
+  - id: acceptance-boundary-correct
+    criteria: Planning no longer promotes every report, Admission emits both exact memberships, and Finalization performs only consequence-bound commit-last retirement.
+    requirement_refs: [FR-RENAME-001, FR-FINALIZE-001, NFR-SCOPE-001]
+  - id: acceptance-release-green
+    criteria: Focused lifecycle tests, lifecycle diagnostics tests, docs lint, lint, bot-repro, build, and full Vitest pass without a blank-file claim.
+    requirement_refs: [NFR-OBSERVE-001, NFR-SCOPE-001]
+
+dispositions:
+  - decision_input_ref: decision-input-admission-owner
+    disposition: adopted — Admission solely owns candidate promotion and exact persistence/release membership; pre-Admission scope-only debt policy is removed.
+    adr_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260825-issue43-destructive-authorization, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: [contract-admission-lifecycle]
+  - decision_input_ref: decision-input-v6-shape
+    disposition: adopted — Keep the unchanged v6 wire shape, replay rows as candidates, and reclassify from current authoritative facts.
+    adr_refs: [adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: [contract-candidate-proof, contract-v6-persistence]
+  - decision_input_ref: decision-input-false-runtime
+    disposition: adopted — Use the narrow positive additive-unbaselined component proof and reject push-spelling-only release.
+    adr_refs: [adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: [contract-admission-lifecycle]
+  - decision_input_ref: decision-input-fail-closed
+    disposition: adopted — Unknown, conflicting, synchronized, destructive, or incomplete candidates remain retained fail closed.
+    adr_refs: [adr-0008-logical-identity-admission-fails-closed, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: [contract-candidate-proof, contract-admission-lifecycle]
+  - decision_input_ref: decision-input-finalization
+    disposition: adopted — Finalization consumes exact consequence-bound release membership after checkpoint and never reclassifies facts.
+    adr_refs: [adr-20260825-issue43-destructive-authorization, adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: [contract-commit-last-retirement]
+  - decision_input_ref: decision-input-blank-unknown
+    disposition: not_applicable — Blank-file causality lacks second-device evidence and is excluded from this design and success claim.
+    adr_refs: [adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: []
+  - decision_input_ref: decision-input-scope-bounded
+    disposition: adopted — Repair only the rename evidence lifecycle boundary and reject broad rollback or generalized identity infrastructure.
+    adr_refs: [adr-20260831-admission-owned-local-rename-constraint-lifecycle]
+    contract_refs: [contract-candidate-proof, contract-v6-persistence]

--- a/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/implementation.md
+++ b/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/implementation.md
@@ -1,0 +1,187 @@
+---
+change: change-20260831-issue51-rename-evidence-lifecycle
+role: implementation
+contracts:
+- contract-candidate-proof
+- contract-admission-lifecycle
+- contract-v6-persistence
+- contract-commit-last-retirement
+contract_projections:
+- id: contract-candidate-proof
+  verifications:
+  - verify-candidate-proof
+  discretion: []
+- id: contract-admission-lifecycle
+  verifications:
+  - verify-fresh-unbaselined
+  - verify-ambiguous-retention
+  - verify-lifecycle-membership
+  discretion: []
+- id: contract-v6-persistence
+  verifications:
+  - verify-replayed-false-v6
+  - verify-persistence-abort
+  - verify-lifecycle-diagnostics
+  discretion: []
+- id: contract-commit-last-retirement
+  verifications:
+  - verify-finalization-faults
+  - verify-repository-gate
+  discretion: []
+adrs:
+- adr-20260831-admission-owned-local-rename-constraint-lifecycle
+- adr-0008-logical-identity-admission-fails-closed
+- adr-20260825-issue43-destructive-authorization
+decision_dispositions:
+- decision_input_ref: decision-input-admission-owner
+  disposition: adopted — Admission solely owns candidate promotion and exact persistence/release
+    membership; pre-Admission scope-only debt policy is removed.
+  adr_refs:
+  - adr-0008-logical-identity-admission-fails-closed
+  - adr-20260825-issue43-destructive-authorization
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs:
+  - contract-admission-lifecycle
+- decision_input_ref: decision-input-v6-shape
+  disposition: adopted — Keep the unchanged v6 wire shape, replay rows as candidates,
+    and reclassify from current authoritative facts.
+  adr_refs:
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs:
+  - contract-candidate-proof
+  - contract-v6-persistence
+- decision_input_ref: decision-input-false-runtime
+  disposition: adopted — Use the narrow positive additive-unbaselined component proof
+    and reject push-spelling-only release.
+  adr_refs:
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs:
+  - contract-admission-lifecycle
+- decision_input_ref: decision-input-fail-closed
+  disposition: adopted — Unknown, conflicting, synchronized, destructive, or incomplete
+    candidates remain retained fail closed.
+  adr_refs:
+  - adr-0008-logical-identity-admission-fails-closed
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs:
+  - contract-candidate-proof
+  - contract-admission-lifecycle
+- decision_input_ref: decision-input-finalization
+  disposition: adopted — Finalization consumes exact consequence-bound release membership
+    after checkpoint and never reclassifies facts.
+  adr_refs:
+  - adr-20260825-issue43-destructive-authorization
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs:
+  - contract-commit-last-retirement
+- decision_input_ref: decision-input-blank-unknown
+  disposition: not_applicable — Blank-file causality lacks second-device evidence
+    and is excluded from this design and success claim.
+  adr_refs:
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs: []
+- decision_input_ref: decision-input-scope-bounded
+  disposition: adopted — Repair only the rename evidence lifecycle boundary and reject
+    broad rollback or generalized identity infrastructure.
+  adr_refs:
+  - adr-20260831-admission-owned-local-rename-constraint-lifecycle
+  contract_refs:
+  - contract-candidate-proof
+  - contract-v6-persistence
+milestones:
+- id: acquisition
+- id: admission
+- id: persistence
+- id: finalization
+- id: verification
+reference_algorithms: []
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Implementation — Issue #51 rename evidence lifecycle
+
+## Goal
+
+Move the decision “this local report must survive as a durable safety constraint” into
+Admission, while leaving acquisition factual, persistence mechanical, and Finalization
+commit-last. Preserve `RenameEvidence`, SyncState v6, exact destructive authorization,
+and existing backend ownership.
+
+## Implementation contracts
+
+### contract-candidate-proof
+
+`component-cycle-acquisition` constructs one immutable cross-component proof projection:
+edge identity, origin, namespace, authoritative local/remote endpoint observations,
+baseline membership, identity/alias/conflict facts, folder/chain completeness, proposal
+membership, and fresh current scope. Old v6 dispositions are historical conservative
+hints only. Missing facts stay unknown. There is no implementation discretion to pass a
+different shared proof shape or to let Admission depend on mutable `MixedEntity` internals.
+
+### contract-admission-lifecycle
+
+`component-plan-admission` applies a positive additive-unbaselined whitelist to each
+connected candidate component. Every other case is safety-binding/inconclusive and
+passes through existing exact consequence checks. `AdmissionResult` exposes exact
+`persistBeforeExecution` and `releaseAfterSafeCheckpoint` edge membership associated
+with dispositions. A successful synchronized rename is in both; deferred is
+persist-only; fresh additive is in neither; loaded false v6 is release-only.
+
+### contract-v6-persistence
+
+`component-rename-debt-carrier` maps only explicit persistence membership to the
+unchanged v6 row. The orchestrator completes every upsert before executor I/O or tracker
+acknowledgement. Any failed upsert aborts the cycle visibly before both side effects and
+preserves loaded and pending retry evidence. Loaded non-binding rows remain stored until
+Finalization. Structured lifecycle diagnostics contain paths/stage/reason, not content
+or credentials.
+
+### contract-commit-last-retirement
+
+`component-cycle-finalization` deletes an exact release member only after its associated
+`resolved_no_action`, or successful `authorized` disposition, and checkpoint commit.
+Deferred, failed, blocked, unassociated, or checkpoint-failed membership remains. It
+does not stat, project scope, inspect baselines, rebuild graphs, or infer membership from
+actions.
+
+## Dependency-ordered units
+
+### acquisition — fixed candidate proof
+
+Files: `change-detector.ts`, `path-observation.ts`, `identity-evidence.ts`,
+`cycle-admission-snapshot.ts`, `sync-cycle-planning.ts`, and focused tests. Carry fresh
+and replayed candidates in the fixed projection. Prove stat authority, fresh current
+scope, and explicit unknowns. Do not decide lifecycle membership.
+
+### admission — promotion and lifecycle output
+
+Files: `plan-admission.ts`, `plan-admission-graph.ts`, `local-rename-admission.ts`, and
+tests. Add the pure additive classifier and exact memberships. Prove fresh additive, synchronized native,
+destructive mismatch, current-scope unknown, chain conflict, and incomplete folder cases.
+
+### persistence — v6 and orchestration integration
+
+Files: `rename-debt.ts`, `state.ts`, `orchestrator.ts`, and tests. Remove the scope-only
+policy role from `collectLocalRenameDebts`; retain at most a mechanical serializer.
+Upsert Admission membership before I/O, abort on any failure, replay v6 rows as
+candidates, and prove compatibility plus diagnostics.
+
+### finalization — consequence-bound retirement
+
+Files: `sync-cycle-finalization.ts` and tests. Consume exact release membership and its
+disposition completion, checkpoint first, then delete. Cover action failure, blocking,
+deferral, missing association, and checkpoint failure.
+
+### verification — rationale and full gate
+
+Update stable architecture/pipeline text only where the owner boundary is documented,
+retain the accepted ADR, run focused tests and the full gate, and keep blank-file
+causality outside completion claims.
+
+## Implementation discretion
+
+Private helper names and placement within each listed unit are free only if they preserve
+the fixed projection, owner, memberships, failure ordering, and verification outcomes.
+Any change to those shared contracts requires design review; there is no open cross-unit
+design choice.

--- a/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/requirements.md
+++ b/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/requirements.md
@@ -1,0 +1,127 @@
+---
+change: change-20260831-issue51-rename-evidence-lifecycle
+role: requirements
+functional_requirements:
+- id: FR-RENAME-001
+  statement: Only Admission shall classify fresh or replayed local rename candidates
+    and emit exact pre-I/O persistence and post-checkpoint release membership.
+  priority: must
+- id: FR-RENAME-002
+  statement: A positively proven additive unbaselined local rename component shall
+    authorize terminal pushes without rename_mismatch and a fresh report shall create
+    no debt.
+  priority: must
+- id: FR-RENAME-003
+  statement: Synchronized, destructive, scope-transitioning, unknown, conflicting,
+    or incomplete rename components shall remain safety binding and fail closed unless
+    their exact consequence is proven.
+  priority: must
+- id: FR-COMPAT-001
+  statement: Existing false SyncState v6 debt shall be reclassified from current authoritative
+    facts and retired only after successful admitted progress and a safe checkpoint
+    without reset or migration.
+  priority: must
+- id: FR-PERSIST-001
+  statement: If any retained rename constraint cannot be upserted, the cycle shall
+    fail visibly before executor I/O or tracker acknowledgement and shall preserve
+    retry evidence.
+  priority: must
+- id: FR-FINALIZE-001
+  statement: Finalization shall retire exact release membership only after its corresponding
+    disposition succeeds or resolves with no action and the clean checkpoint commits.
+  priority: must
+- id: NFR-SAFETY-001
+  statement: Admission-only executable authority, stat-backed absence, fresh current-scope
+    authority, and fail-closed handling of incomplete facts shall remain intact.
+  priority: must
+- id: NFR-OBSERVE-001
+  statement: Structured non-sensitive diagnostics shall distinguish report, replay,
+    promotion, non-binding, retention, release, and persistence-failure lifecycle
+    stages.
+  priority: must
+- id: NFR-SCOPE-001
+  statement: The correction shall reuse the RenameEvidence tuple and SyncState v6
+    and shall not add a general identity graph, persistent state machine, blanket
+    deletion, or blank-file claim.
+  priority: must
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Requirements — Issue #51 rename evidence lifecycle
+
+## Functional requirements
+
+### FR-RENAME-001 — Admission-owned promotion
+
+When a cycle contains a fresh tracker rename or replayed v6 debt, the system shall carry
+it as a candidate until Admission classifies the whole connected component and emits
+exact persistence and release membership. Planning and Finalization shall not infer
+membership from raw reports, scope alone, or action names.
+
+### FR-RENAME-002 — proven additive progress
+
+When current authoritative facts prove that a connected local rename component has no
+baseline, remote identity, conflict, destructive consequence, or incomplete coverage,
+and its only actions are pushes to exact current terminal paths, Admission shall
+authorize those pushes without `rename_mismatch` and shall create no fresh debt.
+
+### FR-RENAME-003 — fail-closed safety
+
+When baseline membership, remote identity, destructive/native consequence, current
+scope transition, unknown/conflicting observation, incomplete folder/chain coverage, or
+mixed evidence exists, Admission shall classify the component safety-binding or
+inconclusive. It shall admit only the existing exact postcondition or defer the whole
+component with zero destructive I/O.
+
+### FR-COMPAT-001 — v6 compatibility
+
+When an existing v6 row is replayed, Admission shall reclassify it from the same fresh
+proof projection. A proven false row may become release-eligible but shall remain stored
+through execution and be deleted only after its associated successful disposition and
+checkpoint. Ambiguous or genuine rows remain stored. No migration or manual reset is
+allowed.
+
+### FR-PERSIST-001 — persistence failure abort
+
+When any safety-binding local constraint cannot be durably upserted, the cycle shall end
+as a visible failure before executor I/O or tracker acknowledgement. Loaded debt and
+pending in-memory evidence shall remain available for retry.
+
+### FR-FINALIZE-001 — consequence-bound retirement
+
+While a row is release-eligible, Finalization shall delete its exact key only after the
+associated disposition resolves with no action or all authorized actions succeed and
+the clean checkpoint commits. Deferral, failure, blocking, absent association, or
+checkpoint failure retains it.
+
+## Invariants and non-functional requirements
+
+- `NFR-SAFETY-001`: only Admission creates executable authority; endpoint absence is
+  authoritative, current scope is freshly projected, stale v6 scope cannot fill current
+  unknown, and incomplete evidence fails closed.
+- `NFR-OBSERVE-001`: diagnostics distinguish fresh, replayed, promoted, non-binding,
+  retained, released, and persistence-failed stages without content or credentials.
+- `NFR-SCOPE-001`: reuse `RenameEvidence` and SyncState v6; do not add a general identity
+  graph, persistent state machine, blanket cleanup, or blank-file success claim.
+
+## Acceptance scenarios
+
+1. Given a never-synchronized local `old.md -> new.md` rename with exact observations
+   and only `push(new.md)`, when Admission runs, then the push is executable, no
+   `rename_mismatch` occurs, and no debt is created.
+2. Given the same current facts plus a stored v6 row, when execution and checkpoint
+   succeed, then the row is deleted after checkpoint; a checkpoint failure retains it.
+3. Given a baseline/remote anchor at `old.md`, when the optimizer proposes an exact
+   native rename, then the edge is persisted before I/O and retired after action plus
+   checkpoint; a mismatched proposal defers and retains it.
+4. Given a v6 row whose old scope says included but current scope is unknown, when
+   Admission runs, then the old value does not authorize additive release.
+5. Given an injected debt-upsert failure, when the cycle reaches the persistence cut,
+   then executor I/O and tracker acknowledgement are both zero and retry evidence stays.
+
+## Non-goals
+
+This change does not prove or fix blank-file creation, redesign remote rename authority,
+roll back unrelated `ff87f7d` changes, change SyncState schema, or add generalized
+identity infrastructure.

--- a/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/verification.md
+++ b/docs/changes/change-20260831-issue51-rename-evidence-lifecycle/verification.md
@@ -1,0 +1,48 @@
+---
+change: change-20260831-issue51-rename-evidence-lifecycle
+role: verification
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Verification
+
+## Success conditions
+
+| Contract | Tier | Evidence | Pass criterion |
+|---|---:|---|---|
+| Candidate proof | T1 | `npm test -- --run src/sync/change-detector.test.ts src/sync/sync-cycle-planning.test.ts` | Fixed projection carries authoritative observations and fresh scope; stale v6 scope never fills current unknown. |
+| Admission lifecycle | T1 | `npm test -- --run src/sync/plan-admission.test.ts src/sync/orchestrator.test.ts` | Fresh additive case progresses without debt; synchronized/ambiguous/folder/chain counterexamples retain exact safety behavior. |
+| v6 compatibility | T1 | `npm test -- --run src/sync/orchestrator.test.ts src/sync/state.test.ts` | Seeded false row converges without reset and deletes only after successful checkpoint; genuine/ambiguous rows remain. |
+| Persistence abort | T1 | `npm test -- --run src/sync/orchestrator.test.ts src/sync/rename-debt.test.ts` | Injected upsert failure yields visible failure, zero executor I/O, zero tracker acknowledgement, and retained retry evidence. |
+| Finalization | T1 | `npm test -- --run src/sync/sync-cycle-finalization.test.ts src/sync/orchestrator.test.ts` | Successful native rename retires once after checkpoint; deferred/failed/blocked/checkpoint-failed cases retain. |
+| Diagnostics | T1 | focused orchestrator/log assertions | Raw, replayed, promoted, non-binding, retained, released, and persist-failed stages are distinguishable without content or credentials. |
+| Documentation | T0 | dev-docs lint and relation/conformance checks | Accepted ADR explicitly amends only ADR 0008 section 6 persistence trigger and preserves Issue 43 authority. |
+| Repository gate | T2 | `npm run lint && npm run lint:bot-repro && npm run build && npm test` | All commands pass. |
+
+## Required adversarial witnesses
+
+- Current scope is unknown while the v6 row stores `included`: no additive release.
+- Old endpoint listing is absent but authoritative stat is unavailable: no absence proof.
+- Baseline/remote identity appears anywhere in a chain: whole component safety-binding.
+- Folder descendant completeness is unavailable: no additive folder classification.
+- Native rename plan mismatches the reported edge: deferral and no destructive I/O.
+- Debt upsert fails: no executor or tracker side effect.
+- Action or checkpoint fails after persistence: debt remains.
+
+## Closure gate
+
+Closure requires all success-condition evidence, no unresolved consequential decision,
+and no claim that blank-file creation was fixed.
+
+## Recorded evidence — 2026-08-31
+
+- Red witness: the unbaselined local rename test failed because the push was deferred as
+  `rename_mismatch` before the Admission lifecycle change.
+- Mutation witness: removing the remote-absence conjunct caused the occupied-remote
+  counterexample to fail by authorizing its push; restoring the conjunct returned green.
+- Focused lifecycle suite: 187 tests passed across Admission, orchestrator, debt,
+  Finalization, and change detection before the final full run.
+- Fake-green guard: no skipped/deleted/weakened-test findings.
+- Repository gate: lint, bot reproduction, build, and all 95 test files / 1604 tests passed.
+- dev-docs lint with conformance: passed with no warnings.

--- a/docs/code-enforcement.md
+++ b/docs/code-enforcement.md
@@ -137,7 +137,7 @@ ratchet: it stops *silent* growth and flags the file as split-when-convenient â€
 is not a mandate to shrink the file by force.
 
 Five modules currently carry such overrides as known debt: `fs/googledrive/auth.ts`
-(337), `sync/orchestrator.ts` (406), `sync/plan-admission.ts` (398),
+(337), `sync/orchestrator.ts` (408), `sync/plan-admission.ts` (398),
 `fs/caching/remote-fs.ts` (326), and `fs/backend-manager.ts` (341). Ratchet them down
 when a natural responsibility split presents itself.
 (`fs/googledrive/index.ts` was here at 397; ADR 0001 lifted its cache/checkpoint

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -275,11 +275,11 @@ export default defineConfig(
 		rules: { "max-lines": ["error", { max: 337, skipBlankLines: true, skipComments: true }] },
 	},
 	{
-		// Re-pinned from 385: the explicit pre-Admission try/catch and the single
-		// admitDestructivePlan cut point must remain together in the composition root;
-		// extracting either would hide which exceptions own COLD evidence recovery.
+		// Re-pinned from 406: Admission-selected debt persistence, its explicit failure,
+		// and executePlan must remain adjacent in the composition root so the pre-I/O
+		// crash-safety cut point is visible rather than hidden behind a shallow wrapper.
 		files: ["src/sync/orchestrator.ts"],
-		rules: { "max-lines": ["error", { max: 406, skipBlankLines: true, skipComments: true }] },
+		rules: { "max-lines": ["error", { max: 408, skipBlankLines: true, skipComments: true }] },
 	},
 	{
 		// Admission is the one pure owner of final destructive authorization. Splitting

--- a/src/sync/change-detector.ts
+++ b/src/sync/change-detector.ts
@@ -14,7 +14,7 @@ import {
 } from "./remote-change-source";
 import {
 	confirmEntryAbsences,
-	confirmCarriedRenameOppositeEndpoints,
+	confirmRenameOppositeEndpoints,
 	confirmUnknownRenameEndpoints,
 	ensureRenameEndpointObservations,
 	exactEntity,
@@ -90,9 +90,9 @@ export async function collectChanges(
 		...collectLocalRenameEvidence(changes));
 	ensureRenameEndpointObservations(changeSet.observations, changeSet.identityEvidence);
 	await confirmUnknownRenameEndpoints(changeSet, deps.localFs, deps.remoteFs);
-	await confirmCarriedRenameOppositeEndpoints(
+	await confirmRenameOppositeEndpoints(
 		changeSet.observations,
-		opts.carriedIdentityEvidence ?? [],
+		changeSet.identityEvidence,
 		deps.localFs,
 		deps.remoteFs,
 	);

--- a/src/sync/cycle-admission-snapshot.ts
+++ b/src/sync/cycle-admission-snapshot.ts
@@ -1,0 +1,45 @@
+import type {
+	IdentityEvidence,
+	LocalRenameEvidence,
+	PathObservation,
+	ScopeProjection,
+	SyncAction,
+	SyncPlan,
+} from "./types";
+
+export interface CycleAdmissionSnapshot {
+	readonly plan: { readonly actions: readonly SyncAction[] };
+	readonly identityEvidence: readonly IdentityEvidence[];
+	/** Local tracker reports and replayed v6 rows are candidates, not pre-authorized constraints. */
+	readonly localRenameCandidates: readonly LocalRenameEvidence[];
+	readonly replayedLocalRenameKeys: ReadonlySet<string>;
+	/** Immutable baseline membership used by Admission's positive additive proof. */
+	readonly baselinePaths: ReadonlySet<string>;
+	readonly observations: readonly PathObservation[];
+	readonly scope: ScopeProjection;
+	readonly namespace: string;
+}
+
+export function captureCycleAdmissionSnapshot(
+	plan: SyncPlan,
+	identityEvidence: readonly IdentityEvidence[],
+	observations: readonly PathObservation[],
+	scope: ScopeProjection,
+	namespace: string,
+	baselinePaths: readonly string[] = plan.actions.flatMap((action) =>
+		action.baseline ? [action.baseline.path] : []),
+	replayedLocalRenameKeys: readonly string[] = [],
+): CycleAdmissionSnapshot {
+	const capturedEvidence = Object.freeze([...identityEvidence]);
+	return Object.freeze({
+		plan: Object.freeze({ actions: Object.freeze([...plan.actions]) }),
+		identityEvidence: capturedEvidence,
+		localRenameCandidates: Object.freeze(capturedEvidence.filter((item): item is LocalRenameEvidence =>
+			item.kind === "rename" && item.side === "local")),
+		replayedLocalRenameKeys: new Set(replayedLocalRenameKeys),
+		baselinePaths: new Set(baselinePaths),
+		observations: Object.freeze([...observations]),
+		scope: Object.freeze({ byEndpoint: new Map(scope.byEndpoint) }),
+		namespace,
+	});
+}

--- a/src/sync/identity-evidence.ts
+++ b/src/sync/identity-evidence.ts
@@ -38,6 +38,10 @@ export function renameOptimizerView(evidence: readonly IdentityEvidence[]): {
 	return { localFiles, localFolders, remote };
 }
 
+export function renameEvidenceKey(evidence: RenameEvidence): string {
+	return `${evidence.side}\0${evidence.oldPath}\0${evidence.newPath}\0${evidence.isFolder}`;
+}
+
 export function completeIdentityEvidence(
 	reported: readonly IdentityEvidence[],
 	observations: readonly PathObservation[],
@@ -102,7 +106,7 @@ function appendOccurrence(
 function dedupeRenameEvidence(evidence: RenameEvidence[]): RenameEvidence[] {
 	const unique = new Map<string, RenameEvidence>();
 	for (const item of evidence) {
-		unique.set(JSON.stringify([item.side, item.oldPath, item.newPath, item.isFolder]), item);
+		unique.set(renameEvidenceKey(item), item);
 	}
 	return [...unique.values()];
 }

--- a/src/sync/local-rename-admission.ts
+++ b/src/sync/local-rename-admission.ts
@@ -1,0 +1,84 @@
+import { projectRenameScope } from "./scope-projection";
+import type { AdmissionComponent } from "./plan-admission-graph";
+import { renameEvidenceKey } from "./identity-evidence";
+import type {
+	IdentityEvidence,
+	LocalRenameEvidence,
+	ScopeProjection,
+} from "./types";
+
+export interface LocalRenameLifecycle {
+	persistBeforeExecution: readonly LocalRenameEvidence[];
+	releaseAfterSafeCheckpoint: readonly LocalRenameEvidence[];
+}
+
+export function classifyNonBindingLocalRenames(
+	components: readonly AdmissionComponent[],
+	baselinePaths: ReadonlySet<string>,
+	scope: ScopeProjection,
+): ReadonlySet<string> {
+	const nonBinding = new Set<string>();
+	for (const component of components) {
+		const candidates = component.evidence.filter((item): item is LocalRenameEvidence =>
+			item.kind === "rename" && item.side === "local");
+		if (candidates.length === 0 || !isNonBindingComponent(
+			component, candidates, baselinePaths, scope,
+		)) continue;
+		for (const candidate of candidates) nonBinding.add(renameEvidenceKey(candidate));
+	}
+	return nonBinding;
+}
+
+export function buildLocalRenameLifecycle(
+	candidates: readonly LocalRenameEvidence[],
+	nonBinding: ReadonlySet<string>,
+	releasableEvidence: readonly IdentityEvidence[],
+): LocalRenameLifecycle {
+	const releasableKeys = new Set(releasableEvidence.flatMap((item) =>
+		item.kind === "rename" && item.side === "local" ? [renameEvidenceKey(item)] : []));
+	return {
+		persistBeforeExecution: Object.freeze(candidates.filter((candidate) =>
+			!nonBinding.has(renameEvidenceKey(candidate)))),
+		releaseAfterSafeCheckpoint: Object.freeze(candidates.filter((candidate) =>
+			nonBinding.has(renameEvidenceKey(candidate)) || releasableKeys.has(renameEvidenceKey(candidate)))),
+	};
+}
+
+function isNonBindingComponent(
+	component: AdmissionComponent,
+	candidates: readonly LocalRenameEvidence[],
+	baselinePaths: ReadonlySet<string>,
+	scope: ScopeProjection,
+): boolean {
+	if (component.evidence.length !== candidates.length) return false;
+	if (component.actions.length === 0 && candidates.every((candidate) =>
+		projectRenameScope(candidate, scope).consequence === "none")) return true;
+	if (candidates.some((candidate) => candidate.isFolder)) return false;
+	if ([...component.paths].some((path) => baselinePaths.has(path) ||
+		scope.byEndpoint.get(path) !== "included")) return false;
+
+	const oldPaths = new Set(candidates.map((candidate) => candidate.oldPath));
+	const newPaths = new Set(candidates.map((candidate) => candidate.newPath));
+	const terminalPaths = new Set([...newPaths].filter((path) => !oldPaths.has(path)));
+	if (terminalPaths.size === 0 || component.actions.length !== terminalPaths.size ||
+		component.actions.some((action) => action.action !== "push" || action.baseline !== undefined ||
+			!terminalPaths.has(action.path))) return false;
+
+	for (const path of new Set([...oldPaths, ...newPaths])) {
+		if (!hasOnlyObservation(component, "remote", path, "absent")) return false;
+		const expectedLocal = terminalPaths.has(path) ? "exact" : "absent";
+		if (!hasOnlyObservation(component, "local", path, expectedLocal)) return false;
+	}
+	return true;
+}
+
+function hasOnlyObservation(
+	component: AdmissionComponent,
+	side: "local" | "remote",
+	path: string,
+	kind: "absent" | "exact",
+): boolean {
+	const observations = component.observations.filter((item) =>
+		item.side === side && item.requestedPath === path);
+	return observations.length > 0 && observations.every((item) => item.kind === kind);
+}

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -76,6 +76,68 @@ function mockProvider(
 
 describe("SyncOrchestrator", () => {
 	describe("plan admission and durable rename debt", () => {
+		it("pushes a never-synchronized local rename without creating durable debt", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const tracker = new LocalChangeTracker();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:root",
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			await localFs.write("final.md", new TextEncoder().encode("new").buffer, 1000);
+			tracker.markRenamed("final.md", "draft.md");
+			const info = vi.fn();
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+				logger: { debug: vi.fn(), info, warn: vi.fn(), error: vi.fn(), flush: vi.fn() } as unknown as Logger,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+
+			await orchestrator.runSync();
+
+			expect(readText(remoteFs, "final.md")).toBe("new");
+			expect(await orchestrator.state.getRenameDebts("test:root")).toEqual([]);
+			expect(tracker.getRenamePairs()).toEqual(new Map());
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			expect(info).toHaveBeenCalledWith("Sync plan created", expect.objectContaining({
+				freshLocalRenameCandidates: 1, replayedLocalRenameCandidates: 0,
+				nonBindingLocalRenameCandidates: 1, persistedLocalRenameConstraints: 0,
+			}));
+			await orchestrator.close();
+		});
+
+		it("re-evaluates and retires an existing false v6 debt after a clean push", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`, lastSyncedIdentity: "test:root",
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			await localFs.write("final.md", new TextEncoder().encode("new").buffer, 1000);
+			const info = vi.fn();
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				logger: { debug: vi.fn(), info, warn: vi.fn(), error: vi.fn(), flush: vi.fn() } as unknown as Logger,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.upsertRenameDebts([{
+				namespace: "test:root", side: "local", oldPath: "draft.md", newPath: "final.md",
+				isFolder: false, oldDisposition: "included", newDisposition: "included",
+			}]);
+
+			await orchestrator.runSync();
+
+			expect(readText(remoteFs, "final.md")).toBe("new");
+			expect(await orchestrator.state.getRenameDebts("test:root")).toEqual([]);
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			expect(info).toHaveBeenCalledWith("Sync plan created", expect.objectContaining({
+				freshLocalRenameCandidates: 0, replayedLocalRenameCandidates: 1,
+				nonBindingLocalRenameCandidates: 1, releasableLocalRenameCandidates: 1,
+			}));
+			await orchestrator.close();
+		});
+
 		it("defers a mutation-backed folder rename until provider confirmation", async () => {
 			const localFs = createMockLocalFs();
 			const remoteFs = createMockRemoteFs();

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -21,7 +21,7 @@ import { buildSyncRecord } from "./state-committer";
 import { CycleSummary } from "./sync-notification";
 import type { SyncCycleResult } from "./sync-notification";
 import { FailedActionTracker } from "./failed-action-tracker";
-import { mergeIdentityEvidence, renameDebtEvidence } from "./rename-debt";
+import { mergeIdentityEvidence, renameDebtEvidence, serializeLocalRenameDebts } from "./rename-debt";
 import {
 	logChangeDetection,
 	logSyncCyclePlan,
@@ -455,6 +455,8 @@ export class SyncOrchestrator {
 		// are not reclassified as evidence-acquisition recovery.
 		const admission = admitDestructivePlan(planning.snapshot);
 		logSyncCyclePlan(this.deps.logger, admission);
+		const localRenameDebts = serializeLocalRenameDebts(debtNamespace,
+			admission.localRenameLifecycle.persistBeforeExecution, admission.snapshot.scope);
 		const { folderRenamePairs } = snapshot;
 
 		if (folderRenamePairs.size > 0) {
@@ -463,9 +465,10 @@ export class SyncOrchestrator {
 				pairs: [...folderRenamePairs.entries()].map(([n, o]) => `${o} → ${n}`),
 			});
 		}
-		// This write is deliberately before executePlan: a crash after tracker capture
-		// must not erase the only authoritative local rename edge.
-		await this.stateStore.upsertRenameDebts(planning.localRenameDebts);
+		// Persist Admission-selected constraints before execution so tracker evidence cannot be lost.
+		await this.stateStore.upsertRenameDebts(localRenameDebts).catch((cause: unknown) => {
+			throw new Error("Local rename constraint persistence failed", { cause });
+		});
 		const total = admission.executable.actions.length;
 
 		const classifyError = (err: unknown) => provider?.classifyError?.(err) ?? classifyHttpError(err);
@@ -497,7 +500,7 @@ export class SyncOrchestrator {
 		this.pendingAdmissionEvidence = await finalizeSyncCycle({
 			admission,
 			result, pendingEvidence: this.pendingAdmissionEvidence, persistedDebts,
-			localRenameDebts: planning.localRenameDebts,
+			localRenameDebts,
 			checkpoint: remoteFs.checkpoint, scopeFingerprint, stateStore: this.stateStore,
 		});
 		// readBackendState now persists only non-secret token state (the cursor lives

--- a/src/sync/path-observation.ts
+++ b/src/sync/path-observation.ts
@@ -134,8 +134,8 @@ export async function confirmUnknownRenameEndpoints(
 	})));
 }
 
-/** Confirm the other side of durable rename evidence so a clean replay can retire its debt. */
-export async function confirmCarriedRenameOppositeEndpoints(
+/** Confirm the opposite side of every rename candidate before Admission classifies it. */
+export async function confirmRenameOppositeEndpoints(
 	observations: PathObservation[],
 	evidence: readonly IdentityEvidence[],
 	localFs: IFileSystem,

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -49,6 +49,90 @@ describe("admitDestructivePlan", () => {
 
 		expect(result.executable.actions).toEqual([action]);
 		expect(result.deferred).toEqual([]);
+		expect(result.localRenameLifecycle.persistBeforeExecution).toEqual([]);
+		expect(result.localRenameLifecycle.releaseAfterSafeCheckpoint).toEqual([]);
+	});
+
+	it("retains a local rename when the additive proof has unknown current scope", () => {
+		const action: SyncAction = { path: "B.md", action: "push", local: entity("B.md") };
+		const evidence = [remoteRename({ side: "local", identityKey: undefined })];
+		const observations: PathObservation[] = [
+			{ kind: "unknown", side: "local", requestedPath: "A.md", reason: "not_observed" },
+			{ kind: "absent", side: "remote", requestedPath: "A.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B.md", entity: entity("B.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B.md", authority: "stat" },
+		];
+
+		const result = admit([action], evidence, observations, projection({
+			"A.md": "unknown", "B.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.deferred[0]?.reasons).toContain("unknown_observation");
+		expect(result.localRenameLifecycle.persistBeforeExecution).toEqual(evidence);
+		expect(result.localRenameLifecycle.releaseAfterSafeCheckpoint).toEqual([]);
+	});
+
+	it("retains a local rename when the remote destination is already occupied", () => {
+		const action: SyncAction = { path: "B.md", action: "push", local: entity("B.md") };
+		const evidence = [remoteRename({ side: "local", identityKey: undefined })];
+		const observations: PathObservation[] = [
+			{ kind: "absent", side: "local", requestedPath: "A.md", authority: "stat" },
+			{ kind: "absent", side: "remote", requestedPath: "A.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B.md", entity: entity("B.md") },
+			{ kind: "exact", side: "remote", requestedPath: "B.md", entity: entity("B.md", "remote") },
+		];
+
+		const result = admit([action], evidence, observations, projection({
+			"A.md": "included", "B.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.localRenameLifecycle.persistBeforeExecution).toEqual(evidence);
+	});
+
+	it("retains a local rename when the source has baseline membership", () => {
+		const action: SyncAction = { path: "B.md", action: "push", local: entity("B.md") };
+		const evidence = [remoteRename({ side: "local", identityKey: undefined })];
+		const observations: PathObservation[] = [
+			{ kind: "absent", side: "local", requestedPath: "A.md", authority: "stat" },
+			{ kind: "absent", side: "remote", requestedPath: "A.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B.md", entity: entity("B.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B.md", authority: "stat" },
+		];
+		const snapshot = captureCycleAdmissionSnapshot(
+			{ actions: [action] }, evidence, observations,
+			projection({ "A.md": "included", "B.md": "included" }), "backend\0root", ["A.md"],
+		);
+
+		const result = admitDestructivePlan(snapshot);
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.localRenameLifecycle.persistBeforeExecution).toEqual(evidence);
+	});
+
+	it("admits only the terminal push for an unbaselined local rename chain", () => {
+		const action: SyncAction = { path: "C.md", action: "push", local: entity("C.md") };
+		const evidence = [
+			remoteRename({ side: "local", identityKey: undefined, oldPath: "A.md", newPath: "B.md" }),
+			remoteRename({ side: "local", identityKey: undefined, oldPath: "B.md", newPath: "C.md" }),
+		];
+		const observations: PathObservation[] = [
+			...(["A.md", "B.md"] as const).flatMap((path) => [
+				{ kind: "absent" as const, side: "local" as const, requestedPath: path, authority: "stat" as const },
+				{ kind: "absent" as const, side: "remote" as const, requestedPath: path, authority: "stat" as const },
+			]),
+			{ kind: "exact", side: "local", requestedPath: "C.md", entity: entity("C.md") },
+			{ kind: "absent", side: "remote", requestedPath: "C.md", authority: "stat" },
+		];
+
+		const result = admit([action], evidence, observations, projection({
+			"A.md": "included", "B.md": "included", "C.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.localRenameLifecycle.persistBeforeExecution).toEqual([]);
+		expect(result.localRenameLifecycle.releaseAfterSafeCheckpoint).toEqual(evidence);
 	});
 
 	it("defers unobserved case-distinct deletions independently", () => {
@@ -164,6 +248,26 @@ describe("admitDestructivePlan", () => {
 		expect(result.dispositions).toEqual([expect.objectContaining({
 			kind: "resolved_no_action", paths: ["A.md", "B.md"], actions: [],
 		})]);
+	});
+
+	it("admits an additive push when a local rename has no synchronized anchor", () => {
+		const action: SyncAction = { path: "B.md", action: "push", local: entity("B.md") };
+		const evidence = [remoteRename({ side: "local", identityKey: undefined })];
+		const observations: PathObservation[] = [
+			{ kind: "absent", side: "local", requestedPath: "A.md", authority: "stat" },
+			{ kind: "absent", side: "remote", requestedPath: "A.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B.md", entity: entity("B.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B.md", authority: "stat" },
+		];
+
+		const result = admit([action], evidence, observations, projection({
+			"A.md": "included", "B.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([action]);
+		expect(result.deferred).toEqual([]);
+		expect(result.localRenameLifecycle.persistBeforeExecution).toEqual([]);
+		expect(result.localRenameLifecycle.releaseAfterSafeCheckpoint).toEqual(evidence);
 	});
 
 	it("keeps captured inputs stable when caller-owned containers change", () => {

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -1,23 +1,22 @@
 import { projectRenameScope, type RenameScopeConsequence } from "./scope-projection";
 import { buildAdmissionComponents, type AdmissionComponent } from "./plan-admission-graph";
+import type { CycleAdmissionSnapshot } from "./cycle-admission-snapshot";
+export { captureCycleAdmissionSnapshot, type CycleAdmissionSnapshot } from "./cycle-admission-snapshot";
+import {
+	buildLocalRenameLifecycle,
+	classifyNonBindingLocalRenames,
+	type LocalRenameLifecycle,
+} from "./local-rename-admission";
+import { renameEvidenceKey } from "./identity-evidence";
 import type {
 	IdentityEvidence,
 	PathObservation,
 	RenameEvidence,
 	ScopeProjection,
 	SyncAction,
-	SyncPlan,
 } from "./types";
 
 const authorizedSyncPlanBrand: unique symbol = Symbol("AuthorizedSyncPlan");
-
-export interface CycleAdmissionSnapshot {
-	readonly plan: { readonly actions: readonly SyncAction[] };
-	readonly identityEvidence: readonly IdentityEvidence[];
-	readonly observations: readonly PathObservation[];
-	readonly scope: ScopeProjection;
-	readonly namespace: string;
-}
 
 /** The executor input that only Admission can construct. */
 export interface AuthorizedSyncPlan {
@@ -65,23 +64,7 @@ export interface AdmissionResult {
 	executable: AuthorizedSyncPlan;
 	dispositions: AdmissionDisposition[];
 	deferred: DeferredComponent[];
-}
-
-export function captureCycleAdmissionSnapshot(
-	plan: SyncPlan,
-	identityEvidence: readonly IdentityEvidence[],
-	observations: readonly PathObservation[],
-	scope: ScopeProjection,
-	namespace: string,
-): CycleAdmissionSnapshot {
-	const capturedScope = Object.freeze({ byEndpoint: new Map(scope.byEndpoint) });
-	return Object.freeze({
-		plan: Object.freeze({ actions: Object.freeze([...plan.actions]) }),
-		identityEvidence: Object.freeze([...identityEvidence]),
-		observations: Object.freeze([...observations]),
-		scope: capturedScope,
-		namespace,
-	});
+	localRenameLifecycle: LocalRenameLifecycle;
 }
 
 /**
@@ -92,8 +75,16 @@ export function captureCycleAdmissionSnapshot(
 export function admitDestructivePlan(
 	snapshot: CycleAdmissionSnapshot,
 ): AdmissionResult {
-	const components = buildAdmissionComponents(
+	const candidateComponents = buildAdmissionComponents(
 		snapshot.plan, snapshot.identityEvidence, snapshot.observations, snapshot.scope,
+	);
+	const nonBindingCandidates = classifyNonBindingLocalRenames(
+		candidateComponents, snapshot.baselinePaths, snapshot.scope,
+	);
+	const effectiveEvidence = snapshot.identityEvidence.filter((item) =>
+		item.kind !== "rename" || item.side !== "local" || !nonBindingCandidates.has(renameEvidenceKey(item)));
+	const components = buildAdmissionComponents(
+		snapshot.plan, effectiveEvidence, snapshot.observations, snapshot.scope,
 	);
 	const authorizedActions = new Set<SyncAction>();
 	const dispositions: AdmissionDisposition[] = [];
@@ -123,11 +114,17 @@ export function admitDestructivePlan(
 		actions: Object.freeze(actions),
 		[authorizedSyncPlanBrand]: snapshot,
 	});
+	const localRenameLifecycle = buildLocalRenameLifecycle(
+		snapshot.localRenameCandidates,
+		nonBindingCandidates,
+		dispositions.flatMap((disposition) => disposition.kind === "deferred" ? [] : disposition.evidence),
+	);
 	return {
 		snapshot,
 		executable,
 		dispositions,
 		deferred: dispositions.filter((item): item is DeferredComponent => item.kind === "deferred"),
+		localRenameLifecycle,
 	};
 }
 

--- a/src/sync/rename-debt.test.ts
+++ b/src/sync/rename-debt.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
-	applyRenameDebtScope,
-	collectLocalRenameDebts,
 	mergeRenameDebtEvidence,
 	renameDebtsBoundToEvidence,
+	serializeLocalRenameDebts,
 	unreleasedIdentityEvidence,
 } from "./rename-debt";
 import type { RenameDebt } from "./state";
-import type { RenameEvidence, ScopeProjection } from "./types";
+import type { LocalRenameEvidence, ScopeProjection } from "./types";
 
 function debt(overrides: Partial<RenameDebt> = {}): RenameDebt {
 	return {
@@ -16,7 +15,7 @@ function debt(overrides: Partial<RenameDebt> = {}): RenameDebt {
 	};
 }
 
-function rename(): RenameEvidence {
+function rename(): LocalRenameEvidence {
 	return {
 		kind: "rename", side: "local", oldPath: "A.md", newPath: "a.md",
 		isFolder: false, authority: "reported",
@@ -34,33 +33,11 @@ describe("rename debt orchestration helpers", () => {
 		expect(merged).toEqual([rename()]);
 	});
 
-	it("restores stored endpoint dispositions only where fresh projection is unknown", () => {
-		const restored = applyRenameDebtScope(
-			projection({ "A.md": "unknown", "a.md": "policy_out" }),
-			[debt({ oldDisposition: "included", newDisposition: "included" })],
-		);
-
-		expect([...restored.byEndpoint]).toEqual([
-			["A.md", "included"], ["a.md", "policy_out"],
-		]);
-	});
-
-	it("keeps unknown when persisted edges disagree about one endpoint", () => {
-		const restored = applyRenameDebtScope(projection({ "A.md": "unknown" }), [
-			debt({ oldDisposition: "included" }),
-			debt({ newPath: "B.md", oldDisposition: "policy_out" }),
-		]);
-
-		expect(restored.byEndpoint.get("A.md")).toBe("unknown");
-	});
-
-	it("persists local rename constraints except an explicit out-to-out no-op", () => {
-		expect(collectLocalRenameDebts(
+	it("serializes only the local rename membership selected by Admission", () => {
+		expect(serializeLocalRenameDebts(
 			"onedrive:root", [rename()], projection({ "A.md": "included", "a.md": "included" }),
 		)).toEqual([debt()]);
-		expect(collectLocalRenameDebts(
-			"onedrive:root", [rename()], projection({ "A.md": "policy_out", "a.md": "policy_out" }),
-		)).toEqual([]);
+		expect(serializeLocalRenameDebts("onedrive:root", [], projection({}))).toEqual([]);
 	});
 
 	it("selects only namespace-local debts bound to released evidence", () => {

--- a/src/sync/rename-debt.ts
+++ b/src/sync/rename-debt.ts
@@ -1,9 +1,10 @@
 import { projectRenameScope } from "./scope-projection";
+import { renameEvidenceKey } from "./identity-evidence";
 import type { RenameDebt } from "./state";
 import type {
 	IdentityEvidence,
+	LocalRenameEvidence,
 	RenameEvidence,
-	ScopeDisposition,
 	ScopeProjection,
 } from "./types";
 
@@ -24,36 +25,15 @@ export function mergeIdentityEvidence(
 	return [...merged.values()];
 }
 
-/** Fill only unknown endpoints; current explicit policy/mobile classifications win. */
-export function applyRenameDebtScope(
-	projection: ScopeProjection,
-	debts: readonly RenameDebt[],
-): ScopeProjection {
-	const candidates = new Map<string, ScopeDisposition>();
-	const conflicts = new Set<string>();
-	for (const debt of debts) {
-		rememberDisposition(candidates, conflicts, debt.oldPath, debt.oldDisposition);
-		rememberDisposition(candidates, conflicts, debt.newPath, debt.newDisposition);
-	}
-	const byEndpoint = new Map(projection.byEndpoint);
-	for (const [path, disposition] of candidates) {
-		if (!conflicts.has(path) && byEndpoint.get(path) === "unknown") {
-			byEndpoint.set(path, disposition);
-		}
-	}
-	return { byEndpoint };
-}
-
-export function collectLocalRenameDebts(
+/** Mechanical v6 serialization for membership already selected by Admission. */
+export function serializeLocalRenameDebts(
 	namespace: string,
-	evidence: readonly IdentityEvidence[],
+	evidence: readonly LocalRenameEvidence[],
 	projection: ScopeProjection,
 ): RenameDebt[] {
-	return evidence.flatMap((item): RenameDebt[] => {
-		if (item.kind !== "rename" || item.side !== "local") return [];
+	return evidence.map((item): RenameDebt => {
 		const rule = projectRenameScope(item, projection);
-		if (rule.consequence === "none") return [];
-		return [{
+		return {
 			namespace,
 			side: item.side,
 			oldPath: item.oldPath,
@@ -61,7 +41,7 @@ export function collectLocalRenameDebts(
 			isFolder: item.isFolder,
 			oldDisposition: rule.oldDisposition,
 			newDisposition: rule.newDisposition,
-		}];
+		};
 	});
 }
 
@@ -99,19 +79,4 @@ export function renameDebtEvidence(debt: RenameDebt): RenameEvidence {
 		isFolder: debt.isFolder,
 		authority: "reported",
 	};
-}
-
-function renameEvidenceKey(evidence: RenameEvidence): string {
-	return `${evidence.side}\0${evidence.oldPath}\0${evidence.newPath}\0${evidence.isFolder}`;
-}
-
-function rememberDisposition(
-	candidates: Map<string, ScopeDisposition>,
-	conflicts: Set<string>,
-	path: string,
-	disposition: ScopeDisposition,
-): void {
-	const current = candidates.get(path);
-	if (current !== undefined && current !== disposition) conflicts.add(path);
-	else candidates.set(path, disposition);
 }

--- a/src/sync/sync-cycle-finalization.ts
+++ b/src/sync/sync-cycle-finalization.ts
@@ -25,12 +25,16 @@ interface SyncCycleFinalizationInput {
  */
 export async function finalizeSyncCycle(input: SyncCycleFinalizationInput): Promise<IdentityEvidence[]> {
 	const succeeded = new Set(input.result.succeeded.map(({ action }) => action));
-	const releasable = input.admission.dispositions.flatMap((disposition) => {
+	const dispositionEvidence = input.admission.dispositions.flatMap((disposition) => {
 		if (disposition.kind === "deferred") return [];
 		if (disposition.kind === "authorized" &&
 			!disposition.actions.every((action) => succeeded.has(action))) return [];
 		return disposition.evidence;
 	});
+	const releasable = [
+		...dispositionEvidence,
+		...input.admission.localRenameLifecycle.releaseAfterSafeCheckpoint,
+	];
 	const checkpointSafe = input.result.failed.length === 0 && input.result.blocked.length === 0 &&
 		input.admission.dispositions.every((disposition) =>
 			disposition.kind !== "deferred" &&
@@ -41,7 +45,7 @@ export async function finalizeSyncCycle(input: SyncCycleFinalizationInput): Prom
 	await input.checkpoint?.commitCheckpoint({ scopeFingerprint: input.scopeFingerprint });
 	const resolvedDebts = renameDebtsBoundToEvidence(
 		[...input.persistedDebts, ...input.localRenameDebts],
-		releasable,
+		input.admission.localRenameLifecycle.releaseAfterSafeCheckpoint,
 		input.admission.snapshot.namespace,
 	);
 	await input.stateStore.deleteRenameDebts(resolvedDebts);

--- a/src/sync/sync-cycle-planning.ts
+++ b/src/sync/sync-cycle-planning.ts
@@ -3,11 +3,8 @@ import type { ChangeSet } from "./change-detector";
 import { planSync } from "./decision-engine";
 import type { AdmissionResult } from "./plan-admission";
 import { captureCycleAdmissionSnapshot } from "./plan-admission";
-import {
-	applyRenameDebtScope,
-	collectLocalRenameDebts,
-	mergeRenameDebtEvidence,
-} from "./rename-debt";
+import { mergeRenameDebtEvidence, renameDebtEvidence } from "./rename-debt";
+import { renameEvidenceKey } from "./identity-evidence";
 import { refinePlan } from "./rename-optimizer";
 import { projectScope, type ScopeProjectionPolicy } from "./scope-projection";
 import type { RenameDebt } from "./state";
@@ -55,7 +52,7 @@ export function prepareSyncCycleSnapshot(
 		...changeSet,
 		identityEvidence: mergeRenameDebtEvidence(changeSet.identityEvidence, persistedDebts),
 	};
-	const scopeProjection = applyRenameDebtScope(projectScope(completeChangeSet, policy), persistedDebts);
+	const scopeProjection = projectScope(completeChangeSet, policy);
 	const filtered = completeChangeSet.entries.filter((entry) =>
 		scopeProjection.byEndpoint.get(entry.path) === "included");
 	if (filtered.length !== completeChangeSet.entries.length) {
@@ -76,16 +73,10 @@ export function prepareSyncCycleSnapshot(
 		completeChangeSet.observations,
 		scopeProjection,
 		namespace,
+		completeChangeSet.entries.flatMap((entry) => entry.prevSync ? [entry.path] : []),
+		persistedDebts.map((debt) => renameEvidenceKey(renameDebtEvidence(debt))),
 	);
-	const localRenameDebts = collectLocalRenameDebts(
-		namespace,
-		completeChangeSet.identityEvidence,
-		scopeProjection,
-	);
-	return {
-		snapshot,
-		localRenameDebts,
-	};
+	return { snapshot };
 }
 
 export function logSyncCyclePlan(
@@ -98,6 +89,14 @@ export function logSyncCyclePlan(
 	}
 	logger?.info("Sync plan created", {
 		total: admission.snapshot.plan.actions.length,
+		localRenameCandidates: admission.snapshot.localRenameCandidates.length,
+		freshLocalRenameCandidates: admission.snapshot.localRenameCandidates.filter((candidate) =>
+			!admission.snapshot.replayedLocalRenameKeys.has(renameEvidenceKey(candidate))).length,
+		replayedLocalRenameCandidates: admission.snapshot.replayedLocalRenameKeys.size,
+		persistedLocalRenameConstraints: admission.localRenameLifecycle.persistBeforeExecution.length,
+		nonBindingLocalRenameCandidates: admission.snapshot.localRenameCandidates.length -
+			admission.localRenameLifecycle.persistBeforeExecution.length,
+		releasableLocalRenameCandidates: admission.localRenameLifecycle.releaseAfterSafeCheckpoint.length,
 		...actionBreakdown,
 	});
 	for (const component of admission.deferred) {

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -71,6 +71,8 @@ export interface RenameEvidence {
 	identityKey?: string;
 }
 
+export type LocalRenameEvidence = RenameEvidence & { side: "local" };
+
 export type IdentityEvidence =
 	| RenameEvidence
 	| { kind: "alias"; side: SyncSide; requestedPath: string; resolvedPath: string }


### PR DESCRIPTION
## Summary

- make Admission the owner of local rename constraint promotion and release
- allow only fully proven additive, unbaselined local renames to proceed without durable debt
- re-evaluate existing false v6 debt from fresh authoritative observations and retire it only after a successful checkpoint
- preserve fail-closed behavior for ambiguous, synchronized, folder, and remote-occupied rename cases

Addresses #51.

The reported persistent `rename_mismatch` deferral is covered by this change. The separate blank-file symptom is not claimed as fixed without second-device runtime evidence.

## Design

The previous flow persisted every local rename report before Admission established whether it constrained a synchronized resource. This could turn a never-synchronized rename into permanent debt.

The revised boundary captures one immutable cycle snapshot, lets Admission emit exact `persistBeforeExecution` and `releaseAfterSafeCheckpoint` memberships, and keeps persistence/finalization mechanical. The SyncState v6 wire shape is unchanged.

## Verification

- `npm run lint`
- `npm run lint:bot-repro`
- `npm run build`
- `npm test` — 95 files, 1604 tests
- dev-docs conformance and design-spine lint
- red regression witness plus a mutation witness for the remote-absence safety conjunct
