### PR TITLE
Fix mobile size input boundary

### DIFF
--- a/docs/adr/0008-logical-identity-admission-fails-closed.md
+++ b/docs/adr/0008-logical-identity-admission-fails-closed.md
@@ -1,6 +1,6 @@
 # ADR 0008 — Logical-identity admission fails closed before sync-plan execution
 
-**Status:** Accepted · 2026-08-25 · **Revised 2026-09-03** (excluded listing entries do not enter Admission)
+**Status:** Accepted · 2026-08-25 · **Revised 2026-09-03** (all deterministic scope exclusions are removed before Admission)
 **Context area:** `sync/` — change evidence, scope projection, destructive admission, checkpoint lifecycle
 **Related:** [ADR 0001](0001-metadata-cache-is-subordinate-to-commit-last.md), [ADR 0002](0002-backends-verified-by-shared-behaviour-contracts.md), [ADR 0006](0006-remote-rename-detection-is-order-independent.md), [Issue #43](https://github.com/takezoh/obsidian-air-sync/issues/43), [Issue #45](https://github.com/takezoh/obsidian-air-sync/issues/45), [Issue #47](https://github.com/takezoh/obsidian-air-sync/issues/47)
 
@@ -40,8 +40,10 @@ depend on that repair being complete.
    endpoint is included. A folder relation crossing scope at any observed descendant
    is discarded, leaving each included path to be planned from its own current and
    baseline facts. Excluded paths have no Admission disposition and cannot affect
-   identity topology or folder-mapping completeness. `unknown`, `mobile_deferred`, and
-   incomplete mappings among included paths fail the whole connected component. An
+   identity topology or folder-mapping completeness. The mobile maximum-size policy
+   follows the same boundary using current entity size; it has no Admission
+   disposition. `unknown` observations and incomplete mappings among included paths
+   fail the whole connected component. An
    included-to-included folder rename remains one opaque folder operation.
    On a case-insensitive local filesystem, COLD replay may expose the requested new
    spelling only as an alias of the old spelling. Admission may reconstruct an

--- a/docs/changes/change-20260903-mobile-size-input-boundary/change.md
+++ b/docs/changes/change-20260903-mobile-size-input-boundary/change.md
@@ -1,0 +1,126 @@
+---
+id: change-20260903-mobile-size-input-boundary
+kind: change
+title: Remove mobile size policy from sync-engine state
+status: done
+created: '2026-09-03'
+profile: sdd@1
+intent: Enforce the mobile maximum file size as sync-input scope instead of an engine-visible
+  deferred state, consistently across batch, scheduler, priority, and checkpoint recovery
+  paths.
+outcomes:
+- Oversized current files are absent from LocalChangeTracker and BatchObservation.
+- Priority pull stops before content I/O when current local or remote metadata proves
+  the file oversized.
+- Raising the effective mobile threshold forces one cold reconcile.
+scope:
+- docs/adr/0008-logical-identity-admission-fails-closed.md governing decision
+- docs/design/design-four-stage-sync-pipeline.md governing invariant
+- docs/sync-pipeline.md active pipeline contract
+- src/main.ts scheduler policy wiring
+- src/sync/opened-file-priority.test.ts priority boundary tests
+- src/sync/opened-file-priority.ts priority boundary
+- src/sync/orchestrator.test.ts threshold-widening recovery test
+- src/sync/orchestrator.ts canonical exclusion policy wiring
+- src/sync/scheduler.test.ts event-ingress tests
+- src/sync/scheduler.ts event-ingress boundary
+- src/sync/scope-fingerprint.test.ts effective-policy fingerprint test
+- src/sync/scope-fingerprint.ts effective-policy fingerprint
+- src/sync/scope-projection.test.ts scope filtering tests
+- src/sync/scope-projection.ts pre-Observation filtering
+- src/sync/sync-cycle-planning.test.ts BatchObservation boundary tests
+- src/sync/types.ts scope disposition vocabulary
+non_goals:
+- Persisting excluded paths or deferred operations
+- Changing unknown-observation fail-closed behavior
+- Cleaning stale failed-action quarantine documentation and permanentCode residue
+change_classes:
+- boundary
+- behavior
+governance:
+  gate: auto
+  reasons: []
+members:
+- role: requirements
+  path: changes/change-20260903-mobile-size-input-boundary/requirements.md
+  required: true
+- role: implementation
+  path: changes/change-20260903-mobile-size-input-boundary/implementation.md
+  required: true
+- role: verification
+  path: changes/change-20260903-mobile-size-input-boundary/verification.md
+  required: true
+promotion:
+- action: upsert
+  target: design-four-stage-sync-pipeline
+  section: invariants
+  item:
+    id: INV-004
+    statement: Configured path and effective mobile-size filtering removes excluded
+      paths and cross-scope identity edges before BatchObservation; LocalChangeTracker,
+      Admission, and later stages cannot observe or branch on them.
+    enforcement: test
+unresolved_decisions: []
+tags: []
+owners: []
+relations:
+- {type: modifies, target: design-four-stage-sync-pipeline}
+- {type: references, target: change-20260903-remove-policy-out}
+- {type: supersedes, target: change-20260903-remove-policy-out}
+source_paths:
+- docs/adr/0008-logical-identity-admission-fails-closed.md
+- docs/design/design-four-stage-sync-pipeline.md
+- docs/sync-pipeline.md
+- src/sync/scope-projection.ts
+- src/sync/scope-projection.test.ts
+- src/sync/types.ts
+- src/sync/scheduler.ts
+- src/sync/scheduler.test.ts
+- src/main.ts
+- src/sync/opened-file-priority.ts
+- src/sync/opened-file-priority.test.ts
+- src/sync/orchestrator.ts
+- src/sync/orchestrator.test.ts
+- src/sync/scope-fingerprint.ts
+- src/sync/scope-fingerprint.test.ts
+- src/sync/sync-cycle-planning.test.ts
+evidence_refs:
+- type: test
+  ref: RED focused suites (9 expected failures, 139 passing controls)
+- type: test
+  ref: GREEN focused suites (168 tests)
+- type: command
+  ref: npm run lint
+- type: command
+  ref: npm run lint:bot-repro (29 tests)
+- type: command
+  ref: npm run build
+- type: command
+  ref: npm run test:coverage (90 files, 1715 tests)
+- type: test
+  ref: live Google Drive, Dropbox, and OneDrive E2E (3 files, 163 tests)
+- type: contract
+  ref: independent causal critique approved with zero findings
+- type: command
+  ref: dev-evidence out-of-scope and closure readiness PASS at scope-7317bcfd40af7979
+summary: Treat oversized current files as absent at every sync input boundary, without
+  deferred state.
+updated: '2026-09-03'
+promotion_applied_at: '2026-09-03T13:08:25.725383+00:00'
+closure:
+  closed_at: '2026-09-03T13:08:54.184759+00:00'
+  content_hash: sha256:49e7066ffb4f47131c8ce3336d8a11de2a9badd02ceda26bda6984de73abc542
+---
+
+## Summary
+
+Remove `mobile_deferred` from the engine model. A single metadata-aware boundary
+predicate treats oversized current files as nonexistent to sync, while current-state
+observation and scope fingerprinting keep threshold changes convergent without durable
+intermediate state.
+
+## Closure Notes
+
+All declared outcomes are implemented. Oversized current files are filtered at local
+event, batch observation, and priority-content boundaries; effective scope widening is
+recovered by one cold scan; no durable intermediate state was added.

--- a/docs/changes/change-20260903-mobile-size-input-boundary/implementation.md
+++ b/docs/changes/change-20260903-mobile-size-input-boundary/implementation.md
@@ -1,0 +1,21 @@
+---
+change: change-20260903-mobile-size-input-boundary
+role: implementation
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Implementation
+
+## Content
+
+1. Make the boundary predicate accept optional current size metadata.
+2. Collect and rename-propagate current sizes before filtering `ChangeSet` facts.
+3. Reduce `ScopeDisposition` to `included | unknown`; retain fail-closed unknown
+   evidence without any deterministic policy state.
+4. Apply the predicate before every scheduler tracker mutation and expand mixed folder
+   renames to eligible file effects.
+5. Apply the same predicate before priority remote observation when local size is
+   sufficient, and after metadata observation before content I/O for remote growth.
+6. Fingerprint the effective mobile byte threshold.
+7. Update governing docs that currently retain `mobile_deferred`.

--- a/docs/changes/change-20260903-mobile-size-input-boundary/requirements.md
+++ b/docs/changes/change-20260903-mobile-size-input-boundary/requirements.md
@@ -1,0 +1,55 @@
+---
+change: change-20260903-mobile-size-input-boundary
+role: requirements
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Requirements
+
+## Content
+
+### R1 — Mobile size is input scope
+
+Given a mobile cycle and a currently existing file larger than the configured maximum,
+when local events or collected facts cross a sync-input boundary, then the path and its
+connected rename facts must not enter `LocalChangeTracker` or `BatchObservation`.
+There is no engine disposition equivalent to `mobile_deferred`.
+
+### R2 — Current facts own size eligibility
+
+Current local and remote entities are authoritative; when both exist, the larger size
+governs. A file rename applies the same current entity size to both endpoints. Baseline
+size alone never keeps an absent or subsequently shrunk file out of scope.
+
+### R3 — Mixed folder rename is file-scoped
+
+Given an included folder rename with both eligible and oversized descendants, local
+event ingress must expand it to eligible file changes only. It must not retain a native
+folder edge capable of moving the excluded descendant.
+
+### R4 — Priority pull obeys the same boundary
+
+If local metadata already proves an opened file oversized, priority sync performs no
+remote observation. If only remote observation proves it oversized, metadata observe
+is allowed but content read, local write, baseline commit, tracker mutation, and
+recovery scheduling are forbidden.
+
+### R5 — Scope widening is re-observed
+
+The effective mobile threshold is part of the committed scope fingerprint. Raising it
+forces exactly one cold reconcile so unchanged remote files behind the delta cursor
+become observable; unchanged effective scope does not repeatedly scan cold.
+
+### R6 — Recovery remains stateless
+
+Filtering writes no excluded-path, deferred-operation, or recovery record. A later
+eligible current state is planned from fresh facts and the last completed baseline.
+
+### Counterexamples
+
+- Renaming `mobile_deferred` while keeping its Admission branch is invalid.
+- Using baseline size as a sticky exclusion is invalid.
+- Allowing a mixed folder native rename to carry an oversized child is invalid.
+- Scheduling the normal batch merely because priority rejected a deterministic size
+  exclusion is invalid.

--- a/docs/changes/change-20260903-mobile-size-input-boundary/verification.md
+++ b/docs/changes/change-20260903-mobile-size-input-boundary/verification.md
@@ -1,0 +1,40 @@
+---
+change: change-20260903-mobile-size-input-boundary
+role: verification
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Verification
+
+## Content
+
+RED evidence before production changes:
+
+- `npm test -- --run src/sync/sync-cycle-planning.test.ts src/sync/scheduler.test.ts src/sync/scope-fingerprint.test.ts src/sync/orchestrator.test.ts`
+- 9 failed / 139 passed, covering BatchObservation contamination, local tracker
+  ingress, local and remote rename propagation, mixed folder expansion, remote-grown
+  priority, baseline non-stickiness, fingerprint change, and one-shot cold recovery.
+
+GREEN evidence:
+
+- Focused suites: 6 files, 168 tests passed.
+- `npm run lint`: passed.
+- `npm run lint:bot-repro`: 29 tests passed; production scan found zero unsafe
+  diagnostics across all declaration boundaries.
+- `npm run build`: TypeScript and production bundle passed.
+- `npm run test:coverage`: 90 files, 1715 tests passed.
+- `npm run test:e2e`: live Google Drive, Dropbox, and OneDrive suites passed — 3
+  files, 163 tests. The earlier credential-less run skipped all three and is not used
+  as evidence.
+- Independent revised causal critique: approved, no findings or open questions.
+- dev-evidence `out-of-scope-changes.v2` and
+  `closure.evidence-readiness.v1`: PASS at `scope-7317bcfd40af7979` against the
+  pre-change commit `c079bfb`.
+
+Static absence checks:
+
+- No `mobile_deferred` or `mobileMaxBytes` remains in production, active pipeline,
+  governing design, or ADR 0008.
+- No rename-debt/quarantine claim remains in the active pipeline or orchestrator
+  recovery comment. Historical completed change packages remain immutable.

--- a/docs/design/design-four-stage-sync-pipeline.md
+++ b/docs/design/design-four-stage-sync-pipeline.md
@@ -31,9 +31,9 @@ invariants:
     finalization policy.
   enforcement: test
 - id: INV-004
-  statement: Configured-scope filtering removes excluded paths and cross-scope identity
-    edges before BatchObservation; Admission and later stages cannot observe or branch
-    on them.
+  statement: Configured path and effective mobile-size filtering removes excluded
+    paths and cross-scope identity edges before BatchObservation; LocalChangeTracker,
+    Admission, and later stages cannot observe or branch on them.
   enforcement: test
 boundaries:
   provides:

--- a/docs/sync-pipeline.md
+++ b/docs/sync-pipeline.md
@@ -7,24 +7,26 @@ Each sync cycle has exactly four top-level responsibility stages:
 1. **Observation** -- `collectChanges()` acquires exact entries, path observations, and normative identity evidence; scope projection and `captureBatchObservation()` freeze those facts without constructing actions.
 2. **Admission** -- `admitBatchObservation()` privately constructs the path-local proposal, builds identity-connected components once, applies conflict and destructive-action policy, assigns every relevant component one disposition and lifecycle membership, and issues the only `AuthorizedSyncPlan`.
 3. **Execution** -- `executePlan()` accepts that authorized plan only, performs its exact effects, and reports exact outcomes without inventing or rerouting actions.
-4. **Commit/finalization** -- per-action state publication records proven successes; `finalizeSyncCycle()` mechanically folds those outcomes with the Admission dispositions, commits a safe checkpoint, and only then retires released evidence and debt.
+4. **Commit/finalization** -- per-action state publication records proven successes; `finalizeSyncCycle()` mechanically folds those outcomes with the Admission dispositions and commits a safe checkpoint last.
 
 These stages describe responsibility owners, not one separately scheduled pass per helper function. Evidence completion, scope projection, and immutable fact capture belong to **Observation**. The path-local decision table, component build, conflict policy, and component-local rename shaping are private to **Admission**. They add no extra network scan merely by being named.
 
 The lower-level cycle sequence within those boundaries is:
 
 1. `collectChanges()` selects HOT/WARM/COLD collection, records authoritative path observations and identity evidence, confirms uncertain absences, and completes required hashes/identity facts.
-2. `applyScope()` removes excluded paths and cross-scope identity edges, then projects mobile and observation completeness over the remaining facts.
+2. `applyScope()` removes configured-path and mobile-size exclusions plus cross-scope identity edges, then projects observation completeness over the remaining facts.
 3. `captureBatchObservation()` fixes included entries, evidence, observations, scope, and namespace without an action carrier.
 4. `admitBatchObservation()` invokes the private path-local `planSync()` helper, then builds evidence-connected components once, shapes and decides each component, and projects the `AuthorizedSyncPlan` while preserving disconnected ordinary proposal order.
 5. `executePlan()` runs only that authorized projection and reports exact completion; each successful action is published through `commitAction()`.
-6. `finalizeSyncCycle()` folds disposition membership with execution completion, commits the checkpoint when safe, then retires released evidence and debt.
+6. `finalizeSyncCycle()` folds disposition membership with execution completion and commits the checkpoint only when safe.
 
 The orchestrator (`SyncOrchestrator.executeSyncOnce()`) only sequences the boundaries. `prepareSyncCycleSnapshot()` projects scope and produces a fact-only `BatchObservation`. The orchestrator passes it once to `admitBatchObservation()` at the authorization cut point; no executable action exists before that call.
 
 File-open priority does not add another set of these stages. It reuses the stored baseline and Admission's exact action projection, while a provider capability supplies only a detached current observation/read. The normal cycle is not re-decided at execution time and does not issue per-component targeted API calls.
 
-**Scope filter (`SyncOrchestrator.isExcluded()`)** — a path is synced only if it passes **both** gates:
+**Scope filter (`SyncOrchestrator.isExcluded()`)** — a path is synced only if it passes
+the configured path gates and, on mobile, its current file size is at or below the
+configured maximum:
 
 1. **Dot-path scope** (`isDotPathOutOfScope`): a dot-prefixed/hidden path (`.airsync`, `.obsidian`, `.git`, …) is in scope only when it sits under a configured `syncDotPaths` root — `settings.syncDotPaths` augmented with the vault's config directory when `enableConfigSync` is on (`getEffectiveSyncDotPaths`, `config-sync.ts`). Normal paths always pass. This is applied symmetrically to local and remote facts before `BatchObservation`; excluded endpoints and identity edges that cross the boundary are discarded.
 2. **Ignore patterns** (`isIgnored`): gitignore-style `ignorePatterns` — likewise augmented with a built-in pattern set (`getEffectiveIgnorePatterns`) prepended when `enableConfigSync` is on while excluding device-specific workspace state. The `syncConfigJsonFiles`, `syncConfigPlugins`, `syncConfigSnippets`, `syncConfigThemes`, and `syncConfigIcons` settings independently add root `*.json`, `plugins/`, `snippets/`, `themes/`, and `icons/`. `community-plugins.json` is classified with `plugins/`, not with generic root JSON, because it is the active community plugin list; it therefore follows `syncConfigPlugins` even when `syncConfigJsonFiles` differs. Root JSON and plugins stay on by default solely for backward compatibility with the pre-toggle Config Sync behavior; all newly introduced subtree scopes default to off and require explicit opt-in. These settings are part of the scope fingerprint, so changing one forces a single cold reconcile and surfaces remote-only files that predate the delta cursor.
@@ -33,7 +35,14 @@ File-open priority does not add another set of these stages. It reuses the store
 - The backend's own metadata path (`INTERNAL_METADATA_PATH` = `.airsync/metadata.json`, `sync/remote-vault.ts`): never synced from either side, even when `.airsync` is opted into `syncDotPaths`. The remote FS hides it too; excluding it here keeps the exclusion symmetric (otherwise a local copy would be pushed, then deleted as a phantom remote deletion).
 - This plugin's own settings file under the config directory (`isOwnPluginDataPath`, `config-sync.ts`): checked regardless of `enableConfigSync`, since a user can opt the config directory into `syncDotPaths` by hand without the toggle. Syncing it would let one device's backend credentials/vaultId overwrite another's — a soft `ignorePatterns` entry alone can't guarantee this (gitignore's last-match-wins semantics would let a user's own pattern override it), so it's enforced as a reserved path instead.
 
-The same `isExcluded()` gates the vault-event dirty tracking (scheduler), so push and pull use one scope rule across hot and cold paths.
+The same metadata-aware `isExcluded()` gates vault-event dirty tracking, collected
+facts before `BatchObservation`, and file-open priority content I/O. A file rename's
+current size applies to both endpoint spellings. If a folder contains both eligible
+and oversized children, the scheduler expands it to eligible file changes instead of
+retaining a native folder move that could carry the excluded child. Baseline size is
+not sticky: only currently existing local/remote entities determine size eligibility.
+The effective mobile threshold is part of the scope fingerprint, so widening it forces
+one cold reconcile for unchanged remote files behind the delta cursor.
 
 `runSync()` is gated on a connected remote (`remoteFs` present), layout-ready, and not-connecting; it serializes via an `AsyncMutex`. A call arriving while a sync runs sets `syncPending` and returns; the lock holder re-runs in a `do/while (syncPending)` loop. A tracker snapshot is acknowledged only after a clean, terminal cycle; an unresolved rename input remains in that in-memory input buffer for the next invocation. Each cycle (`executeSyncOnce`) is wrapped by `executeWithRetry`, which normally retries up to `MAX_RETRIES = 3` with exponential backoff plus jitter (`2^(attempt-1) * 1000 * (0.5 + Math.random())` ms), honoring `Retry-After` (×1000) on 429/403. `AuthError`, a non-rate-limit 403, and 404 abort without retry. A pre-Admission failure reports an error and causes the next normal trigger to use COLD observation; no evidence or recovery instruction is persisted.
 
@@ -102,7 +111,7 @@ Uses `AsyncPool(10)` for parallel local reads. Per-file errors are caught and sk
 
 After initial-match enrichment, `enrichHashesForRenames()` runs for local rename destinations derived from `ChangeSet.identityEvidence`. In warm/cold mode, `list()` returns `hash: ""`, but Admission's local-origin rename proof needs SHA-256 content equivalence. This step calls `stat()` on exact local destination entries. Only the `hash` field is updated; `mtime` and `size` from `list()` are preserved.
 
-Before hash enrichment, `collectChanges()` creates observations for every rename endpoint, confirms unknown endpoints, confirms the opposite side of carried debt/evidence, and in WARM/COLD confirms every baseline absence. A thrown `stat()` aborts the attempt; it is never converted to absence. Hash enrichment then touches exact entries only, and `completeIdentityEvidence()` adds same-root stable-ID occurrences.
+Before hash enrichment, `collectChanges()` creates observations for every rename endpoint, confirms unknown endpoints and their opposite side, and in WARM/COLD confirms every baseline absence. A thrown `stat()` aborts the attempt; it is never converted to absence. Hash enrichment then touches exact entries only, and `completeIdentityEvidence()` adds same-root stable-ID occurrences.
 
 ## Change detection
 
@@ -207,18 +216,17 @@ ordinary work retains proposal order, while a proved component replacement occup
 that component's place.
 `executePlan()` cannot accept a plain proposal through the supported typed API.
 
-Endpoint dispositions are `included`, `mobile_deferred`, or `unknown`.
-Any unknown/mobile endpoint and any incomplete folder descendant mapping fails Admission. The
+Endpoint dispositions are `included` or `unknown`. Deterministic path and mobile-size
+exclusions have no engine representation. Any unknown endpoint and any incomplete folder descendant mapping fails Admission. The
 full local/remote direction matrix and rejected identity inferences are recorded in
 [ADR 0008](adr/0008-logical-identity-admission-fails-closed.md).
 
-Before admitted I/O, local reported edges are upserted into the SyncState v6 rename-debt
-store under the snapshot's backend/root namespace. `finalizeSyncCycle()` does not
-re-evaluate scope, observations, identities, aliases, or action shapes: it folds the
-snapshot-bound dispositions with succeeded action membership. A safe checkpoint commits
-first; only then are mechanically releasable debt and session evidence retired.
-Disconnect/root switch waits on the orchestrator mutex before clearing state, so an
-old-target in-flight cycle cannot recreate debt after teardown.
+`finalizeSyncCycle()` does not re-evaluate scope, observations, identities, aliases,
+or action shapes: it folds the snapshot-bound dispositions with succeeded action
+membership. A safe checkpoint commits last. No pending rename, excluded path, or
+recovery instruction is persisted. Disconnect/root switch waits on the orchestrator
+mutex before clearing state, so an old-target in-flight cycle cannot publish state
+after teardown.
 
 ### Observability
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,7 +147,7 @@ export default class AirSyncPlugin extends Plugin {
 			remoteFs: () => this.backendManager.getRemoteFs(),
 			localTracker: this.localTracker,
 			orchestrator: this.orchestrator,
-			isExcluded: (path) => this.orchestrator.isExcluded(path),
+			isExcluded: (path, currentSize) => this.orchestrator.isExcluded(path, currentSize),
 			registerEvent: (ref) => this.registerEvent(ref),
 			registerWindowEvent: (type, cb) => this.registerDomEvent(window, type, cb),
 			registerDocumentEvent: (type, cb) => this.registerDomEvent(document, type, cb),

--- a/src/sync/opened-file-priority.test.ts
+++ b/src/sync/opened-file-priority.test.ts
@@ -41,6 +41,7 @@ async function arrange() {
 			path: "note.md", localFs, remoteFs, stateStore, localTracker,
 			mutationBarrier: new LocalMutationBarrier(), target: { kind: "independent" as const },
 			supersede, invalidate, invalidateCycle, requestNormalLifecycle,
+			isExcluded: () => false,
 		},
 	};
 }

--- a/src/sync/opened-file-priority.ts
+++ b/src/sync/opened-file-priority.ts
@@ -11,6 +11,7 @@ import type { SyncAction } from "./types";
 export type OpenedFilePriorityResult =
 	| "applied"
 	| "already_current"
+	| "scope_filtered"
 	| "deferred_to_batch"
 	| "failed_retryable";
 
@@ -26,6 +27,7 @@ interface OpenedFilePriorityContext {
 	invalidate(action: SyncAction): boolean;
 	invalidateCycle(): void;
 	requestNormalLifecycle(): void;
+	isExcluded(path: string, currentSize?: number): boolean;
 	logger?: Logger;
 }
 
@@ -39,13 +41,12 @@ export async function syncOpenedFilePriority(
 	const expectedGeneration = ctx.localTracker.generation(ctx.path);
 
 	try {
-		const [localBefore, observed] = await Promise.all([
-			ctx.localFs.stat(ctx.path),
-			ctx.remoteFs.priority.observe({
+		const localBefore = await ctx.localFs.stat(ctx.path);
+		if (localBefore && ctx.isExcluded(ctx.path, localBefore.size)) return filterTarget(ctx);
+		const observed = await ctx.remoteFs.priority.observe({
 				path: ctx.path,
 				identityKey: expectedRecord.remoteIdentityKey,
-			}),
-		]);
+			});
 		if (!localBefore || localBefore.isDirectory || hasChanged(localBefore, expectedRecord)) {
 			invalidateTarget(ctx);
 			return "deferred_to_batch";
@@ -54,6 +55,7 @@ export async function syncOpenedFilePriority(
 			invalidateTarget(ctx);
 			return "deferred_to_batch";
 		}
+		if (ctx.isExcluded(ctx.path, observed.entity.size)) return filterTarget(ctx);
 
 		if (!hasRemoteChanged(observed.entity, expectedRecord)) {
 			const currentRecord = buildSyncRecord(localBefore, observed.entity, ctx.path);
@@ -129,6 +131,14 @@ function invalidateTarget(ctx: OpenedFilePriorityContext): void {
 	if (ctx.target.kind === "superseding") ctx.invalidate(ctx.target.action);
 	ctx.invalidateCycle();
 	ctx.requestNormalLifecycle();
+}
+
+function filterTarget(ctx: OpenedFilePriorityContext): "scope_filtered" {
+	if (ctx.target.kind === "superseding") {
+		ctx.invalidate(ctx.target.action);
+		ctx.invalidateCycle();
+	}
+	return "scope_filtered";
 }
 
 function deferToBatch(ctx: OpenedFilePriorityContext): "deferred_to_batch" {

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -2261,6 +2261,48 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
+		it("runs exactly one cold reconcile when the effective mobile threshold widens", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			addFile(remoteFs, "large.md", "remote content above narrow limit", 1000);
+			const localSeed = addFile(localFs, "seed.md", "seed", 1000);
+			const remoteSeed = addFile(remoteFs, "seed.md", "seed", 1000);
+			const settings = baseMockSettings({
+				backendType: "test",
+				vaultId: `test-${Math.random()}`,
+				mobileMaxFileSizeMB: 0.000005,
+			});
+			remoteFs.checkpoint!.hasCheckpoint = vi.fn().mockResolvedValue(true);
+			wireScopeFingerprint(remoteFs, null);
+			const remoteList = vi.spyOn(remoteFs, "list");
+			const deps = createDeps({
+				getSettings: () => settings,
+				localFs: () => localFs,
+				remoteFs: () => remoteFs,
+				backendProvider: () => mockProvider({}),
+				isMobile: () => true,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await orchestrator.state.put({
+				path: "seed.md", hash: "",
+				localMtime: localSeed.mtime, remoteMtime: remoteSeed.mtime,
+				localSize: localSeed.size, remoteSize: remoteSeed.size, syncedAt: 900,
+			});
+
+			await orchestrator.runSync();
+			expect(localFs.files.has("large.md")).toBe(false);
+			const listCallsBeforeWidening = remoteList.mock.calls.length;
+
+			settings.mobileMaxFileSizeMB = 1;
+			await orchestrator.runSync();
+			expect(localFs.files.has("large.md")).toBe(true);
+			expect(remoteList).toHaveBeenCalledTimes(listCallsBeforeWidening + 1);
+
+			await orchestrator.runSync();
+			expect(remoteList).toHaveBeenCalledTimes(listCallsBeforeWidening + 1);
+			await orchestrator.close();
+		});
+
 		it("does not force cold when settings are unchanged between cycles", async () => {
 			const localFs = createMockLocalFs();
 			const remoteFs = createMockRemoteFs();

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -119,7 +119,7 @@ export class SyncOrchestrator {
 		return hasRemote && !isLocked && !isConnecting && isLayoutReady;
 	}
 
-	isExcluded(path: string): boolean {
+	isExcluded(path: string, currentSize?: number): boolean {
 		const settings = this.deps.getSettings();
 		// The backend's own metadata file is reserved: never sync it from either
 		// side, even when `.airsync` is opted into syncDotPaths. The remote FS also
@@ -131,6 +131,8 @@ export class SyncOrchestrator {
 		// being noise, some backends (Dropbox) reject these outright, which would
 		// otherwise fail every cycle and block the delta checkpoint.
 		if (isSystemJunkFile(path)) return true;
+		if (currentSize !== undefined && this.deps.isMobile() &&
+			currentSize > this.mobileMaxBytes()) return true;
 		const configDir = this.deps.configDir();
 		// This plugin's own data.json (backend credentials/vaultId) is reserved
 		// the same way, regardless of enableConfigSync — a user can put configDir
@@ -143,6 +145,10 @@ export class SyncOrchestrator {
 		// the user's ignore patterns.
 		if (isDotPathOutOfScope(path, getEffectiveSyncDotPaths(settings, configDir))) return true;
 		return isIgnored(path, getEffectiveIgnorePatterns(settings, configDir, this.deps.pluginId()));
+	}
+
+	private mobileMaxBytes(): number {
+		return this.deps.getSettings().mobileMaxFileSizeMB * 1024 * 1024;
 	}
 
 	/**
@@ -215,6 +221,7 @@ export class SyncOrchestrator {
 					this.deps.getSettings(),
 					this.deps.configDir(),
 					this.deps.pluginId(),
+					this.deps.isMobile() ? this.mobileMaxBytes() : null,
 				);
 				// A checkpoint capability without getScopeFingerprint doesn't track
 				// scope at all — skip the check rather than force a spurious cold
@@ -232,9 +239,8 @@ export class SyncOrchestrator {
 				if (!result) return; // Fatal error already handled
 
 				const { succeeded, failed, blocked, conflicts } = result;
-				// failed cycle では cursor が committed state より先に進んでいる可能性がある。
-				// ただし cold recovery を一度支払い済みの local-origin action だけが
-				// quarantine 対象なら、次 cycle の cold scan は不要。
+				// A failed cycle can leave the live cursor ahead of committed state, so
+				// the next explicit sync must reacquire current facts with a cold scan.
 				this.recoverViaColdScan = this.needsColdRecovery(result.outcome);
 				if (failed > 0 || blocked > 0) {
 					this.deps.onStatusChange("partial_error");
@@ -364,6 +370,7 @@ export class SyncOrchestrator {
 				invalidate: (action) => activeBatch?.invalidate(action) ?? false,
 				invalidateCycle: () => activeBatch?.blockCheckpoint(),
 				requestNormalLifecycle: () => this.requestNormalLifecycle(),
+				isExcluded: (candidate, currentSize) => this.isExcluded(candidate, currentSize),
 				logger: this.deps.logger,
 			});
 			this.deps.logger?.info("file-open priority completed", { path, outcome });
@@ -409,11 +416,8 @@ export class SyncOrchestrator {
 			});
 			const { renamePairs } = snapshot;
 
-			const isMobile = this.deps.isMobile();
-			const maxBytes = settings.mobileMaxFileSizeMB * 1024 * 1024;
 			planning = prepareSyncCycleSnapshot(changeSet, namespace, {
-				isExcluded: (path) => this.isExcluded(path),
-				mobileMaxBytes: isMobile ? maxBytes : undefined,
+				isExcluded: (path, currentSize) => this.isExcluded(path, currentSize),
 			}, this.deps.logger);
 			const visiblePaths = new Set(planning.snapshot.scope.byEndpoint.keys());
 			logChangeDetection(changeSet, renamePairs, this.deps.logger, visiblePaths);

--- a/src/sync/scheduler.test.ts
+++ b/src/sync/scheduler.test.ts
@@ -295,6 +295,41 @@ describe("SyncScheduler", () => {
 			).toBe(false);
 		});
 
+		it("does not admit a mobile-oversized file to LocalChangeTracker", () => {
+			scheduler.destroy();
+			const isExcluded = vi.fn((_path: string, size?: number) => (size ?? 0) > 10);
+			deps = createDeps({ isExcluded });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
+			handler({ path: "large.md", stat: { size: 11 } } as unknown as TAbstractFile);
+
+			expect(isExcluded).toHaveBeenCalledWith("large.md", 11);
+			expect(deps.localTracker.getDirtyPaths()).toEqual(new Set());
+		});
+
+		it("expands an included-root mixed-size folder rename to eligible files only", () => {
+			scheduler.destroy();
+			const isExcluded = (_path: string, size?: number) => (size ?? 0) > 10;
+			deps = createDeps({ isExcluded });
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			const eligible = { path: "new/eligible.md", stat: { size: 10 } } as unknown as TAbstractFile;
+			const oversized = { path: "new/oversized.md", stat: { size: 11 } } as unknown as TAbstractFile;
+			const handler = deps.vaultHandlers.get("rename") as RenameHandler;
+			handler(makeFolder("new", [eligible, oversized]), "old");
+
+			expect(deps.localTracker.getFolderRenamePairs()).toEqual(new Map());
+			expect(deps.localTracker.getRenamePairs()).toEqual(
+				new Map([["new/eligible.md", "old/eligible.md"]]),
+			);
+			expect(deps.localTracker.getDirtyPaths()).toEqual(
+				new Set(["old/eligible.md", "new/eligible.md"]),
+			);
+	});
+
 		it("triggers debounced sync on vault change", () => {
 			const handler = deps.vaultHandlers.get("modify") as VaultHandler;
 			handler(makeFile("note.md"));
@@ -406,6 +441,127 @@ describe("SyncScheduler", () => {
 
 			expect(priorityRead).toHaveBeenCalledOnce();
 			expect(readText(localFs, "note.md")).toBe("new");
+			await runtime.close();
+		});
+
+		it("does not priority-read a mobile-oversized opened file", async () => {
+			vi.useRealTimers();
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const local = addFile(localFs, "large.md", "old", 1000);
+			const localStat = await localFs.stat("large.md");
+			if (!localStat) throw new Error("test setup failed");
+			const remote = addFile(remoteFs, "large.md", "remote content", 2000);
+			remote.identityKey = "remote-large-id";
+			const priorityObserve = vi.fn().mockResolvedValue({
+				kind: "current" as const, path: "large.md", identityKey: "remote-large-id", token: "v2",
+				entity: { ...remote },
+				occupant: {
+					kind: "current" as const, path: "large.md", identityKey: "remote-large-id", token: "v2",
+					entity: { ...remote },
+				},
+			});
+			const priorityRead = vi.fn().mockResolvedValue({
+				kind: "content" as const,
+				content: remoteFs.files.get("large.md")!.content.slice(0),
+			});
+			remoteFs.priority = { observe: priorityObserve, read: priorityRead };
+			const tracker = new LocalChangeTracker();
+			const settings = mockSettings({
+				vaultId: `scheduler-mobile-${Math.random()}`,
+				mobileMaxFileSizeMB: 0.000001,
+			});
+			const runtime = new RuntimeSyncOrchestrator({
+				getSettings: () => settings,
+				saveSettings: vi.fn().mockResolvedValue(undefined),
+				configDir: () => ".cfg",
+				pluginId: () => "air-sync",
+				localFs: () => localFs,
+				remoteFs: () => remoteFs,
+				backendProvider: () => null,
+				onStatusChange: vi.fn(), onProgress: vi.fn(), notify: vi.fn(),
+				isMobile: () => true, localTracker: tracker,
+			});
+			await runtime.state.put({
+				path: "large.md", hash: localStat.hash,
+				localMtime: local.mtime, remoteMtime: 1000,
+				localSize: local.size, remoteSize: local.size,
+				remoteIdentityKey: "remote-large-id", syncedAt: 900,
+			});
+			scheduler.destroy();
+			deps = createDeps({
+				orchestrator: runtime, localTracker: tracker, remoteFs: () => remoteFs,
+			});
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			await deps.workspaceHandlers.get("file-open")!({ path: "large.md" });
+
+			expect(priorityObserve).not.toHaveBeenCalled();
+			expect(priorityRead).not.toHaveBeenCalled();
+			expect(readText(localFs, "large.md")).toBe("old");
+			await runtime.close();
+		});
+
+		it("stops a remotely grown mobile file after priority metadata observation", async () => {
+			vi.useRealTimers();
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const local = addFile(localFs, "grown.md", "small", 1000);
+			const localStat = await localFs.stat("grown.md");
+			if (!localStat) throw new Error("test setup failed");
+			const remote = addFile(remoteFs, "grown.md", "remote content above limit", 2000);
+			remote.identityKey = "remote-grown-id";
+			const priorityObserve = vi.fn().mockResolvedValue({
+				kind: "current" as const, path: "grown.md", identityKey: "remote-grown-id", token: "v2",
+				entity: { ...remote },
+				occupant: {
+					kind: "current" as const, path: "grown.md", identityKey: "remote-grown-id", token: "v2",
+					entity: { ...remote },
+				},
+			});
+			const priorityRead = vi.fn().mockResolvedValue({
+				kind: "content" as const,
+				content: remoteFs.files.get("grown.md")!.content.slice(0),
+			});
+			remoteFs.priority = { observe: priorityObserve, read: priorityRead };
+			const tracker = new LocalChangeTracker();
+			const settings = mockSettings({
+				vaultId: `scheduler-mobile-grown-${Math.random()}`,
+				mobileMaxFileSizeMB: 0.00001,
+			});
+			const runtime = new RuntimeSyncOrchestrator({
+				getSettings: () => settings,
+				saveSettings: vi.fn().mockResolvedValue(undefined),
+				configDir: () => ".cfg", pluginId: () => "air-sync",
+				localFs: () => localFs, remoteFs: () => remoteFs,
+				backendProvider: () => null,
+				onStatusChange: vi.fn(), onProgress: vi.fn(), notify: vi.fn(),
+				isMobile: () => true, localTracker: tracker,
+			});
+			await runtime.state.put({
+				path: "grown.md", hash: localStat.hash,
+				localMtime: local.mtime, remoteMtime: 1000,
+				localSize: local.size, remoteSize: local.size,
+				remoteIdentityKey: "remote-grown-id", syncedAt: 900,
+			});
+			const localWrite = vi.spyOn(localFs, "write");
+			const baselineCommit = vi.spyOn(runtime.state, "compareAndPut");
+			scheduler.destroy();
+			deps = createDeps({
+				orchestrator: runtime, localTracker: tracker, remoteFs: () => remoteFs,
+			});
+			scheduler = new SyncScheduler(deps);
+			scheduler.start();
+
+			await deps.workspaceHandlers.get("file-open")!({ path: "grown.md" });
+
+			expect(priorityObserve).toHaveBeenCalledOnce();
+			expect(priorityRead).not.toHaveBeenCalled();
+			expect(localWrite).not.toHaveBeenCalled();
+			expect(baselineCommit).not.toHaveBeenCalled();
+			expect(tracker.getDirtyPaths()).toEqual(new Set());
+			expect(readText(localFs, "grown.md")).toBe("small");
 			await runtime.close();
 		});
 

--- a/src/sync/scheduler.ts
+++ b/src/sync/scheduler.ts
@@ -8,12 +8,19 @@ const DEBOUNCE_MS = 5000;
 function trackScopedFolderRename(
 	folder: TFolder,
 	oldRoot: string,
-	isExcluded: (path: string) => boolean,
+	isExcluded: (path: string, currentSize?: number) => boolean,
 	localTracker: LocalChangeTracker,
+	forceExpansion: boolean,
 ): boolean {
 	const newPrefix = `${folder.path}/`;
 	const pending = [...folder.children];
-	let tracked = false;
+	const descendants: Array<{
+		newPath: string;
+		oldPath: string;
+		newExcluded: boolean;
+		oldExcluded: boolean;
+	}> = [];
+	let hasExcluded = false;
 	while (pending.length > 0) {
 		const child = pending.pop()!;
 		if (child instanceof TFolder) {
@@ -23,19 +30,36 @@ function trackScopedFolderRename(
 		if (!child.path.startsWith(newPrefix)) continue;
 		const relative = child.path.substring(newPrefix.length);
 		const oldPath = relative ? `${oldRoot}/${relative}` : oldRoot;
-		const newExcluded = isExcluded(child.path);
-		const oldExcluded = isExcluded(oldPath);
+		const size = currentFileSize(child);
+		const newExcluded = isExcluded(child.path, size);
+		const oldExcluded = isExcluded(oldPath, size);
+		hasExcluded ||= newExcluded || oldExcluded;
+		descendants.push({ newPath: child.path, oldPath, newExcluded, oldExcluded });
+	}
+	if (!forceExpansion && !hasExcluded) {
+		localTracker.markFolderRenamed(folder.path, oldRoot);
+		return true;
+	}
+	let tracked = false;
+	for (const { newPath, oldPath, newExcluded, oldExcluded } of descendants) {
 		if (newExcluded && oldExcluded) continue;
 		if (!newExcluded && !oldExcluded) {
-			localTracker.markRenamed(child.path, oldPath);
+			localTracker.markRenamed(newPath, oldPath);
 		} else if (!newExcluded) {
-			localTracker.markDirty(child.path);
+			localTracker.markDirty(newPath);
 		} else {
 			localTracker.markDirty(oldPath);
 		}
 		tracked = true;
 	}
 	return tracked;
+}
+
+function currentFileSize(file: TAbstractFile): number | undefined {
+	return "stat" in file && typeof file.stat === "object" && file.stat !== null &&
+		"size" in file.stat && typeof file.stat.size === "number"
+		? file.stat.size
+		: undefined;
 }
 
 export interface SyncOrchestrator {
@@ -50,7 +74,7 @@ export interface SyncSchedulerDeps {
 	remoteFs: () => IFileSystem | null;
 	localTracker: LocalChangeTracker;
 	orchestrator: SyncOrchestrator;
-	isExcluded: (path: string) => boolean;
+	isExcluded: (path: string, currentSize?: number) => boolean;
 	registerEvent: (ref: EventRef) => void;
 	registerWindowEvent: (type: keyof WindowEventMap, cb: () => void) => void;
 	registerDocumentEvent: (type: keyof DocumentEventMap, cb: () => void) => void;
@@ -160,26 +184,23 @@ export class SyncScheduler {
 		const { vault, localTracker, isExcluded } = this.deps;
 
 		const onVaultChange = (file: TAbstractFile) => {
-			if (!isExcluded(file.path)) {
+			if (!isExcluded(file.path, currentFileSize(file))) {
 				localTracker.markDirty(file.path);
 				this.debouncedSync();
 			}
 		};
 
 		const onRename = (file: TAbstractFile, oldPath: string) => {
-			const newExcluded = isExcluded(file.path);
-			const oldExcluded = isExcluded(oldPath);
+			const size = currentFileSize(file);
+			const newExcluded = isExcluded(file.path, size);
+			const oldExcluded = isExcluded(oldPath, size);
 			let tracked = false;
 			if (file instanceof TFolder) {
-				if (!newExcluded && !oldExcluded) {
-					localTracker.markFolderRenamed(file.path, oldPath);
-					tracked = true;
-				} else {
-					// A cross-scope folder edge must not carry an excluded root into the
-					// sync engine. Expand it at this boundary and retain only included
-					// file endpoints; excluded descendants disappear completely.
-					tracked = trackScopedFolderRename(file, oldPath, isExcluded, localTracker);
-				}
+				// A folder operation can move excluded physical children. Expand any
+				// mixed-scope tree at this boundary and retain only included file effects.
+				tracked = trackScopedFolderRename(
+					file, oldPath, isExcluded, localTracker, newExcluded || oldExcluded,
+				);
 			} else if (!newExcluded && !oldExcluded) {
 				localTracker.markRenamed(file.path, oldPath);
 				tracked = true;
@@ -235,11 +256,12 @@ export class SyncScheduler {
 	}
 
 	private wireFileOpenEvent(): void {
-		const { workspace, orchestrator } = this.deps;
+		const { workspace, orchestrator, isExcluded } = this.deps;
 
 		this.deps.registerEvent(
 			workspace.on("file-open", async (file: TFile | null) => {
 				if (!file) return;
+				if (isExcluded(file.path, currentFileSize(file))) return;
 				await orchestrator.pullSingle(file.path);
 			}),
 		);

--- a/src/sync/scope-fingerprint.test.ts
+++ b/src/sync/scope-fingerprint.test.ts
@@ -108,4 +108,19 @@ describe("computeScopeFingerprint", () => {
 		const b = await computeScopeFingerprint(settings, ".cfg", "air-sync-2");
 		expect(a).not.toBe(b);
 	});
+
+	it("includes the effective mobile threshold but ignores it on desktop", async () => {
+		const settings = mockSettings();
+		const mobileNarrow = await computeScopeFingerprint(settings, ".cfg", "air-sync", 10);
+		const mobileWide = await computeScopeFingerprint(settings, ".cfg", "air-sync", 20);
+		const desktopA = await computeScopeFingerprint(
+			mockSettings({ mobileMaxFileSizeMB: 10 }), ".cfg", "air-sync", null,
+		);
+		const desktopB = await computeScopeFingerprint(
+			mockSettings({ mobileMaxFileSizeMB: 20 }), ".cfg", "air-sync", null,
+		);
+
+		expect(mobileNarrow).not.toBe(mobileWide);
+		expect(desktopA).toBe(desktopB);
+	});
 });

--- a/src/sync/scope-fingerprint.ts
+++ b/src/sync/scope-fingerprint.ts
@@ -4,7 +4,8 @@ import { sha256 } from "../utils/hash";
 /**
  * A hash of every setting that determines which paths are in sync scope
  * (`SyncOrchestrator.isExcluded`): the config-sync toggles, `syncDotPaths`,
- * `ignorePatterns`, plus `configDir`/`pluginId` since `getEffectiveSyncDotPaths`/
+ * `ignorePatterns`, the effective mobile byte limit (or null on desktop), plus
+ * `configDir`/`pluginId` since `getEffectiveSyncDotPaths`/
  * `getEffectiveIgnorePatterns` fold them in when config sync is on. Compared
  * against the committed checkpoint's fingerprint so a scope-widening settings
  * change forces one cold reconcile — see `computeScopeFingerprint`'s caller in
@@ -21,6 +22,7 @@ export async function computeScopeFingerprint(
 	settings: AirSyncSettings,
 	configDir: string,
 	pluginId: string,
+	effectiveMobileMaxBytes: number | null = null,
 ): Promise<string> {
 	const canonical = JSON.stringify({
 		enableConfigSync: settings.enableConfigSync,
@@ -33,6 +35,7 @@ export async function computeScopeFingerprint(
 		ignorePatterns: settings.ignorePatterns,
 		configDir,
 		pluginId,
+		effectiveMobileMaxBytes,
 	});
 	return sha256(new TextEncoder().encode(canonical).buffer);
 }

--- a/src/sync/scope-projection.test.ts
+++ b/src/sync/scope-projection.test.ts
@@ -39,17 +39,14 @@ describe("projectRenameScope", () => {
 		});
 	});
 
-	it.each(["unknown", "mobile_deferred"] as const)(
-		"defers the whole edge when either endpoint is %s",
-		(disposition) => {
-			for (const side of ["local", "remote"] as const) {
-				expect(projectRenameScope(rename(side), projection(disposition, "included")).consequence)
-					.toBe("defer");
-				expect(projectRenameScope(rename(side), projection("included", disposition)).consequence)
-					.toBe("defer");
-			}
-		},
-	);
+	it("defers the whole edge when either endpoint is unknown", () => {
+		for (const side of ["local", "remote"] as const) {
+			expect(projectRenameScope(rename(side), projection("unknown", "included")).consequence)
+				.toBe("defer");
+			expect(projectRenameScope(rename(side), projection("included", "unknown")).consequence)
+				.toBe("defer");
+		}
+	});
 
 	it("defaults an absent endpoint to unknown and defers", () => {
 		expect(projectRenameScope(rename("local"), {
@@ -254,17 +251,15 @@ describe("projectScope", () => {
 		]));
 	});
 
-	it("marks oversized included endpoints", () => {
-		const result = projectScope(changeSet({
+	it("removes oversized current files before projection", () => {
+		const result = applyScope(changeSet({
 			entries: [
 				{ path: "large.md", local: entity("large.md", 11) },
 				{ path: "small.md", remote: entity("small.md", 10) },
 			],
-		}), 10);
+		}), { isExcluded: (_path, currentSize) => (currentSize ?? 0) > 10 });
 
-		expect(result.byEndpoint).toEqual(new Map([
-			["large.md", "mobile_deferred"],
-			["small.md", "included"],
-		]));
+		expect(result.changeSet.entries.map((entry) => entry.path)).toEqual(["small.md"]);
+		expect(result.projection.byEndpoint).toEqual(new Map([["small.md", "included"]]));
 	});
 });

--- a/src/sync/scope-projection.ts
+++ b/src/sync/scope-projection.ts
@@ -16,8 +16,7 @@ interface RenameScopeRule {
 }
 
 export interface ScopeProjectionPolicy {
-	isExcluded: (path: string) => boolean;
-	mobileMaxBytes?: number;
+	isExcluded: (path: string, currentSize?: number) => boolean;
 }
 
 export interface ScopedChangeSet {
@@ -38,7 +37,10 @@ export function applyScope(
 		observation.reason === "outside_tracked_root"
 			? [observation.requestedPath]
 			: []));
-	const isIncluded = (path: string) => !outsideRoot.has(path) && !policy.isExcluded(path);
+	const currentSizes = collectCurrentSizes(changeSet);
+	propagateRenameSizes(currentSizes, changeSet.identityEvidence);
+	const isIncluded = (path: string) =>
+		!outsideRoot.has(path) && !policy.isExcluded(path, currentSizes.get(path));
 	const surfacePaths = collectChangeSetPaths(changeSet);
 	const scoped: ChangeSet = {
 		...changeSet,
@@ -58,8 +60,62 @@ export function applyScope(
 	};
 	return {
 		changeSet: scoped,
-		projection: projectScope(scoped, policy.mobileMaxBytes),
+		projection: projectScope(scoped),
 	};
+}
+
+/** Current entities own size scope. Baseline size is deliberately not sticky. */
+function collectCurrentSizes(changeSet: ChangeSet): Map<string, number> {
+	const sizes = new Map<string, number>();
+	for (const entry of changeSet.entries) {
+		for (const entity of [entry.local, entry.remote]) {
+			if (!entity || entity.isDirectory) continue;
+			rememberLargestSize(sizes, entry.path, entity.size);
+			rememberLargestSize(sizes, entity.path, entity.size);
+		}
+	}
+	for (const observation of changeSet.observations) {
+		if (observation.kind !== "exact" && observation.kind !== "alias" &&
+			observation.kind !== "present_unresolved") continue;
+		if (observation.entity.isDirectory) continue;
+		rememberLargestSize(sizes, observation.requestedPath, observation.entity.size);
+		rememberLargestSize(sizes, observation.entity.path, observation.entity.size);
+		if (observation.kind === "alias") {
+			rememberLargestSize(sizes, observation.resolvedPath, observation.entity.size);
+		} else if (observation.kind === "present_unresolved") {
+			rememberLargestSize(sizes, observation.returnedPath, observation.entity.size);
+		}
+	}
+	return sizes;
+}
+
+/** A rename's current file size applies to both spellings before either enters Observation. */
+function propagateRenameSizes(
+	sizes: Map<string, number>,
+	evidence: readonly IdentityEvidence[],
+): void {
+	for (const item of evidence) {
+		if (item.kind !== "rename") continue;
+		propagateSizePair(sizes, item.oldPath, item.newPath);
+		if (!item.isFolder) continue;
+		const oldPrefix = `${item.oldPath}/`;
+		const newPrefix = `${item.newPath}/`;
+		const relatives = new Set<string>();
+		for (const path of sizes.keys()) {
+			if (path.startsWith(oldPrefix)) relatives.add(path.substring(oldPrefix.length));
+			if (path.startsWith(newPrefix)) relatives.add(path.substring(newPrefix.length));
+		}
+		for (const relative of relatives) {
+			propagateSizePair(sizes, `${oldPrefix}${relative}`, `${newPrefix}${relative}`);
+		}
+	}
+}
+
+function propagateSizePair(sizes: Map<string, number>, oldPath: string, newPath: string): void {
+	const size = Math.max(sizes.get(oldPath) ?? -1, sizes.get(newPath) ?? -1);
+	if (size < 0) return;
+	sizes.set(oldPath, size);
+	sizes.set(newPath, size);
 }
 
 function normalizeObservation(
@@ -138,10 +194,9 @@ function crossesScope(
 	return false;
 }
 
-/** Project mobile and observation completeness over already scoped facts. */
+/** Project observation completeness over already scoped facts. */
 export function projectScope(
 	changeSet: Pick<ChangeSet, "entries" | "observations" | "identityEvidence">,
-	mobileMaxBytes?: number,
 ): ScopeProjection {
 	const requiredPaths = collectScopePaths(changeSet.identityEvidence);
 	const paths = new Set(requiredPaths);
@@ -169,34 +224,13 @@ export function projectScope(
 		}
 	}
 
-	const sizes = new Map<string, number>();
-	for (const entry of changeSet.entries) {
-		for (const entity of [entry.local, entry.remote]) {
-			if (entity) rememberLargestSize(sizes, entry.path, entity.size);
-		}
-	}
-	for (const observation of changeSet.observations) {
-		if (isIncidentalDirectory(observation, requiredPaths)) continue;
-		if (observation.kind === "exact" || observation.kind === "present_unresolved") {
-			rememberLargestSize(sizes, observation.requestedPath, observation.entity.size);
-		} else if (observation.kind === "alias") {
-			rememberLargestSize(sizes, observation.resolvedPath, observation.entity.size);
-		}
-	}
-
 	const byEndpoint = new Map<string, ScopeDisposition>();
 	for (const path of paths) {
 		if (unknownPaths.has(path) || !knownPaths.has(path)) {
 			byEndpoint.set(path, "unknown");
 			continue;
 		}
-		const size = sizes.get(path);
-		byEndpoint.set(
-			path,
-			mobileMaxBytes !== undefined && size !== undefined && size > mobileMaxBytes
-				? "mobile_deferred"
-				: "included",
-		);
+		byEndpoint.set(path, "included");
 	}
 	return { byEndpoint };
 }
@@ -252,8 +286,8 @@ function rememberLargestSize(sizes: Map<string, number>, path: string, size: num
 
 function isIndeterminate(
 	disposition: ScopeDisposition,
-): disposition is "unknown" | "mobile_deferred" {
-	return disposition === "unknown" || disposition === "mobile_deferred";
+): disposition is "unknown" {
+	return disposition === "unknown";
 }
 
 function consequenceFor(

--- a/src/sync/sync-cycle-planning.test.ts
+++ b/src/sync/sync-cycle-planning.test.ts
@@ -130,6 +130,147 @@ describe("batch observation boundary", () => {
 		expect([...snapshot.baselinePaths]).toEqual(["old.md"]);
 	});
 
+	it("removes a mobile-oversized rename component before BatchObservation", () => {
+		const changeSet: ChangeSet = {
+			entries: [
+				{
+					path: "old.md", prevSync: baseline("old.md"),
+					remote: { path: "old.md", size: 4, mtime: 1, hash: "base", isDirectory: false },
+				},
+				{
+					path: "new.md",
+					local: { path: "new.md", size: 11, mtime: 2, hash: "new", isDirectory: false },
+				},
+			],
+			observations: [
+				{ kind: "absent", side: "local", requestedPath: "old.md", authority: "stat" },
+				{
+					kind: "exact", side: "remote", requestedPath: "old.md",
+					entity: { path: "old.md", size: 4, mtime: 1, hash: "base", isDirectory: false },
+				},
+				{
+					kind: "exact", side: "local", requestedPath: "new.md",
+					entity: { path: "new.md", size: 11, mtime: 2, hash: "new", isDirectory: false },
+				},
+				{ kind: "absent", side: "remote", requestedPath: "new.md", authority: "stat" },
+			],
+			identityEvidence: [{
+				kind: "rename", side: "local", oldPath: "old.md", newPath: "new.md",
+				isFolder: false, authority: "reported",
+			}],
+			temperature: "hot",
+		};
+
+		const { snapshot } = prepareSyncCycleSnapshot(changeSet, "backend\0root", {
+			isExcluded: (_path, currentSize) => (currentSize ?? 0) > 10,
+		});
+		const admission = admitBatchObservation(snapshot);
+
+		expect(snapshot.entries).toEqual([]);
+		expect(snapshot.observations).toEqual([]);
+		expect(snapshot.evidence).toEqual([]);
+		expect([...snapshot.scope.byEndpoint.keys()]).toEqual([]);
+		expect(admission.failures).toEqual([]);
+		expect(admission.executable.actions).toEqual([]);
+	});
+
+	it("uses current remote size and does not make baseline size sticky", () => {
+		const oversizedRemote: ChangeSet = {
+			entries: [{
+				path: "remote.md",
+				remote: { path: "remote.md", size: 11, mtime: 2, hash: "remote", isDirectory: false },
+			}],
+			observations: [{
+				kind: "exact", side: "remote", requestedPath: "remote.md",
+				entity: { path: "remote.md", size: 11, mtime: 2, hash: "remote", isDirectory: false },
+			}],
+			identityEvidence: [], temperature: "cold",
+		};
+		const historicalOnly: ChangeSet = {
+			entries: [{
+				path: "gone.md",
+				prevSync: { ...baseline("gone.md"), localSize: 11, remoteSize: 11 },
+			}],
+			observations: [
+				{ kind: "absent", side: "local", requestedPath: "gone.md", authority: "stat" },
+				{ kind: "absent", side: "remote", requestedPath: "gone.md", authority: "checkpoint_deleted" },
+			],
+			identityEvidence: [], temperature: "hot",
+		};
+		const shrunkCurrent: ChangeSet = {
+			entries: [{
+				path: "shrunk.md",
+				local: { path: "shrunk.md", size: 4, mtime: 2, hash: "small", isDirectory: false },
+				prevSync: { ...baseline("shrunk.md"), localSize: 11, remoteSize: 11 },
+			}],
+			observations: [{
+				kind: "exact", side: "local", requestedPath: "shrunk.md",
+				entity: { path: "shrunk.md", size: 4, mtime: 2, hash: "small", isDirectory: false },
+			}],
+			identityEvidence: [], temperature: "warm",
+		};
+
+		const remoteSnapshot = prepareSyncCycleSnapshot(oversizedRemote, "backend\0root", {
+			isExcluded: (_path, currentSize) => (currentSize ?? 0) > 10,
+		}).snapshot;
+		const historicalSnapshot = prepareSyncCycleSnapshot(historicalOnly, "backend\0root", {
+			isExcluded: (_path, currentSize) => (currentSize ?? 0) > 10,
+		}).snapshot;
+		const shrunkSnapshot = prepareSyncCycleSnapshot(shrunkCurrent, "backend\0root", {
+			isExcluded: (_path, currentSize) => (currentSize ?? 0) > 10,
+		}).snapshot;
+
+		expect(remoteSnapshot.entries).toEqual([]);
+		expect(remoteSnapshot.observations).toEqual([]);
+		expect([...remoteSnapshot.scope.byEndpoint.keys()]).toEqual([]);
+		expect(historicalSnapshot.entries).toHaveLength(1);
+		expect(historicalSnapshot.observations).toHaveLength(2);
+		expect(historicalSnapshot.scope.byEndpoint.get("gone.md")).toBe("included");
+		expect(shrunkSnapshot.entries).toHaveLength(1);
+		expect(shrunkSnapshot.scope.byEndpoint.get("shrunk.md")).toBe("included");
+	});
+
+	it("propagates a remote rename destination size to its old endpoint", () => {
+		const changeSet: ChangeSet = {
+			entries: [
+				{
+					path: "old.md", prevSync: baseline("old.md"),
+					local: { path: "old.md", size: 4, mtime: 1, hash: "base", isDirectory: false },
+				},
+				{
+					path: "new.md",
+					remote: { path: "new.md", size: 11, mtime: 2, hash: "remote", isDirectory: false },
+				},
+			],
+			observations: [
+				{
+					kind: "exact", side: "local", requestedPath: "old.md",
+					entity: { path: "old.md", size: 4, mtime: 1, hash: "base", isDirectory: false },
+				},
+				{ kind: "absent", side: "remote", requestedPath: "old.md", authority: "checkpoint_deleted" },
+				{ kind: "absent", side: "local", requestedPath: "new.md", authority: "stat" },
+				{
+					kind: "exact", side: "remote", requestedPath: "new.md",
+					entity: { path: "new.md", size: 11, mtime: 2, hash: "remote", isDirectory: false },
+				},
+			],
+			identityEvidence: [{
+				kind: "rename", side: "remote", oldPath: "old.md", newPath: "new.md",
+				isFolder: false, authority: "reported", identityKey: "remote-id",
+			}],
+			temperature: "hot",
+		};
+
+		const { snapshot } = prepareSyncCycleSnapshot(changeSet, "backend\0root", {
+			isExcluded: (_path, currentSize) => (currentSize ?? 0) > 10,
+		});
+
+		expect(snapshot.entries).toEqual([]);
+		expect(snapshot.observations).toEqual([]);
+		expect(snapshot.evidence).toEqual([]);
+		expect([...snapshot.scope.byEndpoint.keys()]).toEqual([]);
+	});
+
 	it.each([
 		{
 			name: "included to excluded as a deletion",

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -34,7 +34,7 @@ export interface MixedEntity {
 
 export type SyncSide = "local" | "remote";
 
-export type ScopeDisposition = "included" | "mobile_deferred" | "unknown";
+export type ScopeDisposition = "included" | "unknown";
 
 export interface ScopeProjection {
 	byEndpoint: ReadonlyMap<string, ScopeDisposition>;


### PR DESCRIPTION
## Summary

- treat the mobile file-size limit as an input-boundary filter before sync planning
- remove `mobile_deferred` from the sync engine's outcome vocabulary
- propagate current file sizes through scheduler, batch observation, rename expansion, and opened-file priority paths
- include the effective mobile size threshold in the scope fingerprint
- keep filtered items cycle-local: no intermediate or durable deferred state is written

## Behavior

- oversized local files are excluded before batch observation
- oversized remote files are excluded after metadata observation and before content transfer
- file renames evaluate both old and new paths using the current file size
- mixed folder renames expand only to eligible file units
- changing the effective size threshold invalidates the scope fingerprint so the next sync re-evaluates eligibility

## Verification

- RED: 9 expected failures with 139 control tests passing before implementation
- focused unit tests: 168 passed
- `npm run lint`
- `npm run lint:bot-repro` (29 passed)
- `npm run build`
- `npm run test:coverage` (1715 passed)
- live E2E: Google Drive, Dropbox, and OneDrive (163 passed)
- independent causal review: approved

## Dependency

This is a stacked PR based on #58 so this PR contains only the mobile-size boundary change. Merge #58 first, then retarget this PR to `main` before merging.
