### PR TITLE
Fix initial match slowdown by publishing admitted observations

### DIFF
--- a/src/sync/orchestrator.test.ts
+++ b/src/sync/orchestrator.test.ts
@@ -91,6 +91,55 @@ function mockProvider(
 }
 
 describe("SyncOrchestrator", () => {
+	it.each(["after-admission", "after-publication"] as const)(
+		"queues and syncs a local edit %s of an initial match", async (timing) => {
+			const localFs = createMockLocalFs();
+			const remoteFs = createMockRemoteFs("actual_resolved");
+			const originalHash = await sha256(new TextEncoder().encode("original").buffer);
+			const modifiedHash = await sha256(new TextEncoder().encode("modified").buffer);
+			addFile(localFs, "note.md", "original", 1000);
+			addFile(remoteFs, "note.md", "original", 1000).remoteChecksum = { algo: "sha256", value: originalHash };
+			const records: Array<{ hash: string } | undefined> = [];
+			const settings = baseMockSettings({ vaultId: `test-${Math.random()}`, enableThreeWayMerge: false });
+			let edited = false;
+			const editAndQueue = () => {
+				if (edited) return;
+				edited = true;
+				// Same size and mtime: the retained dirty generation must drive a
+				// fresh hash comparison, not merely a metadata-only full scan.
+				addFile(localFs, "note.md", "modified", 1000);
+				deps.localTracker.markDirty("note.md");
+				void orchestrator.runSync(); // scheduler's debounced request, while locked
+			};
+			const info = vi.fn((message: string) => {
+				if (timing === "after-admission" && message === "Sync plan created") editAndQueue();
+			});
+			const deps = createDeps({
+				localFs: () => localFs, remoteFs: () => remoteFs, getSettings: () => settings,
+				logger: { debug: vi.fn(), info, warn: vi.fn(), error: vi.fn(), flush: vi.fn() } as unknown as Logger,
+				saveSettings: async () => {
+					records.push(await orchestrator.state.get("note.md"));
+					if (timing === "after-publication") editAndQueue();
+				},
+			});
+			const orchestrator = new SyncOrchestrator(deps);
+			try {
+				await orchestrator.runSync();
+				expect(edited).toBe(true);
+				expect(records).toHaveLength(2);
+				expect(records[0]).toMatchObject({ hash: originalHash });
+				expect(records[1]).toMatchObject({ hash: modifiedHash });
+				expect(readText(localFs, "note.md")).toBe("modified");
+				expect(readText(remoteFs, "note.md")).toBe("modified");
+				expect(deps.localTracker.getDirtyPaths().size).toBe(0);
+				expect(deps.onStatusChange).not.toHaveBeenCalledWith("partial_error");
+				expect(deps.onStatusChange).toHaveBeenLastCalledWith("idle");
+			} finally {
+				await orchestrator.close();
+			}
+		},
+	);
+
 	describe("cold hash-match diagnostics", () => {
 		it("reports checksum enrichment candidates and successful fast matches", async () => {
 			const localFs = createMockLocalFs();

--- a/src/sync/plan-executor.test.ts
+++ b/src/sync/plan-executor.test.ts
@@ -279,6 +279,8 @@ describe("executePlan", () => {
 			const remote = (await ctx.remoteFs.stat("c.md"))!;
 			const localRead = vi.spyOn(ctx.localFs, "read");
 			const remoteRead = vi.spyOn(ctx.remoteFs, "read");
+			const localStat = vi.spyOn(ctx.localFs, "stat");
+			const remoteStat = vi.spyOn(ctx.remoteFs, "stat");
 
 			const plan = makePlan([{ path: "c.md", action: "match", local, remote }]);
 
@@ -288,6 +290,58 @@ describe("executePlan", () => {
 			expect(stateStore.records.has("c.md")).toBe(true);
 			expect(localRead).not.toHaveBeenCalled();
 			expect(remoteRead).not.toHaveBeenCalled();
+			expect(localStat).not.toHaveBeenCalled();
+			expect(remoteStat).not.toHaveBeenCalled();
+		});
+
+		it("publishes the admitted observation despite a later local edit", async () => {
+			const ctx = makeCtx();
+			addFile(ctx.localFs as MockFileSystem, "c.md", "original", 1000);
+			addFile(ctx.remoteFs as MockFileSystem, "c.md", "original", 1000);
+			const local = (await ctx.localFs.stat("c.md"))!;
+			const remote = (await ctx.remoteFs.stat("c.md"))!;
+			addFile(ctx.localFs as MockFileSystem, "c.md", "modified", 2000);
+			const result = await executePlan(makePlan([{ path: "c.md", action: "match", local, remote }]), ctx);
+			expect(result.blocked).toEqual([]);
+			expect(result.failed).toEqual([]);
+			expect(result.succeeded).toHaveLength(1);
+			expect(await ctx.committer.stateStore.get("c.md")).toMatchObject({ hash: local.hash, localMtime: 1000 });
+			expect(readText(ctx.localFs as MockFileSystem, "c.md")).toBe("modified");
+			expect(readText(ctx.remoteFs as MockFileSystem, "c.md")).toBe("original");
+		});
+
+		it("does not overwrite a newer SyncRecord when publishing an observation", async () => {
+			const ctx = makeCtx();
+			addFile(ctx.localFs as MockFileSystem, "c.md", "same");
+			addFile(ctx.remoteFs as MockFileSystem, "c.md", "same");
+			const local = (await ctx.localFs.stat("c.md"))!;
+			const remote = (await ctx.remoteFs.stat("c.md"))!;
+			const plan = makePlan([{ path: "c.md", action: "match", local, remote }]);
+			const newer = { ...buildSyncRecord(local, remote, "c.md"), hash: "newer" };
+			await ctx.committer.stateStore.put(newer);
+			const result = await executePlan(plan, ctx);
+			expect(result.succeeded).toEqual([]);
+			expect(result.failed.length + result.blocked.length).toBe(1);
+			expect(await ctx.committer.stateStore.get("c.md")).toEqual(newer);
+		});
+
+		it("retains endpoint verification and prefix blocking for ordered component matches", async () => {
+			const ctx = makeCtx();
+			const actions: SyncAction[] = [];
+			for (const path of ["folder/a.md", "folder/b.md"]) {
+				addFile(ctx.localFs as MockFileSystem, path, "original", 1000);
+				addFile(ctx.remoteFs as MockFileSystem, path, "original", 1000);
+				actions.push({ path, action: "match",
+					local: (await ctx.localFs.stat(path))!, remote: (await ctx.remoteFs.stat(path))! });
+			}
+			addFile(ctx.localFs as MockFileSystem, "folder/a.md", "modified", 2000);
+			const result = await executePlan(makePlan(actions, true), ctx);
+			expect(result.succeeded).toEqual([]);
+			expect(result.blocked.map(({ reason }) => reason)).toEqual([
+				"Endpoint changed before execution: folder/a.md", "component prefix did not publish",
+			]);
+			expect(await ctx.committer.stateStore.get("folder/a.md")).toBeUndefined();
+			expect(await ctx.committer.stateStore.get("folder/b.md")).toBeUndefined();
 		});
 	});
 

--- a/src/sync/plan-executor.ts
+++ b/src/sync/plan-executor.ts
@@ -156,7 +156,8 @@ export async function executePlan(
 	await settleScheduled(independent.map((component) => {
 		const action = component.actions[0]!;
 		return action.action === "match"
-			? statePool.run(() => executeAction(action, ctx, result, reportProgress))
+			? statePool.run(() => executeAction(action, ctx, result, reportProgress,
+				undefined, publishObservedMatch))
 			: transferPool.run(() => executeAction(action, ctx, result, reportProgress,
 				() => transferPool.noteRateLimit()), transferSize(action));
 	}));
@@ -251,6 +252,7 @@ async function executeAction(
 	result: ExecutionResult,
 	reportProgress: () => void,
 	onRateLimit?: () => void,
+	publish: typeof executeVerifiedAction = executeVerifiedAction,
 ): Promise<void> {
 	const permit = await ctx.acquireActionPermit?.();
 	try {
@@ -263,23 +265,7 @@ async function executeAction(
 			result.blocked.push({ action, reason: "priority observation invalidated pending action" });
 			return;
 		}
-		// Retry only operations that replay safely: push/pull overwrite by path and
-		// delete is idempotent on our backends. A rename would, on replay, re-issue
-		// rename(oldPath, …) against a source the first (successful) attempt already
-		// moved → a spurious not-found failure — so renames run without the retry wrapper.
-		const io = () => runActionIO(action, ctx);
-		const execute = async () => {
-			await checkPublicationInputs(action, ctx, result.succeeded);
-			const entities = action.action === "rename_local" || action.action === "rename_remote"
-				? await io()
-				: await withIoRetry(io, ctx, onRateLimit);
-			const terminalProof = await proveAdmittedTerminal(action, ctx, entities, result.succeeded);
-			const terminalLocal = terminalProof?.localEntity ?? entities.localEntity;
-			const terminalRemote = terminalProof?.remoteEntity ?? entities.remoteEntity;
-			const terminalRecord = await commitAction(action, terminalLocal, terminalRemote,
-				ctx.committer, terminalProof, result.succeeded);
-			return { localEntity: terminalLocal, remoteEntity: terminalRemote, terminalProof, terminalRecord };
-		};
+		const execute = () => publish(action, ctx, result.succeeded, onRateLimit);
 		const paths = localMutationPaths(action);
 		const { localEntity, remoteEntity, terminalProof, terminalRecord } = ctx.mutationBarrier && paths.length > 0
 			? await ctx.mutationBarrier.run(paths, execute)
@@ -310,6 +296,35 @@ async function executeAction(
 		reportProgress();
 		permit?.release();
 	}
+}
+
+/** Independent same-key matches publish the admitted observation, not a new
+ * filesystem observation. Later edits belong to the next tracker generation.
+ * Store CAS and scheduler permits remain shared with effectful execution.
+ */
+async function publishObservedMatch(
+	action: SyncAction, ctx: Pick<ExecutionContext, "committer">,
+): Promise<Omit<CompletedAction, "action">> {
+	const localEntity = action.local;
+	const remoteEntity = action.remote;
+	const terminalRecord = await commitAction(action, localEntity, remoteEntity, ctx.committer);
+	return { localEntity, remoteEntity, terminalRecord };
+}
+
+async function executeVerifiedAction(
+	action: SyncAction, ctx: ExecutionContext, completed: readonly CompletedAction[], onRateLimit?: () => void,
+): Promise<Omit<CompletedAction, "action">> {
+	await checkPublicationInputs(action, ctx, completed);
+	const io = () => runActionIO(action, ctx);
+	// Renames cannot replay safely after their source has already moved.
+	const entities = action.action === "rename_local" || action.action === "rename_remote"
+		? await io() : await withIoRetry(io, ctx, onRateLimit);
+	const terminalProof = await proveAdmittedTerminal(action, ctx, entities, completed);
+	const localEntity = terminalProof?.localEntity ?? entities.localEntity;
+	const remoteEntity = terminalProof?.remoteEntity ?? entities.remoteEntity;
+	const terminalRecord = await commitAction(action, localEntity, remoteEntity,
+		ctx.committer, terminalProof, completed);
+	return { localEntity, remoteEntity, terminalProof, terminalRecord };
 }
 
 function localMutationPaths(action: SyncAction): string[] {


### PR DESCRIPTION
## Summary

Fix the initial-match performance regression following #66 by separating observation publication from effect verification.

- Independent same-key matches publish the already admitted local/remote observation without reacquiring filesystem endpoints. Their execution previously called local and remote `stat()` twice each; local `stat()` reads and hashes the entire file and resolves path casing.
- Preserve shared scheduling permits, error handling, exact SyncRecord CAS, and the existing five-item match concurrency limit.
- Keep endpoint and terminal verification for effectful actions and ordered-component matches, including prefix blocking. Add no persistent state, cross-cycle correctness owner, or recovery branch.
- Preserve later edits for the next queued cycle rather than blocking an ordinary match because its observation is no longer the latest filesystem state.

## Regression coverage

- Strengthen the existing no-I/O match test to monitor `stat()` as well as `read()`.
- Verify publication of the admitted observation despite a later local edit and rejection of a stale SyncRecord CAS.
- Verify ordered-component matches retain endpoint verification and prefix blocking.
- Exercise the real orchestrator with edits after Admission and after publication: the first cycle records the original observation and the queued cycle pushes the edit, even when size and mtime are unchanged.
- Mutation check: temporarily routing independent matches back through effect verification causes three regression tests to fail; restoring the fix returns them to green.

## Verification

- `npm run lint`
- `npm run lint:bot-repro` (55 structural/reproduction tests and dependency-boundary source scans)
- `npm run build`
- `npm run test:coverage` — 1,878 tests across 90 files passed
- Test-weakening guard: no findings
- `git diff --check`

## Limits

The operation-count regression is verified: independent match execution performs zero additional local/remote `stat()` calls instead of two each. Acquisition-time hashing and optional merge-base content storage are unchanged. This build has not been deployed to a real vault, and real-vault latency improvement has not been measured. No schema bump or release is included.
