### PR TITLE
Converge folder renames with added descendants

### DIFF
--- a/src/sync/identity-component-decision.ts
+++ b/src/sync/identity-component-decision.ts
@@ -1,5 +1,6 @@
 import { projectRenameScope, type RenameScopeConsequence } from "./scope-projection";
 import type { AdmissionComponent } from "./plan-admission-graph";
+import { hasRemoteChanged } from "./change-compare";
 import type {
 	IdentityEvidence,
 	PathObservation,
@@ -52,6 +53,36 @@ export function evaluateIdentityComponent(
 		reasons.add("identity_postcondition_unproven");
 	}
 	return [...reasons].sort();
+}
+
+export function canUseOrdinaryLocalFolderActions(
+	component: AdmissionComponent, reasons: readonly AdmissionFailureReason[], scope: ScopeProjection,
+): boolean {
+	if (reasons.length !== 1 || reasons[0] !== "incomplete_folder_mapping") return false;
+	return component.evidence.some((item) => item.kind === "rename" && item.isFolder) &&
+		component.evidence.every((item) => item.kind === "rename" && item.side === "local") &&
+		[...component.paths].every((path) => scope.byEndpoint.get(path) === "included") &&
+		component.actions.length > 0 &&
+		component.actions.every((action) => ordinaryActionProven(action, component.observations));
+}
+
+function ordinaryActionProven(action: SyncAction, observations: readonly PathObservation[]): boolean {
+	if (!observed(observations, "local", action.path, !!action.local) ||
+		!observed(observations, "remote", action.path, !!action.remote)) return false;
+	if (action.action === "cleanup" || action.action === "conflict") return !!action.baseline;
+	if (action.action === "match") return !!action.local && !!action.remote;
+	if (action.action === "push") return !!action.local && (!action.remote ||
+		!!action.baseline && !hasRemoteChanged(action.remote, action.baseline));
+	return action.action === "delete_remote" && !!action.baseline && !!action.remote &&
+		!hasRemoteChanged(action.remote, action.baseline);
+}
+
+function observed(
+	observations: readonly PathObservation[], side: "local" | "remote", path: string, present: boolean,
+): boolean {
+	return observations.some((item) => item.side === side && item.requestedPath === path &&
+		(present ? item.kind === "exact"
+			: item.kind === "absent" && (side === "remote" || item.authority === "stat")));
 }
 function evaluateRenames(
 	component: AdmissionComponent,

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -186,6 +186,130 @@ describe("SyncOrchestrator", () => {
 			await orchestrator.close();
 		});
 
+		it("converges a local folder rename with a newly added descendant", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const tracker = new LocalChangeTracker();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`,
+				lastSyncedIdentity: "test:root", ignorePatterns: ["*.tmp"],
+			});
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await localFs.write("A/known.md", new TextEncoder().encode("kept").buffer, 1000);
+			await orchestrator.runSync();
+			confirmMockPath(remoteFs, "A");
+			const remoteWrite = vi.spyOn(remoteFs, "write");
+			const remoteDelete = vi.spyOn(remoteFs, "delete");
+			const remoteRename = vi.spyOn(remoteFs, "rename");
+
+			await localFs.rename("A", "B");
+			await localFs.write("B/added.md", new TextEncoder().encode("new").buffer, 2000);
+			await localFs.write("B/ignored.tmp", new TextEncoder().encode("private").buffer, 2000);
+			tracker.markFolderRenamed("B", "A");
+			tracker.markDirty("B/added.md");
+			tracker.markDirty("B/ignored.tmp");
+			await orchestrator.runSync();
+
+			expect(readText(remoteFs, "B/known.md")).toBe("kept");
+			expect(readText(remoteFs, "B/added.md")).toBe("new");
+			expect(remoteFs.files.has("A/known.md")).toBe(false);
+			expect(remoteFs.files.has("B/ignored.tmp")).toBe(false);
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			const writesAfterConvergence = remoteWrite.mock.calls.length;
+			const deletesAfterConvergence = remoteDelete.mock.calls.length;
+			const renamesAfterConvergence = remoteRename.mock.calls.length;
+
+			await orchestrator.runSync();
+
+			expect(remoteWrite).toHaveBeenCalledTimes(writesAfterConvergence);
+			expect(remoteDelete).toHaveBeenCalledTimes(deletesAfterConvergence);
+			expect(remoteRename).toHaveBeenCalledTimes(renamesAfterConvergence);
+			await orchestrator.close();
+		});
+
+		it("routes a concurrent remote change through the configured conflict strategy", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const tracker = new LocalChangeTracker();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`,
+				lastSyncedIdentity: "test:root", conflictStrategy: "duplicate",
+			});
+			const recordConflicts = vi.fn().mockResolvedValue(undefined);
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker, recordConflicts,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await localFs.write("A/known.md", new TextEncoder().encode("baseline").buffer, 1000);
+			await orchestrator.runSync();
+			confirmMockPath(remoteFs, "A");
+
+			await remoteFs.write("A/known.md", new TextEncoder().encode("remote changed").buffer, 3000);
+			confirmMockPath(remoteFs, "A");
+			await localFs.rename("A", "B");
+			await localFs.write("B/added.md", new TextEncoder().encode("new").buffer, 2000);
+			tracker.markFolderRenamed("B", "A");
+			tracker.markDirty("B/added.md");
+			await orchestrator.runSync();
+
+			expect(readText(remoteFs, "A/known.md")).toBe("remote changed");
+			expect(readText(remoteFs, "B/known.md")).toBe("baseline");
+			expect(readText(remoteFs, "B/added.md")).toBe("new");
+			expect(recordConflicts).toHaveBeenCalledTimes(1);
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			await orchestrator.close();
+		});
+
+		it("replans an ordinary retry after a partial folder-rename effect failure", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const tracker = new LocalChangeTracker();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`,
+				lastSyncedIdentity: "test:root",
+			});
+			const commitCheckpoint = vi.fn().mockResolvedValue(undefined);
+			remoteFs.checkpoint!.commitCheckpoint = commitCheckpoint;
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await localFs.write("A/known.md", new TextEncoder().encode("kept").buffer, 1000);
+			await orchestrator.runSync();
+			confirmMockPath(remoteFs, "A");
+			commitCheckpoint.mockClear();
+
+			await localFs.rename("A", "B");
+			await localFs.write("B/added.md", new TextEncoder().encode("new").buffer, 2000);
+			tracker.markFolderRenamed("B", "A");
+			tracker.markDirty("B/added.md");
+			const failedDelete = vi.spyOn(remoteFs, "delete").mockRejectedValue(new Error("delete failed"));
+			await orchestrator.runSync();
+
+			expect(readText(remoteFs, "B/known.md")).toBe("kept");
+			expect(readText(remoteFs, "B/added.md")).toBe("new");
+			expect(remoteFs.files.has("A/known.md")).toBe(true);
+			expect(commitCheckpoint).not.toHaveBeenCalled();
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
+
+			failedDelete.mockRestore();
+			confirmMockPath(remoteFs, "B");
+			await orchestrator.runSync();
+
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			expect(remoteFs.files.has("A/known.md")).toBe(false);
+			expect(readText(remoteFs, "B/known.md")).toBe("kept");
+			expect(readText(remoteFs, "B/added.md")).toBe("new");
+			expect(commitCheckpoint).toHaveBeenCalledTimes(1);
+			await orchestrator.close();
+		});
+
 		it("fails closed on an unprovable local rename without I/O or checkpoint advance", async () => {
 			const localFs = createMockLocalFs();
 			const remoteFs = createMockRemoteFs();

--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -219,15 +219,49 @@ describe("SyncOrchestrator", () => {
 			expect(remoteFs.files.has("A/known.md")).toBe(false);
 			expect(remoteFs.files.has("B/ignored.tmp")).toBe(false);
 			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			expect(tracker.getFolderRenamePairs().size).toBe(0);
 			const writesAfterConvergence = remoteWrite.mock.calls.length;
 			const deletesAfterConvergence = remoteDelete.mock.calls.length;
 			const renamesAfterConvergence = remoteRename.mock.calls.length;
+			const localWrite = vi.spyOn(localFs, "write");
+			const localDelete = vi.spyOn(localFs, "delete");
+			const localRename = vi.spyOn(localFs, "rename");
 
 			await orchestrator.runSync();
 
 			expect(remoteWrite).toHaveBeenCalledTimes(writesAfterConvergence);
 			expect(remoteDelete).toHaveBeenCalledTimes(deletesAfterConvergence);
 			expect(remoteRename).toHaveBeenCalledTimes(renamesAfterConvergence);
+			expect(localWrite).not.toHaveBeenCalled();
+			expect(localDelete).not.toHaveBeenCalled();
+			expect(localRename).not.toHaveBeenCalled();
+			await orchestrator.close();
+		});
+
+		it("consumes a fully excluded folder rename after a clean cycle", async () => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs();
+			const tracker = new LocalChangeTracker();
+			const settings = baseMockSettings({
+				backendType: "test", vaultId: `test-${Math.random()}`,
+				lastSyncedIdentity: "test:root", ignorePatterns: ["private/**"],
+			});
+			const deps = createDeps({
+				getSettings: () => settings, localFs: () => localFs, remoteFs: () => remoteFs,
+				localTracker: tracker,
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			await localFs.write("private/A/secret.md", new TextEncoder().encode("private").buffer, 1000);
+			await orchestrator.runSync();
+
+			await localFs.rename("private/A", "private/B");
+			tracker.markFolderRenamed("private/B", "private/A");
+			await orchestrator.runSync();
+
+			expect(remoteFs.files.has("private/A/secret.md")).toBe(false);
+			expect(remoteFs.files.has("private/B/secret.md")).toBe(false);
+			expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			expect(tracker.getFolderRenamePairs().size).toBe(0);
 			await orchestrator.close();
 		});
 
@@ -297,8 +331,12 @@ describe("SyncOrchestrator", () => {
 			expect(remoteFs.files.has("A/known.md")).toBe(true);
 			expect(commitCheckpoint).not.toHaveBeenCalled();
 			expect(deps.onStatusChange).toHaveBeenLastCalledWith("partial_error");
+			expect(tracker.getFolderRenamePairs().size).toBe(1);
 
 			failedDelete.mockRestore();
+			// Remove cycle-local rename evidence before retry. Recovery must use the
+			// committed baseline and fresh endpoint state, not stored intent.
+			tracker.acknowledge(tracker.snapshot());
 			confirmMockPath(remoteFs, "B");
 			await orchestrator.runSync();
 
@@ -307,6 +345,7 @@ describe("SyncOrchestrator", () => {
 			expect(readText(remoteFs, "B/known.md")).toBe("kept");
 			expect(readText(remoteFs, "B/added.md")).toBe("new");
 			expect(commitCheckpoint).toHaveBeenCalledTimes(1);
+			expect(tracker.getFolderRenamePairs().size).toBe(0);
 			await orchestrator.close();
 		});
 

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -473,6 +473,10 @@ export class SyncOrchestrator {
 				const renamed = execution.succeeded.some(({ action }) =>
 					action.action === "rename_remote" &&
 					action.oldPath === oldPath && action.path === newPath);
+				const admittedAsOrdinary = admission.dispositions.some((disposition) =>
+					disposition.kind === "authorized" && disposition.evidence.some((evidence) =>
+						evidence.kind === "rename" && evidence.side === "local" && evidence.isFolder &&
+						evidence.oldPath === oldPath && evidence.newPath === newPath));
 				const remoteAtNew = admission.snapshot.observations.some((observation) =>
 					observation.side === "remote" && observation.requestedPath === newPath &&
 					observation.kind === "exact");
@@ -480,7 +484,7 @@ export class SyncOrchestrator {
 					observation.side === "remote" && observation.requestedPath === oldPath &&
 					(observation.kind === "absent" ||
 						(observation.kind === "alias" && observation.resolvedPath === newPath)));
-				return !renamed && !(remoteAtNew && remoteLeftOld);
+				return !renamed && !admittedAsOrdinary && !(remoteAtNew && remoteLeftOld);
 			});
 			const outcome: SyncCycleOutcome = {
 				execution,

--- a/src/sync/orchestrator.ts
+++ b/src/sync/orchestrator.ts
@@ -469,28 +469,10 @@ export class SyncOrchestrator {
 
 		try {
 			const execution = await executePlan(admission.executable, ctx);
-			const unsettledFolderRename = [...snapshot.folderRenamePairs].some(([newPath, oldPath]) => {
-				const renamed = execution.succeeded.some(({ action }) =>
-					action.action === "rename_remote" &&
-					action.oldPath === oldPath && action.path === newPath);
-				const admittedAsOrdinary = admission.dispositions.some((disposition) =>
-					disposition.kind === "authorized" && disposition.evidence.some((evidence) =>
-						evidence.kind === "rename" && evidence.side === "local" && evidence.isFolder &&
-						evidence.oldPath === oldPath && evidence.newPath === newPath));
-				const remoteAtNew = admission.snapshot.observations.some((observation) =>
-					observation.side === "remote" && observation.requestedPath === newPath &&
-					observation.kind === "exact");
-				const remoteLeftOld = admission.snapshot.observations.some((observation) =>
-					observation.side === "remote" && observation.requestedPath === oldPath &&
-					(observation.kind === "absent" ||
-						(observation.kind === "alias" && observation.resolvedPath === newPath)));
-				return !renamed && !admittedAsOrdinary && !(remoteAtNew && remoteLeftOld);
-			});
 			const outcome: SyncCycleOutcome = {
 				execution,
 				admissionFailures: admission.failures,
-				unsettledLocalRenameInput:
-					admission.unsettledLocalRenameInput || unsettledFolderRename,
+				unsettledLocalRenameInput: admission.unsettledLocalRenameInput,
 			};
 			await this.priorityCoordinator.finalize(async () => {
 				this.activeBatch?.setPhase("finalizing");

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -731,6 +731,38 @@ describe("admitDestructivePlan", () => {
 		expect(result.failures[0]!.reasons).toContain("unknown_observation");
 	});
 
+	it("keeps an incomplete local folder mapping blocked when the remote delete changed", () => {
+		const baseline: SyncRecord = {
+			path: "A/known.md", hash: "h", localMtime: 1, remoteMtime: 1,
+			localSize: 1, remoteSize: 1, syncedAt: 1,
+		};
+		const changedRemote = freshEntity("A/known.md", "changed");
+		const actions: SyncAction[] = [
+			{ path: "A/known.md", action: "delete_remote", remote: changedRemote, baseline },
+			{ path: "B/known.md", action: "push", local: entity("B/known.md") },
+			{ path: "B/added.md", action: "push", local: entity("B/added.md") },
+		];
+		const evidence = [remoteRename({
+			side: "local", identityKey: undefined, oldPath: "A", newPath: "B", isFolder: true,
+		})];
+		const observations: PathObservation[] = [
+			{ kind: "absent", side: "local", requestedPath: "A/known.md", authority: "stat" },
+			{ kind: "exact", side: "remote", requestedPath: "A/known.md", entity: changedRemote },
+			{ kind: "exact", side: "local", requestedPath: "B/known.md", entity: entity("B/known.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/known.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B/added.md", entity: entity("B/added.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/added.md", authority: "stat" },
+		];
+		const result = admit(actions, evidence, observations, projection({
+			A: "included", B: "included", "A/known.md": "included",
+			"B/known.md": "included", "B/added.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.failures[0]!.reasons).toEqual(["incomplete_folder_mapping"]);
+		expect(result.unsettledLocalRenameInput).toBe(true);
+	});
+
 	it("admits a concurrent remote change as an ordinary conflict", () => {
 		const baseline: SyncRecord = {
 			path: "A/known.md", hash: "h", localMtime: 1, remoteMtime: 1,

--- a/src/sync/plan-admission.test.ts
+++ b/src/sync/plan-admission.test.ts
@@ -670,6 +670,93 @@ describe("admitDestructivePlan", () => {
 		expect(result.failures[0]!.reasons).toEqual(["incomplete_folder_mapping"]);
 	});
 
+	it("uses independently proven ordinary actions for an incomplete local folder mapping", () => {
+		const baseline: SyncRecord = {
+			path: "A/known.md", hash: "h", localMtime: 1, remoteMtime: 1,
+			localSize: 1, remoteSize: 1, syncedAt: 1,
+		};
+		const actions: SyncAction[] = [
+			{ path: "A/known.md", action: "delete_remote", remote: entity("A/known.md"), baseline },
+			{ path: "B/known.md", action: "push", local: entity("B/known.md") },
+			{ path: "B/added.md", action: "push", local: entity("B/added.md") },
+		];
+		const evidence = [remoteRename({
+			side: "local", identityKey: undefined, oldPath: "A", newPath: "B", isFolder: true,
+		})];
+		const observations: PathObservation[] = [
+			{ kind: "absent", side: "local", requestedPath: "A/known.md", authority: "stat" },
+			{ kind: "exact", side: "remote", requestedPath: "A/known.md", entity: entity("A/known.md") },
+			{ kind: "exact", side: "local", requestedPath: "B/known.md", entity: entity("B/known.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/known.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B/added.md", entity: entity("B/added.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/added.md", authority: "stat" },
+		];
+		const result = admit(actions, evidence, observations, projection({
+			A: "included", B: "included", "A/known.md": "included",
+			"B/known.md": "included", "B/added.md": "included",
+		}));
+
+		expect(result.failures).toEqual([]);
+		expect(result.executable.actions).toEqual(actions);
+		expect(result.unsettledLocalRenameInput).toBe(false);
+	});
+
+	it("keeps an incomplete local folder mapping blocked without deletion authority", () => {
+		const baseline: SyncRecord = {
+			path: "A/known.md", hash: "h", localMtime: 1, remoteMtime: 1,
+			localSize: 1, remoteSize: 1, syncedAt: 1,
+		};
+		const actions: SyncAction[] = [
+			{ path: "A/known.md", action: "delete_remote", remote: entity("A/known.md"), baseline },
+			{ path: "B/known.md", action: "push", local: entity("B/known.md") },
+			{ path: "B/added.md", action: "push", local: entity("B/added.md") },
+		];
+		const evidence = [remoteRename({
+			side: "local", identityKey: undefined, oldPath: "A", newPath: "B", isFolder: true,
+		})];
+		const observations: PathObservation[] = [
+			{ kind: "unknown", side: "local", requestedPath: "A/known.md", reason: "not_observed" },
+			{ kind: "exact", side: "remote", requestedPath: "A/known.md", entity: entity("A/known.md") },
+			{ kind: "exact", side: "local", requestedPath: "B/known.md", entity: entity("B/known.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/known.md", authority: "stat" },
+			{ kind: "exact", side: "local", requestedPath: "B/added.md", entity: entity("B/added.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/added.md", authority: "stat" },
+		];
+		const result = admit(actions, evidence, observations, projection({
+			A: "included", B: "included", "A/known.md": "included",
+			"B/known.md": "included", "B/added.md": "included",
+		}));
+
+		expect(result.executable.actions).toEqual([]);
+		expect(result.failures[0]!.reasons).toContain("unknown_observation");
+	});
+
+	it("admits a concurrent remote change as an ordinary conflict", () => {
+		const baseline: SyncRecord = {
+			path: "A/known.md", hash: "h", localMtime: 1, remoteMtime: 1,
+			localSize: 1, remoteSize: 1, syncedAt: 1,
+		};
+		const changedRemote = freshEntity("A/known.md", "changed");
+		const conflict: SyncAction = {
+			path: "A/known.md", action: "conflict", remote: changedRemote, baseline,
+		};
+		const added: SyncAction = { path: "B/added.md", action: "push", local: entity("B/added.md") };
+		const evidence = [remoteRename({
+			side: "local", identityKey: undefined, oldPath: "A", newPath: "B", isFolder: true,
+		})];
+		const result = admit([conflict, added], evidence, [
+			{ kind: "absent", side: "local", requestedPath: "A/known.md", authority: "stat" },
+			{ kind: "exact", side: "remote", requestedPath: "A/known.md", entity: changedRemote },
+			{ kind: "exact", side: "local", requestedPath: "B/added.md", entity: entity("B/added.md") },
+			{ kind: "absent", side: "remote", requestedPath: "B/added.md", authority: "stat" },
+		], projection({
+			A: "included", B: "included", "A/known.md": "included", "B/added.md": "included",
+		}));
+
+		expect(result.failures).toEqual([]);
+		expect(result.executable.actions).toEqual([conflict, added]);
+	});
+
 	it("defers a folder rename containing a descendant absent from scope projection", () => {
 		const action: SyncAction = {
 			path: "B", oldPath: "A", action: "rename_local", isFolder: true,

--- a/src/sync/plan-admission.ts
+++ b/src/sync/plan-admission.ts
@@ -22,6 +22,7 @@ export type {
 } from "./local-rename-admission";
 import { renameEvidenceKey, renameOptimizerView } from "./identity-evidence";
 import {
+	canUseOrdinaryLocalFolderActions,
 	evaluateIdentityComponent,
 	type AdmissionFailureReason as IdentityAdmissionFailureReason,
 } from "./identity-component-decision";
@@ -175,6 +176,7 @@ export function admitDestructivePlan(
 	);
 	const authorizedActions: SyncAction[] = [];
 	const dispositions: AdmissionDisposition[] = [];
+	const resolvedLocalRenameInputs = new Set<string>();
 	for (const component of components) {
 		const normalizedRenameState = normalizeFreshLocalRename(component, snapshot.scope);
 		if (normalizedRenameState) {
@@ -211,17 +213,28 @@ export function admitDestructivePlan(
 		const effectiveEvidence = component.evidence.filter((item) =>
 			item.kind !== "rename" || item.side !== "local" ||
 			!nonBindingCandidates.has(renameEvidenceKey(item)));
-		const decidedComponent: AdmissionComponent = {
+		let decidedComponent: AdmissionComponent = {
 			...component,
 			actions: shapeIdentityComponentActions(component.actions, effectiveEvidence),
 			evidence: effectiveEvidence,
 		};
+		let reasons = evaluateIdentityComponent(decidedComponent, snapshot.scope);
+		if (canUseOrdinaryLocalFolderActions(
+			{ ...component, evidence: effectiveEvidence }, reasons, snapshot.scope,
+		)) {
+			decidedComponent = { ...component, evidence: effectiveEvidence };
+			reasons = [];
+			for (const evidence of effectiveEvidence) {
+				if (evidence.kind === "rename" && evidence.side === "local") {
+					resolvedLocalRenameInputs.add(renameEvidenceKey(evidence));
+				}
+			}
+		}
 		const shared = {
 			paths: [...component.paths].sort(),
 			actions: [...decidedComponent.actions],
 			evidence: [...component.evidence].sort(compareEvidence),
 		};
-		const reasons = evaluateIdentityComponent(decidedComponent, snapshot.scope);
 		if (reasons.length > 0) {
 			dispositions.push({
 				kind: "failed",
@@ -253,6 +266,7 @@ export function admitDestructivePlan(
 			evidence.kind === "rename" && evidence.side === "local" &&
 			[...snapshot.baselinePaths].some((path) =>
 				path === evidence.oldPath || path.startsWith(`${evidence.oldPath}/`)) &&
+			!resolvedLocalRenameInputs.has(renameEvidenceKey(evidence)) &&
 			!authorizedActions.some((action) => actionCoversRename(action, evidence))),
 	};
 }


### PR DESCRIPTION
## Summary

- allow Admission to fall back from an incomplete local folder-rename mapping to independently proven managed-file actions
- preserve conflict routing, deletion authority, stateless retry, and terminal-only rename-state commits
- add regression and adversarial coverage for added descendants, exclusions, concurrent remote changes, retries, and fixed-point convergence

## Problem

After a synced folder was renamed locally, adding a new descendant before the next sync made the inferred identity component incomplete. Admission rejected the entire component, so both the known renamed file and the new file failed to converge.

## Safety constraints

- fallback is limited to local-rename-only evidence with a fully included component scope
- action endpoints must have exact current observations
- pushes over existing remote entries and remote deletions require an unchanged baseline
- concurrent remote changes continue through the configured conflict path
- no deferred status, rename debt, recovery journal, or rescan behavior is introduced

## Verification

- reproduced the failure against the unmodified production implementation
- `npm run lint`
- `npm run lint:bot-repro`
- `npm run build`
- `npm run test:coverage` (90 files, 1,713 tests)
- focused orchestrator suite: 89 tests
- mutation check: disabling the fallback makes the new regression test fail

Closes #60
