### PR TITLE
Make OAuth token publication atomic

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -315,6 +315,15 @@ The remote delta cursor is crash-safe at the **filesystem** layer, not the provi
 
 `settings.backendData` is a single flat bag holding **only the active backend's** parameters (tokens live in `SecretStorage`, keyed per backend — never in `backendData`). Switching backends hard-resets it: all params are wiped and every registered backend's plugin-owned secrets are swept (`clearPluginSecrets`), so the new backend starts disconnected and can't reuse another's token under the wrong OAuth client.
 
+OAuth completion and refresh-token rotation publish required refresh credentials at
+the token-acquisition boundary. A nonempty candidate is successful only when the same
+SecretStorage key immediately reads back the exact candidate; until then, response
+access/expiry state and completion effects are not reusable. This synchronous check is
+the strongest boundary exposed by Obsidian's API, not proof of an OS-level disk flush.
+Dropbox/OneDrive custom PKCE attempts also persist a nonsecret client/authority snapshot
+beside their pending state and verifier so callback exchange cannot drift with settings
+edited after authorization started.
+
 Remote-vault binding is **explicit**, not automatic on connect. After auth the user either binds the convention folder `obsidian-air-sync/<Vault Name>` (`BackendManager.bindDefaultRemoteVault` → `resolveRemoteVault`, which find-or-creates it and migrates a legacy `obsidian-air-sync/<uuid>` vault if one matches) or picks any folder via Google Picker (`provider.picker`: current built-in versions use the top-level OAuth Picker and finish through `completeWebFolderPick`; older released versions retain their hosted PickerBuilder client). Custom OAuth has no Picker and takes an explicit folder ID. Dropbox and OneDrive use an in-app modal instead. The folder is the sole binding; there is no `.airsync/metadata.json`. See [docs/google-drive-backend.md](docs/google-drive-backend.md) for the Google Drive specifics.
 
 ### IAuthProvider (fs/auth.ts)

--- a/docs/changes/change-20260906-oauth-authentication-publication/change.md
+++ b/docs/changes/change-20260906-oauth-authentication-publication/change.md
@@ -1,0 +1,96 @@
+---
+id: change-20260906-oauth-authentication-publication
+kind: change
+title: Make OAuth authentication publication fail closed
+status: active
+created: '2026-09-06'
+profile: sdd@1
+intent: Make OAuth completion, refresh rotation, callback ingress, and relay response
+  validation fail closed without creating another credential owner.
+outcomes:
+- All six refresh-based OAuth completion paths report success only after the required
+  refresh credential is immediately readable from SecretStorage.
+- Shared and detached refresh-token rotations publish before any response state is
+  reusable, independently of sync-cycle closeout.
+- Callback denial, static state, Google relay, and pCloud relay inputs are validated
+  at their production trust boundaries with bounded secret-free failures.
+- Custom Dropbox and OneDrive exchanges retain the authorization attempt's original
+  client identity across settings edits and plugin reload.
+scope:
+- src/fs/
+- src/main.ts
+- ARCHITECTURE.md
+- docs/dropbox-backend.md
+- docs/onedrive-backend.md
+- docs/google-drive-backend.md
+- docs/e2e-testing.md
+- docs/bugs/dropbox-built-in-user-limit.md
+- docs/changes/change-20260906-oauth-authentication-publication/
+non_goals:
+- Deploying the Worker or Pages callback
+- Changing CI workflows or Google transport-exception behavior
+- Adding a plugin-owned credential store, journal, migration, or recovery queue
+- Claiming OS-level physical secret durability from synchronous API readback
+change_classes:
+- behavior
+- boundary
+- invariant
+- internal_design
+governance:
+  gate: auto
+  reasons: []
+members:
+- role: requirements
+  path: changes/change-20260906-oauth-authentication-publication/requirements.md
+  required: true
+- role: implementation
+  path: changes/change-20260906-oauth-authentication-publication/implementation.md
+  required: true
+- role: verification
+  path: changes/change-20260906-oauth-authentication-publication/verification.md
+  required: true
+promotion:
+- action: none
+  reason: This change repairs existing OAuth and callback trust boundaries without
+    changing the plugin's durable sync-state authority or introducing a new public
+    capability; current invariants remain documented in the change package and existing
+    architecture/authentication guidance.
+unresolved_decisions: []
+tags: []
+owners: []
+relations: []
+source_paths:
+- src/fs/token-store.ts
+- src/fs/oauth-pkce.ts
+- src/fs/pkce-auth-provider.ts
+- src/fs/googledrive/auth-provider-base.ts
+- src/main.ts
+- docs/changes/change-20260906-oauth-authentication-publication/
+summary: Fail closed across OAuth credential publication, attempt identity, and callback/relay
+  trust boundaries in the plugin and companion auth repository.
+updated: '2026-09-06'
+---
+
+## Summary
+
+Repair seven independently reproduced OAuth/authentication roots across the plugin
+and relay repositories. Required credentials use exact synchronous SecretStorage
+readback as the automated publication boundary; native restart durability remains a
+separate manual observation.
+
+## Closure Notes
+
+Source implementation and automated repository gates are complete. Relay deployment is
+explicitly excluded. Native restart continuity and Dropbox's provider-console/new-account
+acceptance remain unverified external evidence, so this change stays active rather than
+claiming full closure.
+
+
+{% transition from="draft" to="ready" date="2026-09-06" %}
+Integrated design approved; implementation contract has no open decisions.
+{% /transition %}
+
+
+{% transition from="ready" to="active" date="2026-09-06" %}
+Source fixes and automated verification are in progress; native restart and provider-console evidence remain separate.
+{% /transition %}

--- a/docs/changes/change-20260906-oauth-authentication-publication/design-plan/design.md
+++ b/docs/changes/change-20260906-oauth-authentication-publication/design-plan/design.md
@@ -1,0 +1,159 @@
+# OAuth authentication publication — integrated design
+
+Revision `oauth-authentication-publication-r1`. This plan adopts draft B as the structural winner and grafts draft A's explicit provisional-manager disposal rule. It is grounded in the seven accepted roots in `investigation-2.json`, the eight reviewed critique issues in `critique.json`, and the two user-approved boundaries in `approved-decisions.md`. Plugin source is `/workspace/obsidian-air-sync`; relay evidence was read from the same-revision mirror `/tmp/obsidian-air-sync-auth`, while implementation targets `/workspace/obsidian-air-sync-auth` at verified revision `68bf84510a7ee81738355a14ea66e5e1faca69d3` or its descendant. Source and repository-owned tests are in scope. Worker/Pages deployment, CI workflow changes, Google transport-exception behavior, and claims of OS/process-restart durability are outside scope.
+
+## Requirements
+
+<!-- anchor: req-completion-publication -->
+`req-completion-publication` (FR, must): Google built-in/custom, Dropbox built-in/custom, and OneDrive built-in/custom completion resolves only after a required refresh credential is immediately readable under its existing SecretStorage key. A returned nonempty refresh token is the required candidate; only an equal readback proves it. If the response omits refresh_token, a previously readable nonempty refresh token remains sufficient for reauthorization. Fresh authorization with neither fails.
+
+<!-- anchor: req-rotation-publication -->
+`req-rotation-publication` (FR, must): every changed refresh token from shared or detached managers is published and read back before access, expiry, or refresh state from that response becomes reusable. Sync closeout success or failure cannot decide credential publication.
+
+<!-- anchor: req-attempt-identity -->
+`req-attempt-identity` (FR, must): each custom Dropbox/OneDrive attempt snapshots its client ID and, for OneDrive, authority at start. Authorization and exchange use that exact snapshot despite later settings edits; missing or inconsistent snapshot data rejects before exchange.
+
+<!-- anchor: req-google-wire -->
+`req-google-wire` (FR, must): Google callback and refresh handlers validate every HTTP-success JSON response as a non-null, non-array object with nonempty string `access_token`, finite positive numeric `expires_in`, and optional string `refresh_token` before projection. Transport exceptions retain current behavior.
+
+<!-- anchor: req-authorization-denial -->
+`req-authorization-denial` (FR, must): Google worker, pCloud worker, static callback, and plugin protocol ingress detect authorization denial before success-only gates. `access_denied` projects to `Authorization was denied.`; every other nonempty error code projects to `Authorization failed (<code>).`; `error_description`, `error_uri`, and other parameters never contribute text. Channel wrappers may differ, semantic code/message may not.
+
+<!-- anchor: req-static-state -->
+`req-static-state` (FR, must): static callback accepts state only when decoding/parsing yields a non-null, non-array object with string `app` and `nonce`, and `app` is an own allowlisted key. Base64url and legacy base64 remain supported and successful forwarding preserves the exact raw state.
+
+<!-- anchor: req-pcloud-wire -->
+`req-pcloud-wire` (FR, must): pCloud HTTP success requires a non-null, non-array object with numeric `result === 0` and nonempty string long-lived `access_token`; no refresh or expiry is required. Region host allowlist and existing upstream/logical-error behavior remain.
+
+<!-- anchor: req-compatibility-security -->
+`req-compatibility-security` (NFR, must): preserve all six secret namespaces, pending verifier/state reload, Picker `picked_file_ids`, detached-manager isolation, current token-endpoint diagnostic channels, mobile compatibility, and secrets-outside-settings. Never put credentials or provider descriptions in settings, sync state, notices, logs, HTML, or new errors.
+
+<!-- anchor: req-source-verification -->
+`req-source-verification` (NFR, must): both repositories own executable tests over production boundaries and pass source gates. Immediate SecretStorage equality is testable locally; restart durability is a separately recorded native checklist. Deployment and CI workflow adoption are not performed or claimed.
+
+## Grounded components
+
+<!-- anchor: component-secret-publication -->
+`component-secret-publication` is the existing plugin `src/fs/token-store.ts` boundary over injected `ISecretStore`. It owns key construction and the required candidate-equal operation; no new credential owner is added.
+
+<!-- anchor: component-auth-providers -->
+`component-auth-providers` is the existing Google and shared PKCE auth-provider bases plus completion callers. It owns provisional completion-manager lifetime, candidate selection, attempt snapshot capture/validation, and the success boundary before save/reset/filesystem/folder selection.
+
+<!-- anchor: component-token-manager -->
+`component-token-manager` is `BaseOAuthTokenManager` and the Google/shared-PKCE factories. It owns response installation ordering and the shared/detached rotation hook. The two cycle `readBackendState` paths cease being refresh-token writers and retain only optional access/expiry projection.
+
+<!-- anchor: component-denial-policy -->
+`component-denial-policy` is the semantic owner for the exact two-case denial projection. The plugin keeps a small pure helper; relay/static implementations reproduce the same contract locally because no cross-repository runtime package is warranted. Google relay, pCloud relay, static callback, and plugin protocol handler are enforcement producers, not independent policy owners.
+
+<!-- anchor: component-google-relay -->
+`component-google-relay` is relay `worker/src/oauth.ts` and its router seam. It owns Google HTTP-success response validation and worker denial enforcement; outbound fetch is replaceable in tests.
+
+<!-- anchor: component-pcloud-relay -->
+`component-pcloud-relay` is relay `worker/src/pcloud.ts` and its router seam. It owns the access-only response boundary, regional host restriction, and worker denial enforcement.
+
+<!-- anchor: component-static-callback -->
+`component-static-callback` is relay `docs/callback/index.html`. It owns decode/schema/own-key/redirect ordering and local denial rendering; tests execute its actual inline script.
+
+<!-- anchor: component-relay-harness -->
+`component-relay-harness` is a planned repository-owned Node test/typecheck surface under relay `worker/`; it runs production handlers/static script without credentials, deployment, global packages, or `/tmp` harness dependency.
+
+## Invariants
+
+<!-- anchor: invariant-secrets-outside-settings -->
+`invariant-secrets-outside-settings`: refresh/access credentials remain exclusively in SecretStorage or ephemeral manager/call memory. Settings may contain nonsecret expiry, pending state/verifier, and custom attempt identity snapshot; sync checkpoint/state and diagnostics contain no credential copy. This traces to `req-compatibility-security`.
+
+<!-- anchor: invariant-candidate-equality -->
+`invariant-candidate-equality`: required publication succeeds only when the exact nonempty candidate is synchronously returned by `getSecret` immediately after `setSecret`. Old presence cannot prove a different candidate; a thrown, missing, or unequal readback fails closed. This traces to `req-completion-publication`, `req-rotation-publication`, and the approved SecretStorage boundary.
+
+## Implementation contracts
+
+<!-- anchor: contract-secret-publication -->
+`contract-secret-publication` owns the common mechanism. Input `input-required-candidate` is produced by a validated provider response, is opaque and stack-bounded, and is needed before completion/rotation success. Input `input-secret-readback` is produced synchronously by the injected store at the existing key and is needed immediately. Rule `rule-candidate-equal` writes the exact candidate then compares exact readback. Determinate equal yields `observable-publication-success`; missing/unequal (`conflicting`) or read/write exception (`unknown`) yields `failure-secret-publication`, a fixed secret-free authentication error. No retry, rollback, settings copy, async adapter, or physical-durability assertion is introduced. The existing optional secret setter/clear behavior and namespaces remain compatible. Normal witness: a fresh candidate reads back identically. Adversarial witnesses: dropped write over empty or old storage, stale read, throwing adapter, and a sentinel-bearing thrown cause all reject without exposing the sentinel. `verify-secret-publication` is T0.
+
+<!-- anchor: contract-completion-publication -->
+`contract-completion-publication` is owned by `component-auth-providers`. After state/PKCE and token-response validation, exchange occurs on a provisional manager that is not installed as the provider's reusable manager. Completion selects a fresh returned refresh candidate, otherwise the existing readable refresh; it proves `contract-secret-publication` before returning nonsecret updates or installing/reusing the manager. Fresh candidate has precedence: old presence never masks a dropped replacement. Missing both gives `failure-refresh-missing`; publication uncertainty gives `failure-secret-publication`. On any post-exchange publication failure, discard the provisional manager and all newly acquired in-memory access/refresh/expiry state; a later call must start a fresh explicit attempt and cannot use a fast path. No resolved updates, save, reset, filesystem construction, Picker selection, or success Notice occurs. Existing pending fields/snapshot remain until a new explicit attempt; reuse of a consumed code is not promised. Normal/retained witnesses span all six variants. Adversarial witnesses include missing initial refresh, dropped replacement over old secret, throwing store, and a second access/completion attempt proving no unpublished response reuse. Verification is `verify-six-completions` and `verify-completion-side-effects`.
+
+<!-- anchor: contract-rotation-publication -->
+`contract-rotation-publication` is owned by `component-token-manager`. Input is one validated refresh response and the manager's previous refresh identity. An absent/unchanged refresh keeps current behavior. For a changed nonempty refresh, the async rotation hook must complete candidate-equal publication before any access/expiry/refresh field from the response is installed and before the refresh promise resolves. A hook failure installs none of that response and propagates the safe publication failure; a second `getAccessToken` cannot return its access token. All shared and detached factories wire the hook. Required refresh writes are removed from both late `readBackendState` paths so checkpoint flush cannot suppress publication and a stale shared snapshot cannot overwrite a detached rotation. Existing refresh dedup/cooldown and sync commit/abort ordering remain; no cross-manager serialization, rollback, recovery state, or extra network call is promised. One write/read occurs only on actual rotation. Verification covers four shared/detached paths, failed-publication second calls, unchanged hook counts, and rotation followed by checkpoint failure.
+
+<!-- anchor: contract-attempt-identity -->
+`contract-attempt-identity` is owned by `component-auth-providers`. `startAuth` captures a nonsecret immutable `pendingAuthIdentity` snapshot from the same effective identity used to build the URL: provider kind, custom client ID, and OneDrive authority where applicable. It returns/persists that snapshot with pending state/verifier and constructs a provisional attempt manager from it. At callback, pending state, verifier, and snapshot are read once from active `backendData`. Missing fields, wrong provider/kind, empty custom client ID/authority, or mismatch between an existing attempt manager's recorded identity and the snapshot yields `failure-attempt-identity` before any token request. Current editable settings are not the exchange authority; the exact snapshot constructs/reconstructs the provisional manager after reload, so intervening settings edits do not change exchange identity. A new `startAuth` replaces the prior attempt snapshot/manager/state. Built-in fixed identities follow the same representation with their fixed values; connected-manager lifetime remains unchanged. Tests capture both next authorize URL and exchange request after prior exchange failure/settings edits, plus reload and mismatch/no-network controls.
+
+<!-- anchor: contract-google-wire -->
+`contract-google-wire` is owned by `component-google-relay`. An HTTP-success body is parsed as unknown and accepted only by `req-google-wire`; absent refresh remains valid and empty refresh is omitted. Valid callback preserves raw state and Picker IDs; valid refresh emits only accepted fields. Invalid JSON/shape yields `failure-google-token-shape`: fixed callback HTML or `{error:"invalid_token_response"}` JSON with HTTP 502 and no upstream value. Existing non-2xx mapping and transport-exception behavior are unchanged. Normal witness includes missing/rotated refresh; adversarial tests include null, array, bad JSON, missing/empty/nonstring access, nonfinite/nonpositive expiry, wrong refresh type, and sentinels absent from output.
+
+<!-- anchor: contract-authorization-denial -->
+`contract-authorization-denial` is owned by `component-denial-policy` and enforced at all four ingresses. Input is only the current untrusted `error` query value; `error_description`, `error_uri`, code/token/state dumps and provider text are ignored. A nonempty `access_denied` maps exactly to code `access_denied` and message `Authorization was denied.`; any other nonempty code maps to its same text-safe code and `Authorization failed (<code>).`. HTML escapes it and static/plugin paths use text-only presentation. Error presence wins over code/access token/Picker fields and causes zero exchange/completion/folder-selection/mutation.
+
+For plugin ingress, `input-active-pending-state` is acquired once at protocol-handler invocation from the normalized active settings bag `this.settings.backendData.pendingAuthState`; that active bag is the sole producer/authority. Only a nonempty string exactly equal to raw `params.state` permits the denial Notice. Missing, nonstring, unequal, or backend-switched state has no Notice and no manager dispatch or other side effect. Worker/static may render their bounded denial only after their own state shape and own allowlisted app target checks; they do not claim CSRF authority. Matching semantic inputs must yield identical code/message across Worker, static, and plugin aside from channel wrappers. Tests cover mixed error+success, malicious descriptions, markup/oversized text safety, matching/mismatching/missing plugin state, and zero effect counts.
+
+<!-- anchor: contract-static-state -->
+`contract-static-state` is owned by `component-static-callback`. Decode base64url or legacy base64, parse, require a non-null non-array object with string app/nonce, then check own allowlist membership before lookup or redirect. Decode/schema failures produce fixed invalid-state text; valid unknown app produces fixed unknown-app text. Neither redirects nor throws. Valid input forwards the exact original state and allows extra existing fields. Prototype-like app names must fail. Verification executes the production inline script for both encodings and malformed shapes.
+
+<!-- anchor: contract-pcloud-wire -->
+`contract-pcloud-wire` is owned by `component-pcloud-relay`. The already allowlisted/defaulted US/EU host produces the upstream body. JSON must be a non-null, non-array object with numeric result. Nonzero result remains HTTP 400 logical failure; zero requires a nonempty string access token. Invalid JSON/shape/zero-without-token yields fixed secret-free HTTP 502. Existing network/upstream status behavior, raw state handoff, hostname output, default US and EU selection remain. No refresh/expiry or universal schema is introduced. Tests prove invalid host makes no request and valid access-only responses succeed.
+
+<!-- anchor: contract-repository-verification -->
+`contract-repository-verification` is owned by `component-relay-harness`. Plugin gate is `npm run lint && npm run lint:bot-repro && npm run build && npm run test:coverage`. Relay owns `npm test` and `npm run typecheck` scripts exercising production handlers and static source after a clean install. No CI workflow edit is required. Contract evolution is additive validation/fail-closed handling only: keys, endpoints, valid callbacks, state encodings, pCloud valid shape, and cross-version valid flows remain compatible; rollback needs no data migration. Real-device checklist records completion, restart continuity, observed rotation without token capture, and second restart on representative desktop/mobile; unexecuted cases remain unverified. Worker/Pages deployment remains separately authorized.
+
+## ADR decisions
+
+<!-- anchor: adr-sync-state-separation -->
+`adr-sync-state-separation` applies accepted ADR 0001: auth credentials never become sync checkpoint/cache/record state, and moving rotation publication earlier must not change sync lifecycle ownership.
+
+<!-- anchor: adr-shared-behaviour-tests -->
+`adr-shared-behaviour-tests` applies accepted ADR 0002 to production-boundary fixtures and discriminating controls; no filesystem family is added.
+
+<!-- anchor: adr-live-e2e-boundary -->
+`adr-live-e2e-boundary` applies accepted ADR 0003: fakes/source tests do not establish native restart durability or deployed relay parity.
+
+<!-- anchor: adr-auth-publication-boundary -->
+`adr-auth-publication-boundary` fixes required refresh publication at completion/token-acquisition rather than late sync snapshots. This is accepted for this change by the user's immediate-readback approval. It preserves SecretStorage ownership, shared/detached isolation, and candidate equality; it rejects async adapters, journals, checkpoint ownership, blind writes, and old-secret fallback for a different candidate.
+
+<!-- anchor: adr-callback-trust-boundaries -->
+`adr-callback-trust-boundaries` fixes provider-local runtime validators and one semantic denial policy owner with local enforcement copies. It accepts an attempt-scoped nonsecret identity snapshot because authorize/exchange identity must survive settings edits/reload; it rejects a universal OAuth schema/package, provider-description reflection, current-settings exchange identity, and deployment coupling.
+
+## Units
+
+`unit-auth-publication` (chunk 1) implements required publication, provisional completion-manager disposal, async rotation ordering, all shared/detached factory hooks, late refresh-writer removal, focused token/provider/caller/orchestrator tests, and ownership docs. It changes no sync authority/order, key namespace, migration, rollback, recovery state, or physical durability claim.
+
+`unit-attempt-identity` (chunk 2, after unit-auth-publication because `pkce-auth-provider.ts` overlaps) adds the typed pending identity snapshot, start/callback/reload validation, provisional manager construction, and Dropbox/OneDrive request-capture mismatch tests. No secret or general identity cache is added.
+
+`unit-relay-validation` (chunk 2, independent) adds Google/pCloud local validators, worker denial enforcement, repository-owned tests/scripts, and relay README correction. It makes no deployment, transport-exception, CI workflow, new endpoint, or pCloud refresh change.
+
+`unit-callback-ingress` (chunk 3, after denial policy foundations) adds the pure plugin projection/correlation seam, protocol tests, static state/denial handling, and production-script tests. No new deep-link error protocol or arbitrary provider text is added.
+
+`unit-final-verification` (chunk 4) runs both source gates, updates plugin architecture/auth docs and relay README, records the native checklist as executed or unverified, and reports deployment as not performed.
+
+## Acceptance
+
+`acceptance-seven-roots`: all seven causal roots have discriminating green repository-owned tests and compatibility controls, with failures observed at their owning boundary and no downstream success effect.
+
+`acceptance-publication-before-reuse`: dropped/unequal/throwing writes reject completion/rotation, discard provisional or uninstalled response state, and cannot be reused by a later fast path; checkpoint outcome is irrelevant.
+
+`acceptance-attempt-snapshot`: settings edits between start and callback do not alter exchange identity; missing/inconsistent snapshot makes zero token requests and no auth success effects.
+
+`acceptance-denial-parity`: matching denial produces exact cross-runtime semantics; plugin shows it only for an exact current active pending-state match, otherwise has no side effect; provider descriptions and sentinels never appear.
+
+`acceptance-owned-gates`: plugin and relay gates run without `/tmp` harnesses, credentials, deployment, global package dependence, or CI workflow changes.
+
+`acceptance-native-boundary`: only immediate equality is claimed by automated tests; restart durability is supported by recorded device evidence or explicitly remains unverified.
+
+## Decision closure and critique resolution
+
+All recovered decision inputs are closed in `spine.yaml`; no consequential design choice or open question remains. Private helper/test-fixture naming alone is delegated, and must preserve the two named invariants and owning contract verification.
+
+`resolved_issues[]` trace (all `verdict:Y` findings):
+
+- `issue_ref: issue-completion-manager-retention` — provisional manager non-installation/disposal plus second-call witness.
+- `issue_ref: issue-attempt-config-drift-open` — start-time persisted nonsecret identity snapshot and pre-exchange rejection.
+- `issue_ref: issue-denial-owner-split` — one `component-denial-policy` owner with four enforcement producers.
+- `issue_ref: issue-denial-projection-open` — the exact two-case message contract.
+- `issue_ref: issue-denial-state-source-gap` — one active-backend pending-state read at handler entry and silent no-effect mismatch.
+- `issue_ref: issue-dangling-invariant-refs` — two anchored, requirement-backed invariant definitions.
+- `issue_ref: issue-google-network-scope-broadening` — transport exceptions explicitly preserved.
+- `issue_ref: issue-ci-gate-unowned` — workflow obligations removed.
+
+Every reviewed issue is substantively closed rather than renamed or deferred.
+
+The retained scope expansions are only the shared rotation boundary, nonsecret pending identity snapshot, pCloud malformed-success classification, repository-owned relay tests, native checklist, and the critic-induced denial-policy owner. Each traces directly to an accepted root or user-approved evidence boundary. No deployment or production mutation is authorized.

--- a/docs/changes/change-20260906-oauth-authentication-publication/design-plan/spine.yaml
+++ b/docs/changes/change-20260906-oauth-authentication-publication/design-plan/spine.yaml
@@ -1,0 +1,351 @@
+artifact: design-plan-spine
+version: 2
+granularity_profile: boundary-complete
+
+scope_expansion_signals:
+  - id: scope-signal-rotation-boundary
+    kind: shared_boundary
+    target_ref: contract-rotation-publication
+    witness: Required refresh publication moves from late cycle snapshots to shared token acquisition for every shared and detached manager.
+    requirement_refs: [req-rotation-publication, req-compatibility-security]
+    authority_refs: [investigation-2.json#hypothesis-d2-rotation-publication, approved-decisions.md]
+  - id: scope-signal-attempt-snapshot
+    kind: persistent_state
+    target_ref: contract-attempt-identity
+    witness: A nonsecret pending identity snapshot is persisted with state/verifier so authorize and exchange remain identical across settings edits and reload.
+    requirement_refs: [req-attempt-identity, req-compatibility-security]
+    authority_refs: [approved user direction, critique.json#issue-attempt-config-drift-open]
+  - id: scope-signal-pcloud-http-repair
+    kind: compatibility_operation
+    target_ref: contract-pcloud-wire
+    witness: Malformed pCloud HTTP-success bodies become fixed 502 failures while valid access-only and logical-error behavior remain compatible.
+    requirement_refs: [req-pcloud-wire, req-compatibility-security]
+    authority_refs: [recovery.json#discovered-legacy-pcloud-boundary]
+  - id: scope-signal-repo-owned-relay-tests
+    kind: operational_procedure
+    target_ref: contract-repository-verification
+    witness: The relay repository gains owned test/typecheck commands because accepted RED evidence otherwise exists only in an external harness.
+    requirement_refs: [req-source-verification]
+    authority_refs: [investigation-2.json#harness_gaps, approved-decisions.md]
+  - id: scope-signal-native-checklist
+    kind: operational_procedure
+    target_ref: acceptance-native-boundary
+    witness: Real-device restart evidence is separated from the synchronous readback guarantee because the native API supplies no physical-durability contract.
+    requirement_refs: [req-source-verification]
+    authority_refs: [approved-decisions.md, recovery.json#unknown-native-secret-persistence]
+  - id: scope-signal-denial-owner
+    kind: critic_induced_contract
+    target_ref: component-denial-policy
+    witness: One semantic owner fixes exact denial parity across four local enforcement sites and closes the reviewed owner split.
+    requirement_refs: [req-authorization-denial, req-compatibility-security]
+    authority_refs: [critique.json#issue-denial-owner-split, approved user direction]
+
+requirements:
+  - id: req-completion-publication
+    type: FR
+    priority: must
+    statement: All six refresh-based OAuth completions require immediate candidate-equal SecretStorage readback; an existing readable refresh satisfies an omitted replacement only.
+  - id: req-rotation-publication
+    type: FR
+    priority: must
+    statement: Changed refresh candidates from shared and detached managers publish before any state from that response is reusable, independently of sync closeout.
+  - id: req-attempt-identity
+    type: FR
+    priority: must
+    statement: Custom PKCE authorize and exchange use one start-time identity snapshot; missing or inconsistent snapshot data rejects before exchange.
+  - id: req-google-wire
+    type: FR
+    priority: must
+    statement: Both Google relay HTTP-success handlers validate the provider-local token shape before projection while preserving transport-exception behavior.
+  - id: req-authorization-denial
+    type: FR
+    priority: must
+    statement: Four callback ingresses detect denial before success gates and apply the same exact error-code projection without provider descriptions.
+  - id: req-static-state
+    type: FR
+    priority: must
+    statement: Static callback validates object/string state and own app membership while preserving both encodings and exact raw forwarding.
+  - id: req-pcloud-wire
+    type: FR
+    priority: must
+    statement: Legacy pCloud validates its distinct access-only success shape while retaining host, region, logical-error and refresh-free behavior.
+  - id: req-compatibility-security
+    type: NFR
+    priority: must
+    statement: Preserve secret namespaces, reload, Picker, detached-manager, diagnostics and mobile contracts; keep credentials and provider descriptions out of durable nonsecret state and output.
+  - id: req-source-verification
+    type: NFR
+    priority: must
+    statement: Both repositories own executable source tests and gates; deployment, CI workflow changes and physical restart durability remain separately authorized or evidenced.
+  - id: invariant-secrets-outside-settings
+    type: invariant
+    priority: must
+    statement: Credentials remain only in SecretStorage or ephemeral manager memory and never in settings, sync state, or diagnostic output.
+  - id: invariant-candidate-equality
+    type: invariant
+    priority: must
+    statement: Required publication succeeds only when synchronous immediate readback equals the exact nonempty candidate.
+
+components:
+  - id: component-secret-publication
+    kind: existing
+    contract_refs: [contract-secret-publication]
+    paths: [src/fs/token-store.ts, src/fs/secret-store.ts, src/fs/token-store.test.ts]
+  - id: component-auth-providers
+    kind: existing
+    contract_refs: [contract-completion-publication, contract-attempt-identity]
+    paths: [src/fs/googledrive/auth-provider-base.ts, src/fs/pkce-auth-provider.ts, src/fs/backend-manager.ts, src/fs/backend-auth-folder-pick.ts]
+  - id: component-token-manager
+    kind: existing
+    contract_refs: [contract-rotation-publication]
+    paths: [src/fs/oauth-pkce.ts, src/fs/googledrive/provider-base.ts, src/fs/pkce-app-folder-provider.ts]
+  - id: component-denial-policy
+    kind: planned
+    contract_refs: [contract-authorization-denial]
+    paths: [src/fs/oauth-callback-error.ts, src/main.ts, /tmp/obsidian-air-sync-auth/worker/src/oauth.ts, /tmp/obsidian-air-sync-auth/worker/src/pcloud.ts, /tmp/obsidian-air-sync-auth/docs/callback/index.html]
+  - id: component-google-relay
+    kind: existing
+    contract_refs: [contract-google-wire, contract-authorization-denial]
+    paths: [/tmp/obsidian-air-sync-auth/worker/src/oauth.ts, /tmp/obsidian-air-sync-auth/worker/src/index.ts]
+  - id: component-pcloud-relay
+    kind: existing
+    contract_refs: [contract-pcloud-wire, contract-authorization-denial]
+    paths: [/tmp/obsidian-air-sync-auth/worker/src/pcloud.ts, /tmp/obsidian-air-sync-auth/worker/src/index.ts]
+  - id: component-static-callback
+    kind: existing
+    contract_refs: [contract-static-state, contract-authorization-denial]
+    paths: [/tmp/obsidian-air-sync-auth/docs/callback/index.html]
+  - id: component-relay-harness
+    kind: planned
+    contract_refs: [contract-repository-verification]
+    paths: [/tmp/obsidian-air-sync-auth/worker/tests/oauth.test.mjs, /tmp/obsidian-air-sync-auth/worker/tests/pcloud.test.mjs, /tmp/obsidian-air-sync-auth/worker/tests/static-callback.test.mjs, /tmp/obsidian-air-sync-auth/worker/package.json]
+
+contracts:
+  - id: contract-secret-publication
+    dimension: required-secret-publication-postcondition
+    owner: component-secret-publication
+    requirement_refs: [req-completion-publication, req-rotation-publication, req-compatibility-security, invariant-secrets-outside-settings, invariant-candidate-equality]
+    unit_refs: [unit-auth-publication]
+    adr_refs: [adr-auth-publication-boundary, adr-sync-state-separation]
+    partition:
+      outcomes: [determinate, unknown, conflicting]
+      default_policy: Only exact immediate readback of the nonempty candidate succeeds; missing, unequal, throwing or unavailable readback fails safely.
+    verification:
+      - {id: verify-secret-publication, tier: T0, command: 'npm test -- --run src/fs/token-store.test.ts'}
+    discretion:
+      - id: discretion-publication-helper-factoring
+        unit_ref: unit-auth-publication
+        question: Name and locally factor the synchronous required-publication helper and fixtures.
+        scope:
+          files: [src/fs/token-store.ts, src/fs/token-store.test.ts]
+          component: component-secret-publication
+          visibility: private
+        escalate_when: [Changing key construction, equality, synchronous API shape, failure semantics, or credential ownership.]
+        constraints: [Preserve existing air-sync backend/name token keys and explicit clearing.]
+        preserves:
+          contract_refs: [contract-secret-publication]
+          invariant_refs: [invariant-secrets-outside-settings, invariant-candidate-equality]
+        verification_refs: [verify-secret-publication]
+  - id: contract-completion-publication
+    dimension: provisional-manager-completion-order
+    owner: component-auth-providers
+    requirement_refs: [req-completion-publication, req-compatibility-security]
+    unit_refs: [unit-auth-publication]
+    adr_refs: [adr-auth-publication-boundary]
+    partition:
+      outcomes: [determinate, unknown, conflicting]
+      default_policy: Missing initial refresh or unproved replacement rejects completion and discards the provisional manager before all success effects.
+    verification:
+      - {id: verify-six-completions, tier: T1, command: 'npm test -- --run src/fs/googledrive/auth-completion-audit.test.ts src/fs/dropbox/auth-completion-audit.test.ts src/fs/onedrive/auth-completion-audit.test.ts'}
+      - {id: verify-completion-side-effects, tier: T1, command: 'npm test -- --run src/fs/backend-manager.test.ts src/fs/backend-auth-folder-pick.test.ts'}
+  - id: contract-rotation-publication
+    dimension: publication-before-token-response-installation
+    owner: component-token-manager
+    requirement_refs: [req-rotation-publication, req-compatibility-security]
+    unit_refs: [unit-auth-publication]
+    adr_refs: [adr-auth-publication-boundary, adr-sync-state-separation]
+    partition:
+      outcomes: [determinate, unknown, conflicting]
+      default_policy: Unchanged or absent refresh keeps current behavior; changed refresh requires equal readback before installing any response state and otherwise fails closed.
+    verification:
+      - {id: verify-rotation-manager-order, tier: T1, command: 'npm test -- --run src/fs/oauth-pkce.test.ts src/fs/googledrive/auth-completion-audit.test.ts src/fs/dropbox/auth-completion-audit.test.ts src/fs/onedrive/auth-completion-audit.test.ts'}
+      - {id: verify-rotation-closeout-independence, tier: T1, command: 'npm test -- --run src/sync/orchestrator.test.ts'}
+  - id: contract-attempt-identity
+    dimension: persisted-attempt-scoped-client-identity
+    owner: component-auth-providers
+    requirement_refs: [req-attempt-identity, req-compatibility-security]
+    unit_refs: [unit-attempt-identity]
+    adr_refs: [adr-callback-trust-boundaries]
+    partition:
+      outcomes: [determinate, unknown, conflicting]
+      default_policy: A complete matching start-time identity snapshot is the sole exchange identity; missing or manager-mismatched snapshot rejects before network access.
+    verification:
+      - {id: verify-custom-attempt-identity, tier: T1, command: 'npm test -- --run src/fs/dropbox/auth-completion-audit.test.ts src/fs/onedrive/auth-completion-audit.test.ts src/fs/dropbox/auth.test.ts src/fs/onedrive/auth.test.ts'}
+  - id: contract-google-wire
+    dimension: provider-response-runtime-boundary
+    owner: component-google-relay
+    requirement_refs: [req-google-wire, req-compatibility-security]
+    unit_refs: [unit-relay-validation]
+    adr_refs: [adr-callback-trust-boundaries]
+    partition:
+      outcomes: [determinate, unknown]
+      default_policy: Invalid JSON or shape from an HTTP-success response becomes a fixed route-specific 502 without provider value projection; transport exceptions remain unchanged.
+    verification:
+      - {id: verify-google-relay-source, tier: T1, command: 'npm test --prefix /workspace/obsidian-air-sync-auth/worker'}
+  - id: contract-authorization-denial
+    dimension: exact-cross-runtime-denial-projection
+    owner: component-denial-policy
+    requirement_refs: [req-authorization-denial, req-compatibility-security]
+    unit_refs: [unit-relay-validation, unit-callback-ingress]
+    adr_refs: [adr-callback-trust-boundaries]
+    partition:
+      outcomes: [determinate, unknown, conflicting]
+      default_policy: access_denied maps to its fixed denial sentence; every other nonempty code maps to the fixed code-bearing sentence; plugin state unavailable or unequal produces no side effect.
+    verification:
+      - {id: verify-plugin-denial, tier: T1, command: 'npm test -- --run src/main-commands.test.ts src/fs/oauth-callback-error.test.ts'}
+      - {id: verify-relay-denial, tier: T1, command: 'npm test --prefix /workspace/obsidian-air-sync-auth/worker'}
+  - id: contract-static-state
+    dimension: callback-state-runtime-boundary
+    owner: component-static-callback
+    requirement_refs: [req-static-state, req-authorization-denial, req-compatibility-security]
+    unit_refs: [unit-callback-ingress]
+    adr_refs: [adr-callback-trust-boundaries]
+    partition:
+      outcomes: [determinate, unknown]
+      default_policy: Decode, parse, structural validation and own-entry allowlisting must all pass before redirect; every other state produces fixed bounded text without redirect or throw.
+    verification:
+      - {id: verify-static-production-script, tier: T1, command: 'npm test --prefix /workspace/obsidian-air-sync-auth/worker'}
+  - id: contract-pcloud-wire
+    dimension: provider-specific-access-token-boundary
+    owner: component-pcloud-relay
+    requirement_refs: [req-pcloud-wire, req-compatibility-security]
+    unit_refs: [unit-relay-validation]
+    adr_refs: [adr-callback-trust-boundaries]
+    partition:
+      outcomes: [determinate, unknown]
+      default_policy: Numeric nonzero result remains logical failure; malformed success or zero without nonempty access token becomes fixed bounded 502.
+    verification:
+      - {id: verify-pcloud-relay-source, tier: T1, command: 'npm test --prefix /workspace/obsidian-air-sync-auth/worker'}
+  - id: contract-repository-verification
+    dimension: source-owned-gates-and-claim-boundary
+    owner: component-relay-harness
+    requirement_refs: [req-source-verification, req-compatibility-security]
+    unit_refs: [unit-relay-validation, unit-callback-ingress, unit-final-verification]
+    adr_refs: [adr-shared-behaviour-tests, adr-live-e2e-boundary]
+    verification:
+      - {id: verify-plugin-gate, tier: T2, command: 'npm run lint && npm run lint:bot-repro && npm run build && npm run test:coverage'}
+      - {id: verify-relay-gate, tier: T2, command: 'npm test --prefix /workspace/obsidian-air-sync-auth/worker && npm run typecheck --prefix /workspace/obsidian-air-sync-auth/worker'}
+
+adrs:
+  - id: adr-sync-state-separation
+    status: accepted
+    decision_input_refs: [decision-input-secret-domain, decision-input-writers]
+  - id: adr-shared-behaviour-tests
+    status: accepted
+    decision_input_refs: [decision-input-adr]
+  - id: adr-live-e2e-boundary
+    status: accepted
+    decision_input_refs: [decision-input-native-proof, decision-input-deployment]
+  - id: adr-auth-publication-boundary
+    status: accepted
+    decision_input_refs: [decision-input-secret-publication, decision-input-completion-callers, decision-input-isolation, decision-input-writers]
+  - id: adr-callback-trust-boundaries
+    status: accepted
+    decision_input_refs: [decision-input-attempt-identity, decision-input-error-channels, decision-input-runtime-schemas, decision-input-denial-copy, decision-input-pcloud]
+
+units:
+  - title: unit-auth-publication
+    chunk: '1'
+    contract_refs: [contract-secret-publication, contract-completion-publication, contract-rotation-publication]
+    files: [src/fs/token-store.ts, src/fs/token-store.test.ts, src/fs/oauth-pkce.ts, src/fs/oauth-pkce.test.ts, src/fs/googledrive/auth-provider-base.ts, src/fs/googledrive/provider-base.ts, src/fs/pkce-auth-provider.ts, src/fs/pkce-app-folder-provider.ts, src/fs/googledrive/auth-completion-audit.test.ts, src/fs/dropbox/auth-completion-audit.test.ts, src/fs/onedrive/auth-completion-audit.test.ts, src/fs/backend-manager.test.ts, src/fs/backend-auth-folder-pick.test.ts, src/sync/orchestrator.test.ts, ARCHITECTURE.md, docs/google-drive-backend.md]
+    depends_on: []
+    acceptance: [All six completions reject unproved publication without success side effects or retained unpublished manager state., Four rotation routes publish before installation and remain independent of sync closeout., Late cycle refresh writes are removed without changing checkpoint ordering.]
+    objective: Establish one candidate-equal publication postcondition and move required rotation proof before token response reuse.
+    output_format: Production TypeScript, focused Vitest coverage, and ownership documentation.
+    tool_guidance: Use injected SecretStorage and real manager/provider code with controlled storage/request fixtures.
+    task_boundaries: No async secret API, journal, rollback, sync-state owner, extra provider request, migration, or durability claim.
+    decision_closure_reason: User approved immediate equality; provisional managers and pre-install hooks close retention and ordering.
+  - title: unit-attempt-identity
+    chunk: '2'
+    contract_refs: [contract-attempt-identity]
+    files: [src/fs/pkce-auth-provider.ts, src/fs/pkce-app-folder-provider.ts, src/fs/dropbox/provider-base.ts, src/fs/dropbox/provider-custom.ts, src/fs/onedrive/provider-base.ts, src/fs/onedrive/provider-custom.ts, src/fs/dropbox/auth.test.ts, src/fs/onedrive/auth.test.ts, src/fs/dropbox/auth-completion-audit.test.ts, src/fs/onedrive/auth-completion-audit.test.ts]
+    depends_on: [unit-auth-publication]
+    acceptance: [Start persists the exact nonsecret identity snapshot used by authorize., Callback/reload exchange uses that snapshot despite settings edits., Missing or inconsistent snapshot performs zero token requests.]
+    objective: Bind each PKCE authorize/exchange pair to one start-time identity snapshot.
+    output_format: Typed settings/lifecycle edits and production-path request-capture tests.
+    tool_guidance: Reuse custom-provider fixtures and assert actual authorize and token request identity.
+    task_boundaries: No secret copy, general identity cache, connected-settings redesign, or migration routine.
+    decision_closure_reason: The explicit user direction selects persisted start-time snapshot and pre-exchange rejection.
+  - title: unit-relay-validation
+    chunk: '2'
+    contract_refs: [contract-google-wire, contract-pcloud-wire, contract-authorization-denial, contract-repository-verification]
+    files: [/workspace/obsidian-air-sync-auth/worker/src/oauth.ts, /workspace/obsidian-air-sync-auth/worker/src/pcloud.ts, /workspace/obsidian-air-sync-auth/worker/src/index.ts, /workspace/obsidian-air-sync-auth/worker/src/html.ts, /workspace/obsidian-air-sync-auth/worker/tests/oauth.test.mjs, /workspace/obsidian-air-sync-auth/worker/tests/pcloud.test.mjs, /workspace/obsidian-air-sync-auth/worker/package.json, /workspace/obsidian-air-sync-auth/README.md]
+    depends_on: []
+    acceptance: [Malformed Google and pCloud successes reject with bounded route-specific failures., Denial is projected before exchange with exact semantic parity and no provider description., Owned test and typecheck scripts exercise production handlers.]
+    objective: Close relay trust boundaries with provider-local validators, exact denial projection, and owned tests.
+    output_format: Worker TypeScript, repository-owned Node tests/scripts, and corrected relay documentation.
+    tool_guidance: Mock only outbound fetch/environment; use no credentials or deployment.
+    task_boundaries: No deployment, CI workflow, Google transport-exception change, endpoint addition, universal OAuth schema, or pCloud refresh requirement.
+    decision_closure_reason: Exact denial messages and malformed-success classifications are fixed by approved scope and this contract.
+  - title: unit-callback-ingress
+    chunk: '3'
+    contract_refs: [contract-authorization-denial, contract-static-state, contract-repository-verification]
+    files: [src/main.ts, src/main-commands.test.ts, src/fs/oauth-callback-error.ts, src/fs/oauth-callback-error.test.ts, /workspace/obsidian-air-sync-auth/docs/callback/index.html, /workspace/obsidian-air-sync-auth/worker/tests/static-callback.test.mjs]
+    depends_on: [unit-relay-validation, unit-auth-publication]
+    acceptance: [Plugin Notice occurs only for exact current active pending-state match and denial causes no dispatch., Static malformed/prototype state fails without redirect or throw., Both encodings and exact raw state forwarding remain green.]
+    objective: Enforce denial correlation and structural state checks at browser/plugin ingress.
+    output_format: Lifecycle-thin plugin/static edits and production callback tests.
+    tool_guidance: Use one pure plugin helper and execute the actual inline static script.
+    task_boundaries: No callback framework, new deep-link wire format, provider-description reflection, state re-encoding, or pending-state clearing.
+    decision_closure_reason: Policy owner, exact projection, state source/time, and silent mismatch outcome are fixed.
+  - title: unit-final-verification
+    chunk: '4'
+    contract_refs: [contract-repository-verification]
+    files: [ARCHITECTURE.md, docs/google-drive-backend.md, /workspace/obsidian-air-sync-auth/README.md]
+    depends_on: [unit-auth-publication, unit-attempt-identity, unit-relay-validation, unit-callback-ingress]
+    acceptance: [Both source gates pass without external harnesses., Docs state immediate-readback and native-check limitations plus current/legacy callback paths., Deployment and unexecuted device checks remain explicitly unverified.]
+    objective: Verify seven repairs and preserve durable ownership and honest claim boundaries.
+    output_format: Gate evidence, scoped docs, promotion proposal, and native-checklist status.
+    tool_guidance: Run repository-owned commands; record executions and never infer deployed or native parity.
+    task_boundaries: No deployment, credential capture, CI edit, durability claim, or unrelated sync work.
+    decision_closure_reason: User approval explicitly separates source fixes from deployment and native persistence evidence.
+
+acceptance:
+  - id: acceptance-seven-roots
+    criteria: All seven accepted roots have discriminating green repository-owned tests and passing compatibility controls with no downstream success leakage.
+    requirement_refs: [req-completion-publication, req-rotation-publication, req-attempt-identity, req-google-wire, req-authorization-denial, req-static-state, req-pcloud-wire]
+  - id: acceptance-publication-before-reuse
+    criteria: Failed candidate readback discards completion managers or leaves refresh responses uninstalled, so later calls cannot reuse unpublished access and checkpoint outcome is irrelevant.
+    requirement_refs: [req-completion-publication, req-rotation-publication, req-compatibility-security]
+  - id: acceptance-attempt-snapshot
+    criteria: Settings edits cannot change an active attempt exchange identity; missing or inconsistent snapshots make zero token requests.
+    requirement_refs: [req-attempt-identity, req-compatibility-security]
+  - id: acceptance-denial-parity
+    criteria: Exact denial messages match across runtimes; plugin emits Notice only for current raw state equality, and no provider description or sentinel is exposed.
+    requirement_refs: [req-authorization-denial, req-compatibility-security]
+  - id: acceptance-owned-gates
+    criteria: Both source gates run without external harnesses, credentials, deployment, global packages or CI workflow changes.
+    requirement_refs: [req-source-verification]
+  - id: acceptance-native-boundary
+    criteria: Automated tests claim immediate equality only; restart durability has recorded device evidence or remains explicitly unverified.
+    requirement_refs: [req-source-verification, req-completion-publication, req-rotation-publication]
+
+dispositions:
+  - {decision_input_ref: decision-input-secret-publication, disposition: 'adopted: synchronous exact candidate readback; physical durability excluded', adr_refs: [adr-auth-publication-boundary], contract_refs: [contract-secret-publication]}
+  - {decision_input_ref: decision-input-secret-keys, disposition: 'adopted: preserve all existing namespaces, skip-empty and explicit clear', contract_refs: [contract-secret-publication]}
+  - {decision_input_ref: decision-input-secret-domain, disposition: 'adopted: SecretStorage remains credential authority outside settings and sync state', adr_refs: [adr-sync-state-separation], contract_refs: [contract-secret-publication]}
+  - {decision_input_ref: decision-input-completion-callers, disposition: 'adopted: reject before caller success effects and discard provisional manager', contract_refs: [contract-completion-publication]}
+  - {decision_input_ref: decision-input-isolation, disposition: 'adopted: preserve detached/shared instance isolation with the same publication contract', contract_refs: [contract-rotation-publication]}
+  - {decision_input_ref: decision-input-writers, disposition: 'adopted: publish at acquisition and remove late required-refresh writes', adr_refs: [adr-auth-publication-boundary], contract_refs: [contract-rotation-publication]}
+  - {decision_input_ref: decision-input-attempt-identity, disposition: 'adopted: persist and use the start-time nonsecret identity snapshot; reject missing or inconsistent snapshot before exchange', adr_refs: [adr-callback-trust-boundaries], contract_refs: [contract-attempt-identity]}
+  - {decision_input_ref: decision-input-state, disposition: 'adopted: preserve raw state, encodings, verifier correlation and reload with snapshot extension', contract_refs: [contract-attempt-identity, contract-static-state, contract-authorization-denial]}
+  - {decision_input_ref: decision-input-picker, disposition: 'adopted: preserve picked_file_ids and legacy hosted endpoint', contract_refs: [contract-google-wire, contract-completion-publication]}
+  - {decision_input_ref: decision-input-pcloud, disposition: 'adopted: retain access-only shape and regional/status semantics', contract_refs: [contract-pcloud-wire]}
+  - {decision_input_ref: decision-input-error-channels, disposition: 'adopted: change authorization denial/malformed success only; preserve other channels', contract_refs: [contract-authorization-denial, contract-google-wire, contract-pcloud-wire]}
+  - {decision_input_ref: decision-input-runtime-schemas, disposition: 'adopted: provider-local runtime predicates, no universal package', adr_refs: [adr-callback-trust-boundaries], contract_refs: [contract-google-wire, contract-static-state, contract-pcloud-wire]}
+  - {decision_input_ref: decision-input-static-docs, disposition: 'adopted: correct current versus legacy description without endpoint removal', contract_refs: [contract-static-state, contract-repository-verification]}
+  - {decision_input_ref: decision-input-denial-copy, disposition: 'adopted: access_denied fixed sentence; all other nonempty codes fixed code-bearing sentence; descriptions ignored', adr_refs: [adr-callback-trust-boundaries], contract_refs: [contract-authorization-denial]}
+  - {decision_input_ref: decision-input-native-proof, disposition: 'adopted evidence boundary: native restart checklist is separate and may remain unverified', contract_refs: [contract-secret-publication, contract-repository-verification]}
+  - {decision_input_ref: decision-input-deployment, disposition: 'rejected from scope: no Worker or Pages deployment or deployed-parity claim', contract_refs: [contract-repository-verification]}
+  - {decision_input_ref: decision-input-issue52, disposition: 'subsumed: test missing-candidate and failed-readback roots without claiming reporter attribution', contract_refs: [contract-completion-publication]}
+  - {decision_input_ref: decision-input-adr, disposition: 'adopted: accepted sync/test/e2e boundaries plus accepted user-approved auth ADRs', adr_refs: [adr-sync-state-separation, adr-shared-behaviour-tests, adr-live-e2e-boundary, adr-auth-publication-boundary, adr-callback-trust-boundaries], contract_refs: [contract-rotation-publication, contract-repository-verification]}

--- a/docs/changes/change-20260906-oauth-authentication-publication/implementation.md
+++ b/docs/changes/change-20260906-oauth-authentication-publication/implementation.md
@@ -1,0 +1,224 @@
+---
+change: change-20260906-oauth-authentication-publication
+role: implementation
+contracts:
+- contract-secret-publication
+- contract-completion-publication
+- contract-rotation-publication
+- contract-attempt-identity
+- contract-google-wire
+- contract-authorization-denial
+- contract-static-state
+- contract-pcloud-wire
+- contract-repository-verification
+contract_projections:
+- id: contract-secret-publication
+  verifications:
+  - verify-secret-publication
+  discretion:
+  - discretion-publication-helper-factoring
+- id: contract-completion-publication
+  verifications:
+  - verify-six-completions
+  - verify-completion-side-effects
+  discretion: []
+- id: contract-rotation-publication
+  verifications:
+  - verify-rotation-manager-order
+  - verify-rotation-closeout-independence
+  discretion: []
+- id: contract-attempt-identity
+  verifications:
+  - verify-custom-attempt-identity
+  discretion: []
+- id: contract-google-wire
+  verifications:
+  - verify-google-relay-source
+  discretion: []
+- id: contract-authorization-denial
+  verifications:
+  - verify-plugin-denial
+  - verify-relay-denial
+  discretion: []
+- id: contract-static-state
+  verifications:
+  - verify-static-production-script
+  discretion: []
+- id: contract-pcloud-wire
+  verifications:
+  - verify-pcloud-relay-source
+  discretion: []
+- id: contract-repository-verification
+  verifications:
+  - verify-plugin-gate
+  - verify-relay-gate
+  discretion: []
+adrs:
+- adr-sync-state-separation
+- adr-shared-behaviour-tests
+- adr-live-e2e-boundary
+- adr-auth-publication-boundary
+- adr-callback-trust-boundaries
+decision_dispositions:
+- decision_input_ref: decision-input-secret-publication
+  disposition: 'adopted: synchronous exact candidate readback; physical durability
+    excluded'
+  adr_refs:
+  - adr-auth-publication-boundary
+  contract_refs:
+  - contract-secret-publication
+- decision_input_ref: decision-input-secret-keys
+  disposition: 'adopted: preserve all existing namespaces, skip-empty and explicit
+    clear'
+  contract_refs:
+  - contract-secret-publication
+- decision_input_ref: decision-input-secret-domain
+  disposition: 'adopted: SecretStorage remains credential authority outside settings
+    and sync state'
+  adr_refs:
+  - adr-sync-state-separation
+  contract_refs:
+  - contract-secret-publication
+- decision_input_ref: decision-input-completion-callers
+  disposition: 'adopted: reject before caller success effects and discard provisional
+    manager'
+  contract_refs:
+  - contract-completion-publication
+- decision_input_ref: decision-input-isolation
+  disposition: 'adopted: preserve detached/shared instance isolation with the same
+    publication contract'
+  contract_refs:
+  - contract-rotation-publication
+- decision_input_ref: decision-input-writers
+  disposition: 'adopted: publish at acquisition and remove late required-refresh writes'
+  adr_refs:
+  - adr-auth-publication-boundary
+  contract_refs:
+  - contract-rotation-publication
+- decision_input_ref: decision-input-attempt-identity
+  disposition: 'adopted: persist and use the start-time nonsecret identity snapshot;
+    reject missing or inconsistent snapshot before exchange'
+  adr_refs:
+  - adr-callback-trust-boundaries
+  contract_refs:
+  - contract-attempt-identity
+- decision_input_ref: decision-input-state
+  disposition: 'adopted: preserve raw state, encodings, verifier correlation and reload
+    with snapshot extension'
+  contract_refs:
+  - contract-attempt-identity
+  - contract-static-state
+  - contract-authorization-denial
+- decision_input_ref: decision-input-picker
+  disposition: 'adopted: preserve picked_file_ids and legacy hosted endpoint'
+  contract_refs:
+  - contract-google-wire
+  - contract-completion-publication
+- decision_input_ref: decision-input-pcloud
+  disposition: 'adopted: retain access-only shape and regional/status semantics'
+  contract_refs:
+  - contract-pcloud-wire
+- decision_input_ref: decision-input-error-channels
+  disposition: 'adopted: change authorization denial/malformed success only; preserve
+    other channels'
+  contract_refs:
+  - contract-authorization-denial
+  - contract-google-wire
+  - contract-pcloud-wire
+- decision_input_ref: decision-input-runtime-schemas
+  disposition: 'adopted: provider-local runtime predicates, no universal package'
+  adr_refs:
+  - adr-callback-trust-boundaries
+  contract_refs:
+  - contract-google-wire
+  - contract-static-state
+  - contract-pcloud-wire
+- decision_input_ref: decision-input-static-docs
+  disposition: 'adopted: correct current versus legacy description without endpoint
+    removal'
+  contract_refs:
+  - contract-static-state
+  - contract-repository-verification
+- decision_input_ref: decision-input-denial-copy
+  disposition: 'adopted: access_denied fixed sentence; all other nonempty codes fixed
+    code-bearing sentence; descriptions ignored'
+  adr_refs:
+  - adr-callback-trust-boundaries
+  contract_refs:
+  - contract-authorization-denial
+- decision_input_ref: decision-input-native-proof
+  disposition: 'adopted evidence boundary: native restart checklist is separate and
+    may remain unverified'
+  contract_refs:
+  - contract-secret-publication
+  - contract-repository-verification
+- decision_input_ref: decision-input-deployment
+  disposition: 'rejected from scope: no Worker or Pages deployment or deployed-parity
+    claim'
+  contract_refs:
+  - contract-repository-verification
+- decision_input_ref: decision-input-issue52
+  disposition: 'subsumed: test missing-candidate and failed-readback roots without
+    claiming reporter attribution'
+  contract_refs:
+  - contract-completion-publication
+- decision_input_ref: decision-input-adr
+  disposition: 'adopted: accepted sync/test/e2e boundaries plus accepted user-approved
+    auth ADRs'
+  adr_refs:
+  - adr-sync-state-separation
+  - adr-shared-behaviour-tests
+  - adr-live-e2e-boundary
+  - adr-auth-publication-boundary
+  - adr-callback-trust-boundaries
+  contract_refs:
+  - contract-rotation-publication
+  - contract-repository-verification
+milestones:
+- id: '1'
+- id: '2'
+- id: '3'
+- id: '4'
+reference_algorithms: []
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Implementation
+
+## Decisions
+
+- SecretStorage remains the only durable credential owner. Required publication is a synchronous exact candidate write/readback postcondition; no plugin-owned credential store, journal, rollback, or async adapter is added.
+- Completion exchanges on a provisional manager. Only successful required publication permits the manager/result to become reusable; failure discards it.
+- Rotation publication moves into the existing token-manager response-acceptance hook and completes before response fields are installed. The shared Google/PKCE `readBackendState` paths stop writing refresh tokens.
+- Custom PKCE attempts persist a nonsecret identity snapshot at start. Callback/reload uses the snapshot, not current editable settings, and rejects incomplete/inconsistent identity before exchange.
+- One semantic denial policy owns the exact projection. Plugin, Google worker, pCloud worker, and static callback enforce local copies tested for equality; no cross-repository runtime package is introduced.
+- Provider-local runtime validators preserve Google and pCloud's distinct success contracts. Google transport exceptions, CI workflows, and deployment remain untouched.
+
+## Contracts and seams
+
+- `contract-secret-publication`: add a narrow required-refresh operation in `src/fs/token-store.ts`; test equal, missing, stale, throwing, and sentinel-bearing failures through `ISecretStore`.
+- `contract-completion-publication`: update both auth bases and manager/folder-pick consumers so failure precedes all success effects and provisional state cannot escape.
+- `contract-rotation-publication`: make the existing rotation hook awaitable, invoke it before token-response installation, wire all shared/detached factories, and remove late required-refresh writes.
+- `contract-attempt-identity`: extend Dropbox/OneDrive backend data with the pending nonsecret identity snapshot, populate it at start, clear it with other pending fields on success, and reconstruct/validate from it on callback/reload.
+- `contract-google-wire` and `contract-pcloud-wire`: validate parsed unknown values in each provider owner and exercise exported production handlers with mocked outbound fetch only.
+- `contract-authorization-denial`: use a pure plugin helper for projection/correlation so `main.ts` stays lifecycle-only; worker/static use text-safe local implementations with parity fixtures.
+- `contract-static-state`: execute the production inline script in a minimal DOM/location VM and assert redirects, visible text, and absence of exceptions.
+- `contract-repository-verification`: add relay-owned `npm test` and `npm run typecheck`; do not edit workflows or deploy.
+
+## Dependency-ordered units
+
+1. `unit-auth-publication`: token-store postcondition, provisional completion manager, pre-install rotation hook, four factory paths, late writer removal, focused tests, and plugin ownership docs. This unit lands coherently so no intermediate final state has unwired hooks and removed writers.
+2. In parallel after its prerequisites:
+   - `unit-attempt-identity` follows unit 1 because it overlaps `pkce-auth-provider.ts`; add snapshot fields/defaults, start/callback/reload logic, and request-capture tests.
+   - `unit-relay-validation` is independent; add Google/pCloud validators, denial handling, owned worker tests/scripts, and README correction in `/workspace/obsidian-air-sync-auth`.
+3. `unit-callback-ingress`: after denial semantics are available, implement plugin state-correlated Notice behavior and static state/denial tests across both repositories.
+4. `unit-final-verification`: update remaining architecture guidance, run both source gates, and record device/deployment evidence honestly.
+
+## File boundary
+
+Plugin production changes are limited to token storage, OAuth manager/auth-provider factories, Dropbox/OneDrive backend-data defaults/types, protocol ingress/helper, and relevant architecture/auth docs. Relay changes are limited to worker OAuth/pCloud handlers/router support as needed, static callback, worker package-owned tests/scripts, and README. Existing investigation test files are retained and promoted into maintainable coverage. No sync orchestrator behavior, provider endpoint, filesystem registry, migration code, deployment configuration, credential capture, or CI workflow is added.
+
+## Implementation discretion
+
+Private helper names and fixture factoring inside `src/fs/token-store.ts` and its test may vary only while preserving exact keys, synchronous equality, fixed safe failures, `invariant-candidate-equality`, and `invariant-secrets-outside-settings`. Any change to owner, API timing, wire fields, failure outcome, snapshot representation, or denial text requires returning to design; it is not implementer discretion.

--- a/docs/changes/change-20260906-oauth-authentication-publication/requirements.md
+++ b/docs/changes/change-20260906-oauth-authentication-publication/requirements.md
@@ -1,0 +1,115 @@
+---
+change: change-20260906-oauth-authentication-publication
+role: requirements
+functional_requirements:
+- id: req-completion-publication
+  statement: All six refresh-based OAuth completions require immediate candidate-equal
+    SecretStorage readback; an existing readable refresh satisfies an omitted replacement
+    only.
+  priority: must
+- id: req-rotation-publication
+  statement: Changed refresh candidates from shared and detached managers publish
+    before any state from that response is reusable, independently of sync closeout.
+  priority: must
+- id: req-attempt-identity
+  statement: Custom PKCE authorize and exchange use one start-time identity snapshot;
+    missing or inconsistent snapshot data rejects before exchange.
+  priority: must
+- id: req-google-wire
+  statement: Both Google relay HTTP-success handlers validate the provider-local token
+    shape before projection while preserving transport-exception behavior.
+  priority: must
+- id: req-authorization-denial
+  statement: Four callback ingresses detect denial before success gates and apply
+    the same exact error-code projection without provider descriptions.
+  priority: must
+- id: req-static-state
+  statement: Static callback validates object/string state and own app membership
+    while preserving both encodings and exact raw forwarding.
+  priority: must
+- id: req-pcloud-wire
+  statement: Legacy pCloud validates its distinct access-only success shape while
+    retaining host, region, logical-error and refresh-free behavior.
+  priority: must
+- id: req-compatibility-security
+  statement: Preserve secret namespaces, reload, Picker, detached-manager, diagnostics
+    and mobile contracts; keep credentials and provider descriptions out of durable
+    nonsecret state and output.
+  priority: must
+- id: req-source-verification
+  statement: Both repositories own executable source tests and gates; deployment,
+    CI workflow changes and physical restart durability remain separately authorized
+    or evidenced.
+  priority: must
+- id: invariant-secrets-outside-settings
+  statement: Credentials remain only in SecretStorage or ephemeral manager memory
+    and never in settings, sync state, or diagnostic output.
+  priority: must
+- id: invariant-candidate-equality
+  statement: Required publication succeeds only when synchronous immediate readback
+    equals the exact nonempty candidate.
+  priority: must
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Requirements
+
+## Functional requirements
+
+### FR-1 — Completion publication
+
+- When any registered Google/Dropbox/OneDrive built-in or custom OAuth completion receives a nonempty refresh candidate, the plugin shall write it to the existing backend SecretStorage key and require an immediate exact readback before reporting completion.
+- When a valid reauthorization response omits a refresh token, the plugin shall accept the already readable nonempty refresh credential for that backend.
+- If neither exists, or fresh-candidate readback is missing, unequal, or throws, completion shall fail before settings save, sync reset, filesystem construction, folder selection, or success notice.
+- A manager that has exchanged the code but has not completed publication shall remain provisional and shall be discarded on failure; its access/refresh/expiry state shall never be reused.
+
+### FR-2 — Rotation publication
+
+- When a validated refresh response contains a changed nonempty refresh token, every shared or detached manager shall complete the same candidate-equal publication before installing or exposing any state from that response.
+- If publication fails, the refresh call shall fail and a subsequent access call shall not return the unpublished response's access token.
+- Required refresh publication shall not depend on sync closeout or `readBackendState`; late cycle refresh writers shall be removed without changing checkpoint ordering.
+
+### FR-3 — Attempt identity
+
+- When custom Dropbox or OneDrive authorization starts, the plugin shall snapshot the effective client ID and OneDrive authority used for the authorize URL and persist that nonsecret snapshot with pending state/verifier.
+- When callback exchange begins, it shall use exactly that snapshot even if editable settings changed or the plugin reloaded.
+- Missing, incomplete, wrong-provider, or manager-inconsistent snapshot data shall reject before any token request. A new explicit start supersedes the old snapshot and provisional attempt manager.
+
+### FR-4 — Google relay token shape
+
+- On an HTTP-success token response, both Google callback and refresh handlers shall require a non-null, non-array object, nonempty string `access_token`, finite positive numeric `expires_in`, and optional string `refresh_token` before projecting fields.
+- Invalid JSON or shape shall produce the route-specific fixed HTTP 502 result without provider values. Existing upstream non-2xx and transport-exception behavior shall remain unchanged.
+
+### FR-5 — Authorization denial
+
+- At Google worker, pCloud worker, static callback, and plugin protocol ingress, a nonempty authorization `error` shall take precedence over success parameters and cause no exchange/completion/folder-selection mutation.
+- `access_denied` shall project to `Authorization was denied.`; every other nonempty code shall project to `Authorization failed (<code>).` using text-safe channel rendering.
+- `error_description`, `error_uri`, and all other provider-controlled text shall be ignored.
+- The plugin shall acquire `settings.backendData.pendingAuthState` once from the active normalized backend bag when the protocol callback arrives. It shall show a denial Notice only when that value is a nonempty string exactly equal to raw callback state; otherwise it shall have no side effect.
+
+### FR-6 — Static callback state
+
+- The static callback shall accept only decoded JSON that is a non-null, non-array object with string `app` and `nonce`, and whose app is an own allowlisted key.
+- It shall continue to accept base64url and legacy base64 and shall forward the exact original state on success.
+- Malformed, null, primitive, array, prototype-name, or unknown-app input shall not throw or redirect and shall show bounded fixed text.
+
+### FR-7 — pCloud response shape
+
+- pCloud HTTP success shall require an object with numeric `result`; nonzero remains the existing HTTP 400 logical failure, while zero additionally requires a nonempty string long-lived `access_token`.
+- Invalid JSON/shape shall return a fixed HTTP 502. The US/EU host allowlist, missing-host default, upstream-status behavior, raw state, and refresh-free contract shall remain.
+
+## Non-functional requirements
+
+- NFR-1: credentials remain in SecretStorage or ephemeral manager memory, never settings, sync state, logs, notices, HTML, or error text. Existing six key namespaces, explicit clearing, Picker fields, state encodings/reload, detached manager isolation, channel-specific diagnostics, and mobile compatibility remain.
+- NFR-2: immediate `getSecret` equality is the automated publication boundary. OS/process-restart durability is verified only by a recorded real-device checklist and is not inferred from mocks or the API signature.
+- NFR-3: plugin and relay repositories own executable production-boundary tests and pass their source gates. Worker/Pages deployment and CI workflow changes are outside this change.
+
+## Acceptance
+
+- `acceptance-seven-roots`: every verified root has a discriminating green owned test plus compatibility controls.
+- `acceptance-publication-before-reuse`: dropped, stale, unequal, or throwing publication cannot resolve completion or leave reusable response state; checkpoint failure cannot suppress a successful rotation write.
+- `acceptance-attempt-snapshot`: settings drift cannot alter an in-flight exchange identity, and missing/inconsistent snapshot produces zero network calls.
+- `acceptance-denial-parity`: all runtimes produce the exact semantic messages; mismatched/absent plugin state produces no Notice or dispatch; provider descriptions and sentinel secrets are absent.
+- `acceptance-owned-gates`: both source gates run without external harnesses, credentials, deployment, global packages, or CI changes.
+- `acceptance-native-boundary`: restart evidence is recorded per checked platform or explicitly marked unverified.

--- a/docs/changes/change-20260906-oauth-authentication-publication/verification.md
+++ b/docs/changes/change-20260906-oauth-authentication-publication/verification.md
@@ -1,0 +1,64 @@
+---
+change: change-20260906-oauth-authentication-publication
+role: verification
+---
+
+<!-- lifecycle is owned by change.md -->
+
+# Verification
+
+## T0 — pure and storage boundary
+
+- `npm test -- --run src/fs/token-store.test.ts`
+  - Exact nonempty candidate writes/readbacks succeed.
+  - Empty, dropped, stale/unequal, and throwing reads/writes fail with fixed secret-free errors.
+  - Existing key formats, skip-empty optional writes, explicit clear, and legacy key reads remain.
+- Pure denial helper tests assert the exact tuples:
+  - `access_denied` → `Authorization was denied.`
+  - every other nonempty code → `Authorization failed (<code>).`
+  - descriptions/URIs do not affect output.
+
+## T1 — production-boundary integration
+
+- Six completion variants:
+  - `npm test -- --run src/fs/googledrive/auth-completion-audit.test.ts src/fs/dropbox/auth-completion-audit.test.ts src/fs/onedrive/auth-completion-audit.test.ts`
+  - Cover missing initial refresh, retained existing refresh with omitted replacement, equal fresh publication, dropped replacement over empty/old storage, thrown storage, and no reusable provisional response after failure.
+- Caller effects and rotation lifecycle:
+  - `npm test -- --run src/fs/backend-manager.test.ts src/fs/backend-auth-folder-pick.test.ts src/fs/oauth-pkce.test.ts src/sync/orchestrator.test.ts`
+  - Assert no save/reset/filesystem/folder-selection success on failure; all shared/detached paths publish before response installation; a second access cannot reuse failed response; successful rotation remains readable after checkpoint failure; sync closeout ordering stays unchanged.
+- Attempt identity:
+  - `npm test -- --run src/fs/dropbox/auth.test.ts src/fs/onedrive/auth.test.ts src/fs/dropbox/auth-completion-audit.test.ts src/fs/onedrive/auth-completion-audit.test.ts`
+  - Capture authorize URL and token request identity after failure/settings edit, through reload, and for missing/wrong snapshot. Rejected cases make zero token requests.
+- Plugin denial:
+  - Execute the actual protocol handler with matching, missing, unequal, and active-backend-switched pending state. Only exact current equality shows Notice; all denial cases make zero completion/picker calls. Mixed success parameters cannot win.
+- Relay/static:
+  - `npm test --prefix /workspace/obsidian-air-sync-auth/worker`
+  - Google invalid JSON/null/array/access/expiry/refresh shapes fail both routes with bounded 502; valid omitted/rotated refresh and Picker/state controls pass; existing transport exception behavior is pinned unchanged.
+  - pCloud malformed shapes fail, valid access-only US/EU/default-host cases pass, invalid host makes zero requests, and logical/upstream status controls pass.
+  - Worker/static/plugin-equivalent denial fixtures assert exact message parity and absence of description/token sentinels.
+  - Static production script rejects null/primitive/array/wrong fields/prototype names/invalid encodings without redirect or throw; both valid encodings preserve raw state.
+
+## T2 — repository gates
+
+- Plugin: `npm run lint && npm run lint:bot-repro && npm run build && npm run test:coverage`
+- Relay: `npm test --prefix /workspace/obsidian-air-sync-auth/worker && npm run typecheck --prefix /workspace/obsidian-air-sync-auth/worker`
+- Run relay commands from repository-owned dependencies/scripts. No `/tmp` audit harness, credentials, external network, deployment, or CI workflow is part of the pass condition.
+
+## Manual native evidence
+
+For each representative desktop/mobile target: complete authorization, verify authenticated UI without recording token values, restart Obsidian and verify continuity, induce or observe a refresh-token rotation, then restart and verify continuity again. Record platform/app/plugin versions and pass/fail only—never secret contents. Any unexecuted target remains `unverified`; automated Map/store tests do not upgrade that status.
+
+## Completion criteria
+
+All seven roots' discriminating tests and compatibility controls are green, both T2 gates pass, no late refresh writer or success leakage remains, error outputs contain no sentinels, documentation states current versus legacy callback paths, and deployment/native claims match actual evidence. Worker/Pages deployment is explicitly `not performed` unless separately approved later.
+
+## Recorded evidence — 2026-09-06
+
+- Plugin focused OAuth/callback suites: 54 tests passed.
+- Plugin complete suite/coverage gate: 94 files, 1923 tests passed; statements 84.56%, branches 80.70%, functions 83.34%, lines 86.13%.
+- Plugin lint, Dashboard reproduction guard, TypeScript production build, and `git diff --check`: passed.
+- Auth relay actual worktree: repository-owned Node suite 15 tests passed; `npm run typecheck` and `git diff --check`: passed.
+- Dev-docs lint: passed without warnings.
+- Worker/Pages deployment: not performed (outside approved scope).
+- Native desktop/mobile restart and observed-rotation restart checks: unverified; no OS-level durability claim is made.
+- Dropbox App Console additional-user setting was reported changed by the owner, but current console state and a new-account end-to-end authorization remain unverified from this workspace.

--- a/docs/dropbox-backend.md
+++ b/docs/dropbox-backend.md
@@ -126,7 +126,8 @@ with Dropbox. Refreshing an access token needs only the `client_id`.
   `/Apps/<App>/`.
 - **Token storage**: refresh + access tokens in Obsidian SecretStorage (keyed per
   backend type); the access-token expiry lives in `settings.backendData`. Tokens
-  refreshed mid-sync are written back after the cycle.
+  rotated during refresh are written and immediately read back before the refreshed
+  response becomes reusable; cycle closeout is not a credential publication point.
 - The built-in app key is committed in `fs/auth-config.ts` (`DROPBOX_AUTH`); it is a
   public PKCE identifier (no secret), so it ships embedded and connects with no per-user setup.
 
@@ -138,7 +139,9 @@ Folder scope — that swaps the auth identity. The user supplies **their own Dro
 key** (a public PKCE identifier — no secret), stored in `backendData.customClientId` as a
 plain value; they must register `obsidian://air-sync-auth` as a redirect URI in that app.
 `DropboxCustomAuthProvider` overrides the PKCE seams to read the app key from
-`backendData` per call. Tokens live under the `dropbox-custom` SecretStorage keys,
+`backendData` when authorization starts. That public identity is snapshotted beside
+the pending state/verifier and remains the callback exchange identity even if settings
+are edited before return. Tokens live under the `dropbox-custom` SecretStorage keys,
 separate from the built-in. `disconnect` clears the tokens but preserves `customClientId`
 so a reconnect needs no re-entry. (Dropbox has no authority/account-type concept, so —
 unlike `onedrive-custom` — there is no account-type selector.)

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -235,6 +235,23 @@ external-protocol navigation attempt, and passes the real Drive folder lookup. I
 display/profile/human is available, report the live criterion as unverified—do not treat it as
 skipped or green.
 
+## Manual SecretStorage restart check
+
+Automated tests can prove the synchronous Obsidian API boundary—`setSecret` followed by an
+exact `getSecret`—but cannot prove when the native credential backend has physically flushed
+data. For each representative desktop/mobile target, record only the platform, Obsidian and
+plugin versions, and pass/fail for this checklist (never record token values):
+
+1. Complete OAuth and confirm the backend is connected.
+2. Fully terminate and restart Obsidian; confirm the connection remains usable.
+3. Exercise a provider refresh that rotates the refresh token, when the provider/test account
+   makes that observable without exposing the token value.
+4. Fully terminate and restart again; confirm the connection remains usable.
+
+An unrun platform or an unobserved rotation remains `unverified`. A mock SecretStorage, a
+successful build, and immediate same-process readback must not be reported as OS-level restart
+durability evidence.
+
 ## Notes
 
 - **Dropbox mtime.** `DropboxFs` reports `server_modified` (the upload wall-clock) as `mtime`,

--- a/docs/google-drive-backend.md
+++ b/docs/google-drive-backend.md
@@ -149,7 +149,7 @@ Two OAuth implementations share a common base class (`GoogleAuthBase`). The serv
 
 ### Token storage
 
-Tokens (`refreshToken`, `accessToken`) are stored in Obsidian's `SecretStorage` via `token-store.ts`, never in `settings.backendData`. Only non-secret data lives in `settings.backendData`: `remoteVaultFolderId`, `accessTokenExpiry`, and `pendingAuthState`/`pendingCodeVerifier` (transient, to survive a plugin reload mid-flow), plus the custom-OAuth fields. The delta cursor is **not** here — it lives in the `MetadataStore` (`META_STORE`), co-located with the file map (ADR 0001) (`customClientId`/`customClientSecret` are SecretStorage secret-name references, `customScope`, `customRedirectUri`, `customIncludeGrantedScopes`).
+Tokens (`refreshToken`, `accessToken`) are stored in Obsidian's `SecretStorage` via `token-store.ts`, never in `settings.backendData`. Completion succeeds only after an immediately exact readback of its required refresh credential; a rotated refresh token uses the same check before refreshed response state is installed. This is an API-level postcondition, not a claim that the OS has physically flushed storage. Only non-secret data lives in `settings.backendData`: `remoteVaultFolderId`, `accessTokenExpiry`, and `pendingAuthState`/`pendingCodeVerifier` (transient, to survive a plugin reload mid-flow), plus the custom-OAuth fields. The delta cursor is **not** here — it lives in the `MetadataStore` (`META_STORE`), co-located with the file map (ADR 0001) (`customClientId`/`customClientSecret` are SecretStorage secret-name references, `customScope`, `customRedirectUri`, `customIncludeGrantedScopes`).
 
 ## Resumable upload
 

--- a/docs/onedrive-backend.md
+++ b/docs/onedrive-backend.md
@@ -113,8 +113,9 @@ client); the plugin then exchanges the code for tokens directly with Microsoft.
   the App Folder (`special/approot`); `offline_access` enables the refresh token.
 - **Token storage**: refresh + access tokens in Obsidian SecretStorage (keyed per
   backend type, `onedrive`); the access-token expiry lives in
-  `settings.backendData`. Tokens refreshed mid-sync are written back after the
-  cycle. Microsoft's consumer endpoint has no programmatic token revoke, so
+  `settings.backendData`. A rotated refresh token is written and immediately read
+  back before the refreshed response becomes reusable; cycle closeout is not a
+  credential publication point. Microsoft's consumer endpoint has no programmatic token revoke, so
   disconnect clears the SecretStorage tokens (sufficient) and drops the in-memory
   manager.
 - The built-in `client_id` is the real Entra (Azure AD) application id, committed in
@@ -129,9 +130,10 @@ shared `OneDriveProviderBase` — identical client/FS/folder-binding/error behav
 App Folder scope — that swaps the auth identity. The user supplies their own Entra
 **Application (client) ID** and an **account type**, both stored in `backendData`
 (`customClientId`, `customAuthority`) as plain values (the client id is a public PKCE
-identifier — no secret). `OneDriveCustomAuthProvider` overrides the PKCE seams to read
-the client id and authority from `backendData` per call, so the authorize URL and token
-endpoint hit the chosen tenant. Tokens live under the `onedrive-custom` SecretStorage
+identifier — no secret). `OneDriveCustomAuthProvider` snapshots the effective client id
+and authority beside the pending state/verifier when authorization starts, so settings
+edited before callback cannot change the token endpoint or client identity for that
+attempt. Tokens live under the `onedrive-custom` SecretStorage
 keys, separate from the built-in. `disconnect` clears the tokens but preserves
 `customClientId`/`customAuthority` so a reconnect needs no re-entry.
 

--- a/src/fs/dropbox/auth-completion-audit.test.ts
+++ b/src/fs/dropbox/auth-completion-audit.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockSecretStore, mockRes, spyRequestUrl } from "./test-helpers";
+import { DropboxAuthProvider } from "./auth";
+import { DropboxCustomAuthProvider } from "./provider-custom";
+import { DropboxProvider } from "./provider";
+import { DROPBOX_AUTH } from "../auth-config";
+
+vi.mock("obsidian");
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+const pending = {
+	pendingAuthState: "audit-state",
+	pendingCodeVerifier: "audit-verifier",
+	customClientId: "audit-client",
+	customClientSecret: "audit-secret",
+	customAuthority: "consumers",
+};
+const callback = "obsidian://air-sync-auth?code=audit-code&state=audit-state";
+
+describe.each([["dropbox", DropboxAuthProvider], ["dropbox-custom", DropboxCustomAuthProvider]] as const)("%s durable completion audit", (type, Provider) => {
+	const attempt = {
+		...pending,
+		pendingAuthIdentity: {
+			backendType: type,
+			clientId: type === "dropbox" ? DROPBOX_AUTH.clientId : pending.customClientId,
+		},
+	};
+	function setup(existing = "") {
+		const store = createMockSecretStore({
+			"audit-client": "client-value",
+			"audit-secret": "secret-value",
+			...(existing ? { [`air-sync-${type}-refresh-token`]: existing } : {}),
+		});
+		return { store, auth: new Provider(store) };
+	}
+
+	it("rejects initial completion when the response omits a durable refresh credential", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({ access_token: "new-access", expires_in: 3600 }));
+		const { auth } = setup();
+		await expect(auth.completeAuth(callback, attempt)).rejects.toThrow();
+		expect(auth.isAuthenticated(attempt)).toBe(false);
+	});
+
+	it("rejects completion when the fresh refresh write cannot be read back", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({
+			access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600,
+		}));
+		const { auth, store } = setup();
+		const original = store.setSecret.bind(store);
+		vi.spyOn(store, "setSecret").mockImplementation((key, value) => {
+			if (key !== `air-sync-${type}-refresh-token`) original(key, value);
+		});
+		await expect(auth.completeAuth(callback, attempt)).rejects.toThrow();
+		expect(auth.isAuthenticated(attempt)).toBe(false);
+	});
+
+	it("preserves a stored refresh credential when the response omits its replacement", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({ access_token: "new-access", expires_in: 3600 }));
+		const { auth, store } = setup("existing-refresh");
+		await auth.completeAuth(callback, attempt);
+		expect(store.getSecret(`air-sync-${type}-refresh-token`)).toBe("existing-refresh");
+		expect(auth.isAuthenticated(attempt)).toBe(true);
+	});
+
+	it("completes normally when a fresh refresh credential is readable", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({
+			access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600,
+		}));
+		const { auth, store } = setup();
+		const result = await auth.completeAuth(callback, attempt);
+		expect(store.getSecret(`air-sync-${type}-refresh-token`)).toBe("new-refresh");
+		expect(auth.isAuthenticated(attempt)).toBe(true);
+		expect(result.pendingAuthState).toBe("");
+	});
+});
+
+describe("Dropbox rotating refresh publication audit", () => {
+	const oldSecrets = {
+		"air-sync-dropbox-refresh-token": "old-refresh",
+		"air-sync-dropbox-access-token": "old-access",
+	};
+	const rotated = { access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 };
+
+	function dropRefreshWrites(store: ReturnType<typeof createMockSecretStore>): void {
+		const original = store.setSecret.bind(store);
+		vi.spyOn(store, "setSecret").mockImplementation((key, value) => {
+			if (key !== "air-sync-dropbox-refresh-token") original(key, value);
+		});
+	}
+
+	it("does not lose a rotated refresh token at shared-cycle publication", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes(rotated));
+		const store = createMockSecretStore(oldSecrets);
+		const provider = new DropboxProvider(store);
+		const shared = provider.auth.getOrCreateAuth({});
+		shared.setTokens("old-refresh", "old-access", 0);
+		dropRefreshWrites(store);
+
+		await expect(shared.getAccessToken()).rejects.toThrow("Secret credential could not be saved securely");
+		provider.readBackendState();
+
+		expect(store.getSecret("air-sync-dropbox-refresh-token")).toBe("old-refresh");
+		expect(shared.getTokenState()).toMatchObject({ refreshToken: "old-refresh", accessToken: "old-access" });
+		await expect(shared.getAccessToken()).rejects.toThrow("Secret credential could not be saved securely");
+	});
+
+	it("does not lose a rotated refresh token from a detached manager", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes(rotated));
+		const store = createMockSecretStore(oldSecrets);
+		const auth = new DropboxAuthProvider(store, "audit-client");
+		const detached = auth.createDetachedAuth({});
+		detached.setTokens("old-refresh", "old-access", 0);
+		dropRefreshWrites(store);
+
+		await expect(detached.getAccessToken()).rejects.toThrow("Secret credential could not be saved securely");
+
+		expect(store.getSecret("air-sync-dropbox-refresh-token")).toBe("old-refresh");
+		expect(detached.getTokenState()).toMatchObject({ refreshToken: "old-refresh", accessToken: "old-access" });
+	});
+});
+
+describe("Dropbox custom cached-manager identity audit", () => {
+	const customPending = {
+		...pending,
+		pendingAuthIdentity: { backendType: "dropbox-custom", clientId: pending.customClientId },
+	};
+	it("uses the edited client id when the prior failure happened before manager creation", async () => {
+		const request = (await spyRequestUrl()).mockResolvedValue(
+			mockRes({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }),
+		);
+		const auth = new DropboxCustomAuthProvider(createMockSecretStore());
+		await expect(auth.completeAuth(
+			"obsidian://air-sync-auth?code=audit-code&state=wrong-state",
+			customPending,
+		)).rejects.toThrow(/state mismatch/i);
+
+		vi.stubGlobal("window", { open: vi.fn(), location: { href: "" } });
+		const edited = { ...customPending, customClientId: "edited-client" };
+		const next = await auth.startAuth(edited);
+		await auth.completeAuth(
+			`obsidian://air-sync-auth?code=retry-code&state=${String(next.pendingAuthState)}`,
+			{ ...edited, ...next },
+		);
+
+		const exchange = request.mock.calls[0]![0] as { body?: string };
+		expect(new URLSearchParams(exchange.body).get("client_id")).toBe("edited-client");
+	});
+
+	it("uses the edited client id when retrying after a failed exchange created the manager", async () => {
+		const request = await spyRequestUrl();
+		request
+			.mockResolvedValueOnce(mockRes({ error: "invalid_grant" }, { status: 400 }))
+			.mockResolvedValueOnce(mockRes({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }));
+		const store = createMockSecretStore();
+		const auth = new DropboxCustomAuthProvider(store);
+		await expect(auth.completeAuth(callback, customPending)).rejects.toThrow();
+
+		vi.stubGlobal("window", { open: vi.fn(), location: { href: "" } });
+		const edited = { ...customPending, customClientId: "edited-client" };
+		const next = await auth.startAuth(edited);
+		await auth.completeAuth(
+			`obsidian://air-sync-auth?code=retry-code&state=${String(next.pendingAuthState)}`,
+			{ ...edited, ...next },
+		);
+
+		const second = request.mock.calls[1]![0] as { body?: string };
+		expect(new URLSearchParams(second.body).get("client_id")).toBe("edited-client");
+	});
+
+	it("keeps the start-time client id when settings change before callback", async () => {
+		const request = (await spyRequestUrl()).mockResolvedValue(
+			mockRes({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }),
+		);
+		vi.stubGlobal("window", { open: vi.fn(), location: { href: "" } });
+		const auth = new DropboxCustomAuthProvider(createMockSecretStore());
+		const started = await auth.startAuth({ customClientId: "started-client" });
+
+		await auth.completeAuth(
+			`obsidian://air-sync-auth?code=code&state=${String(started.pendingAuthState)}`,
+			{ ...started, customClientId: "edited-client" },
+		);
+
+		const exchange = request.mock.calls[0]![0] as { body?: string };
+		expect(new URLSearchParams(exchange.body).get("client_id")).toBe("started-client");
+	});
+
+	it("rejects a missing attempt identity before token exchange", async () => {
+		const request = await spyRequestUrl();
+		const auth = new DropboxCustomAuthProvider(createMockSecretStore());
+		await expect(auth.completeAuth(callback, pending)).rejects.toThrow(/attempt identity/i);
+		expect(request).not.toHaveBeenCalled();
+	});
+});

--- a/src/fs/dropbox/auth.test.ts
+++ b/src/fs/dropbox/auth.test.ts
@@ -15,6 +15,8 @@ async function makeProvider(secrets: Record<string, string> = {}) {
 	return { auth: new DropboxAuthProvider(store, "test-client-id"), store };
 }
 
+const ATTEMPT_IDENTITY = { backendType: "dropbox", clientId: "test-client-id" };
+
 describe("DropboxAuthProvider.isAuthenticated", () => {
 	it("is true only when a refresh secret is stored", async () => {
 		const { auth } = await makeProvider();
@@ -52,6 +54,7 @@ describe("DropboxAuthProvider.startAuth", () => {
 		const state = JSON.parse(atob(b64 + "=".repeat((4 - (b64.length % 4)) % 4))) as { app: string };
 		expect(state.app).toBe("obsidian-plugin");
 		expect(url.searchParams.get("state")).toBe(out.pendingAuthState);
+		expect(out.pendingAuthIdentity).toEqual({ backendType: "dropbox", clientId: "test-client-id" });
 	});
 
 	it("derives a code_challenge that is the base64url SHA-256 of the verifier", async () => {
@@ -78,6 +81,7 @@ describe("DropboxAuthProvider.completeAuth", () => {
 		const out = await auth.completeAuth("obsidian://air-sync-auth?code=THECODE&state=abc", {
 			pendingAuthState: "abc",
 			pendingCodeVerifier: "verifier-xyz",
+			pendingAuthIdentity: ATTEMPT_IDENTITY,
 		});
 
 		const opts = spy.mock.calls[0]![0] as RequestUrlParam;
@@ -125,6 +129,7 @@ describe("DropboxAuthProvider.completeAuth", () => {
 			auth.completeAuth("obsidian://air-sync-auth?code=THECODE&state=abc", {
 				pendingAuthState: "abc",
 				pendingCodeVerifier: "verifier-xyz",
+				pendingAuthIdentity: ATTEMPT_IDENTITY,
 			}),
 		).rejects.toThrow(/Invalid Dropbox token response/);
 	});

--- a/src/fs/dropbox/auth.ts
+++ b/src/fs/dropbox/auth.ts
@@ -87,7 +87,7 @@ export class DropboxAuth extends BaseOAuthTokenManager {
 			throw new Error(`Token exchange failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertDropboxTokenResponse(res.json);
-		this.storeTokenResponse(res.json);
+		await this.storeTokenResponse(res.json);
 	}
 
 	protected async performRefresh(): Promise<string> {
@@ -119,7 +119,7 @@ export class DropboxAuth extends BaseOAuthTokenManager {
 			throw new Error(`Token refresh failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertDropboxTokenResponse(res.json);
-		this.storeTokenResponse(res.json);
+		await this.storeTokenResponse(res.json);
 		return this.accessToken;
 	}
 

--- a/src/fs/dropbox/provider-base.ts
+++ b/src/fs/dropbox/provider-base.ts
@@ -40,6 +40,7 @@ export const DEFAULT_DROPBOX_DATA: DropboxBackendData = {
 	accessTokenExpiry: 0,
 	pendingCodeVerifier: "",
 	pendingAuthState: "",
+	pendingAuthIdentity: null,
 	pendingPickedFolderPath: "",
 };
 

--- a/src/fs/dropbox/provider-custom.test.ts
+++ b/src/fs/dropbox/provider-custom.test.ts
@@ -67,6 +67,7 @@ describe("DropboxCustomAuthProvider.completeAuth", () => {
 			customClientId: "user-appkey",
 			pendingAuthState: "abc",
 			pendingCodeVerifier: "verifier-xyz",
+			pendingAuthIdentity: { backendType: "dropbox-custom", clientId: "user-appkey" },
 		});
 
 		const body = new URLSearchParams((spy.mock.calls[0]![0] as RequestUrlParam).body as string);

--- a/src/fs/dropbox/provider-custom.ts
+++ b/src/fs/dropbox/provider-custom.ts
@@ -26,6 +26,7 @@ const DEFAULT_DROPBOX_CUSTOM_DATA: DropboxCustomData = {
 	accessTokenExpiry: 0,
 	pendingCodeVerifier: "",
 	pendingAuthState: "",
+	pendingAuthIdentity: null,
 	pendingPickedFolderPath: "",
 	customClientId: "",
 };

--- a/src/fs/googledrive/auth-completion-audit.test.ts
+++ b/src/fs/googledrive/auth-completion-audit.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockSecretStore, mockRes, spyRequestUrl } from "./test-helpers.test";
+import { GoogleDriveCustomAuthProvider } from "./provider-custom";
+import { GoogleDriveProvider } from "./provider";
+
+vi.mock("obsidian");
+afterEach(() => { vi.restoreAllMocks(); });
+
+const pending = {
+	pendingAuthState: "audit-state",
+	pendingCodeVerifier: "audit-verifier",
+	customClientId: "audit-client",
+	customClientSecret: "audit-secret",
+	customAuthority: "consumers",
+};
+const callback = "obsidian://air-sync-auth?code=audit-code&state=audit-state";
+
+describe.each([["googledrive-custom", GoogleDriveCustomAuthProvider]] as const)("%s durable completion audit", (type, Provider) => {
+	function setup(existing = "") {
+		const store = createMockSecretStore({
+			"audit-client": "client-value",
+			"audit-secret": "secret-value",
+			...(existing ? { [`air-sync-${type}-refresh-token`]: existing } : {}),
+		});
+		return { store, auth: new Provider(store) };
+	}
+
+	it("rejects initial completion when the response omits a durable refresh credential", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({ access_token: "new-access", expires_in: 3600 }));
+		const { auth } = setup();
+		await expect(auth.completeAuth(callback, pending)).rejects.toThrow();
+		expect(auth.isAuthenticated(pending)).toBe(false);
+	});
+
+	it("rejects completion when the fresh refresh write cannot be read back", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({
+			access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600,
+		}));
+		const { auth, store } = setup();
+		const original = store.setSecret.bind(store);
+		vi.spyOn(store, "setSecret").mockImplementation((key, value) => {
+			if (key !== `air-sync-${type}-refresh-token`) original(key, value);
+		});
+		await expect(auth.completeAuth(callback, pending)).rejects.toThrow();
+		expect(auth.isAuthenticated(pending)).toBe(false);
+	});
+
+	it("preserves a stored refresh credential when the response omits its replacement", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({ access_token: "new-access", expires_in: 3600 }));
+		const { auth, store } = setup("existing-refresh");
+		await auth.completeAuth(callback, pending);
+		expect(store.getSecret(`air-sync-${type}-refresh-token`)).toBe("existing-refresh");
+		expect(auth.isAuthenticated(pending)).toBe(true);
+	});
+
+	it("completes normally when a fresh refresh credential is readable", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({
+			access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600,
+		}));
+		const { auth, store } = setup();
+		const result = await auth.completeAuth(callback, pending);
+		expect(store.getSecret(`air-sync-${type}-refresh-token`)).toBe("new-refresh");
+		expect(auth.isAuthenticated(pending)).toBe(true);
+		expect(result.pendingAuthState).toBe("");
+	});
+});
+
+describe("Google Drive rotating refresh publication audit", () => {
+	const oldSecrets = {
+		"air-sync-googledrive-refresh-token": "old-refresh",
+		"air-sync-googledrive-access-token": "old-access",
+	};
+	const rotated = {
+		access_token: "new-access",
+		refresh_token: "new-refresh",
+		expires_in: 3600,
+		token_type: "Bearer",
+	};
+
+	function dropRefreshWrites(store: ReturnType<typeof createMockSecretStore>): void {
+		const original = store.setSecret.bind(store);
+		vi.spyOn(store, "setSecret").mockImplementation((key, value) => {
+			if (key !== "air-sync-googledrive-refresh-token") original(key, value);
+		});
+	}
+
+	it("does not lose a rotated refresh token at shared-cycle publication", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes(rotated));
+		const store = createMockSecretStore(oldSecrets);
+		const provider = new GoogleDriveProvider(store);
+		const shared = provider.auth.getOrCreateGoogleAuth({} as never);
+		shared.setTokens("old-refresh", "old-access", 0);
+		dropRefreshWrites(store);
+
+		await expect(shared.getAccessToken()).rejects.toThrow("Secret credential could not be saved securely");
+		provider.readBackendState();
+
+		expect(store.getSecret("air-sync-googledrive-refresh-token")).toBe("old-refresh");
+		expect(shared.getTokenState()).toMatchObject({ refreshToken: "old-refresh", accessToken: "old-access" });
+		await expect(shared.getAccessToken()).rejects.toThrow("Secret credential could not be saved securely");
+	});
+
+	it("does not lose a rotated refresh token from a detached manager", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes(rotated));
+		const store = createMockSecretStore(oldSecrets);
+		const provider = new GoogleDriveProvider(store);
+		const detached = provider.auth.createDetachedGoogleAuth({} as never);
+		detached.setTokens("old-refresh", "old-access", 0);
+		dropRefreshWrites(store);
+
+		await expect(detached.getAccessToken()).rejects.toThrow("Secret credential could not be saved securely");
+
+		expect(store.getSecret("air-sync-googledrive-refresh-token")).toBe("old-refresh");
+		expect(detached.getTokenState()).toMatchObject({ refreshToken: "old-refresh", accessToken: "old-access" });
+	});
+});

--- a/src/fs/googledrive/auth-provider-base.ts
+++ b/src/fs/googledrive/auth-provider-base.ts
@@ -4,7 +4,7 @@ import type { ISecretStore } from "../secret-store";
 import type { Logger } from "../../logging/logger";
 import type { IGoogleAuth } from "./auth";
 import type { GoogleDriveBackendData } from "./provider";
-import { setBackendSecret, getBackendSecret, hasBackendSecret } from "../token-store";
+import { setBackendSecret, getBackendSecret, hasBackendSecret, publishBackendSecret } from "../token-store";
 
 interface GoogleDriveTokens {
 	refreshToken: string;
@@ -17,12 +17,6 @@ export function readGoogleDriveTokens(store: ISecretStore, type: string): Google
 		refreshToken: getBackendSecret(store, type, "refresh"),
 		accessToken: getBackendSecret(store, type, "access"),
 	};
-}
-
-/** Persist the Google Drive refresh+access tokens to SecretStorage (empty values are skipped). */
-export function storeGoogleDriveTokens(store: ISecretStore, type: string, tokens: GoogleDriveTokens): void {
-	setBackendSecret(store, type, "refresh", tokens.refreshToken);
-	setBackendSecret(store, type, "access", tokens.accessToken);
 }
 
 /** Plugin-owned secret names every Google Drive backend stores under air-sync-<type>-<name>-token. */
@@ -115,7 +109,7 @@ export abstract class GoogleDriveAuthProviderBase implements IAuthProvider {
 		backendData: Record<string, unknown>,
 	): Promise<Record<string, unknown>> {
 		const data = backendData as Partial<GoogleDriveBackendData & { pendingCodeVerifier?: string }>;
-		const auth = this.createAuthIfNeeded(backendData);
+		const auth = this.takeAuthForCompletion(backendData);
 		if (!auth) {
 			throw new Error("OAuth credentials are missing");
 		}
@@ -127,18 +121,28 @@ export abstract class GoogleDriveAuthProviderBase implements IAuthProvider {
 			auth.setCodeVerifier(data.pendingCodeVerifier);
 		}
 
-		const params = parseAuthCallbackParams(input);
-		await auth.handleAuthCallback(params);
-		const tokens = auth.getTokenState();
+		try {
+			const params = parseAuthCallbackParams(input);
+			await auth.handleAuthCallback(params);
+			const tokens = auth.getTokenState();
+			const requiredRefresh = tokens.refreshToken || getBackendSecret(this.secretStore, this.backendType, "refresh");
 
-		// Store tokens in SecretStorage instead of returning them for backendData
-		storeGoogleDriveTokens(this.secretStore, this.backendType, tokens);
+			publishBackendSecret(this.secretStore, this.backendType, "refresh", requiredRefresh);
+			setBackendSecret(this.secretStore, this.backendType, "access", tokens.accessToken);
+			if (!tokens.refreshToken) {
+				auth.setTokens(requiredRefresh, tokens.accessToken, tokens.accessTokenExpiry);
+			}
+			this.googleAuth = auth;
 
-		return {
-			accessTokenExpiry: tokens.accessTokenExpiry,
-			pendingAuthState: "",
-			pendingCodeVerifier: "",
-		};
+			return {
+				accessTokenExpiry: tokens.accessTokenExpiry,
+				pendingAuthState: "",
+				pendingCodeVerifier: "",
+			};
+		} catch (err) {
+			this.googleAuth = null;
+			throw err;
+		}
 	}
 
 	/** Return the current in-memory token state (for persistence after refresh). */
@@ -188,18 +192,23 @@ export abstract class GoogleDriveAuthProviderBase implements IAuthProvider {
 		return this.googleAuth;
 	}
 
-	/** Get-or-create for COMPLETING the flow. Returns null (silently) if creds are missing. */
-	protected createAuthIfNeeded(backendData: Record<string, unknown>): IGoogleAuth | null {
-		if (this.googleAuth) return this.googleAuth;
+	/**
+	 * Take the pending manager out of the reusable slot for completion. It remains
+	 * provisional until required credential publication succeeds.
+	 */
+	protected takeAuthForCompletion(backendData: Record<string, unknown>): IGoogleAuth | null {
+		const pending = this.googleAuth;
+		this.googleAuth = null;
 		if (!this.hasCredentials(backendData)) return null;
-		this.googleAuth = this.buildAuth(backendData);
-		return this.googleAuth;
+		return pending ?? this.buildAuth(backendData);
 	}
 
 	/** Get or create the SHARED GoogleAuth instance for FS creation. */
 	getOrCreateGoogleAuth(data: GoogleDriveBackendData, logger?: Logger): IGoogleAuth {
 		if (!this.googleAuth) {
-			this.googleAuth = this.buildAuth(data as unknown as Record<string, unknown>, logger);
+			this.googleAuth = this.wireRefreshPersistence(
+				this.buildAuth(data as unknown as Record<string, unknown>, logger),
+			);
 		}
 		return this.googleAuth;
 	}
@@ -209,21 +218,19 @@ export abstract class GoogleDriveAuthProviderBase implements IAuthProvider {
 	 * display, folder pick) that must not reset the live sync's shared in-memory tokens.
 	 */
 	createDetachedGoogleAuth(data: GoogleDriveBackendData, logger?: Logger): IGoogleAuth {
-		return this.wireDetachedRefreshPersistence(
+		return this.wireRefreshPersistence(
 			this.buildAuth(data as unknown as Record<string, unknown>, logger),
 		);
 	}
 
 	/**
-	 * Wire a detached auth so a refresh that ROTATES the refresh token persists the
-	 * new value to SecretStorage. Without this, a rotated token would live only on
-	 * the throwaway instance and be discarded, leaving the stored (and shared
-	 * in-memory) token stale so the next real sync's refresh fails. Subclasses call
-	 * this on the instance they return from {@link createDetachedGoogleAuth}.
+	 * Wire any reusable auth so a rotated refresh token is proven in SecretStorage
+	 * before the response installs access, expiry, or refresh state. The same seam is
+	 * used by shared and detached instances.
 	 */
-	protected wireDetachedRefreshPersistence(auth: IGoogleAuth): IGoogleAuth {
+	protected wireRefreshPersistence(auth: IGoogleAuth): IGoogleAuth {
 		auth.setRefreshTokenRotatedHook((refreshToken) => {
-			setBackendSecret(this.secretStore, this.backendType, "refresh", refreshToken);
+			publishBackendSecret(this.secretStore, this.backendType, "refresh", refreshToken);
 		});
 		return auth;
 	}

--- a/src/fs/googledrive/auth.test.ts
+++ b/src/fs/googledrive/auth.test.ts
@@ -260,6 +260,62 @@ describe("GoogleAuth.getAccessToken concurrency", () => {
 });
 
 describe("GoogleDriveProvider.completeAuth", () => {
+	it("rejects a fresh built-in OAuth callback that has no durable refresh token", async () => {
+		const { GoogleDriveProvider } = await import("./provider");
+		const { GoogleAuth } = await import("./auth");
+		const secretStore = createMockSecretStore();
+		const provider = new GoogleDriveProvider(secretStore);
+		const authInternal = provider.auth as unknown as GoogleDriveAuthProviderInternal;
+
+		authInternal.googleAuth = new GoogleAuth();
+		authInternal.googleAuth.setAuthState("saved-state");
+
+		await expect(provider.auth.completeAuth(
+			"https://callback?access_token=new-access&expires_in=3600&state=saved-state",
+			{ pendingAuthState: "saved-state" },
+		)).rejects.toThrow(/refresh token/i);
+	});
+
+	it("does not report success when SecretStorage drops the fresh refresh-token write", async () => {
+		const { GoogleDriveProvider } = await import("./provider");
+		const { GoogleAuth } = await import("./auth");
+		const provider = new GoogleDriveProvider({
+			getSecret: () => null,
+			setSecret: () => {},
+		});
+		const authInternal = provider.auth as unknown as GoogleDriveAuthProviderInternal;
+
+		authInternal.googleAuth = new GoogleAuth();
+		authInternal.googleAuth.setAuthState("saved-state");
+
+		await expect(provider.auth.completeAuth(
+			"https://callback?access_token=new-access&refresh_token=new-refresh&expires_in=3600&state=saved-state",
+			{ pendingAuthState: "saved-state" },
+		)).rejects.toThrow(/secret|refresh token/i);
+	});
+
+	it("keeps an existing durable refresh token when a reauthorization callback omits it", async () => {
+		const { GoogleDriveProvider } = await import("./provider");
+		const { GoogleAuth } = await import("./auth");
+		const secretStore = createMockSecretStore({
+			"air-sync-googledrive-refresh-token": "existing-refresh",
+		});
+		const provider = new GoogleDriveProvider(secretStore);
+		const authInternal = provider.auth as unknown as GoogleDriveAuthProviderInternal;
+
+		authInternal.googleAuth = new GoogleAuth();
+		authInternal.googleAuth.setTokens("existing-refresh", "", 0);
+		authInternal.googleAuth.setAuthState("saved-state");
+
+		await provider.auth.completeAuth(
+			"https://callback?access_token=new-access&expires_in=3600&state=saved-state",
+			{ pendingAuthState: "saved-state" },
+		);
+
+		expect(secretStore.getSecret("air-sync-googledrive-refresh-token"))
+			.toBe("existing-refresh");
+	});
+
 	it("restores CSRF state on existing auth that lacks it", async () => {
 		const { GoogleDriveProvider } = await import("./provider");
 		const { GoogleAuth } = await import("./auth");

--- a/src/fs/googledrive/auth.ts
+++ b/src/fs/googledrive/auth.ts
@@ -19,7 +19,7 @@ export interface IGoogleAuth {
 	 * otherwise be discarded with the instance — leaving the shared/stored token
 	 * stale and failing the next real refresh.
 	 */
-	setRefreshTokenRotatedHook(cb: (refreshToken: string) => void): void;
+	setRefreshTokenRotatedHook(cb: (refreshToken: string) => void | Promise<void>): void;
 	readonly isAuthenticated: boolean;
 	getAuthorizationUrl(): Promise<string>;
 	getAuthState(): string | null;
@@ -190,7 +190,7 @@ export class GoogleAuth extends GoogleAuthBase {
 
 			const token: unknown = response.json;
 			assertTokenResponse(token);
-			this.storeTokenResponse(token);
+			await this.storeTokenResponse(token);
 			return this.accessToken;
 		} catch (err) {
 			this.handleRefreshError(err);
@@ -289,7 +289,7 @@ export class GoogleAuthDirect extends GoogleAuthBase {
 
 			const token: unknown = response.json;
 			assertTokenResponse(token);
-			this.storeTokenResponse(token);
+			await this.storeTokenResponse(token);
 			this.clearAuthState();
 			this.logger?.debug("Token exchange successful");
 		} catch (err) {
@@ -316,7 +316,7 @@ export class GoogleAuthDirect extends GoogleAuthBase {
 
 			const token: unknown = response.json;
 			assertTokenResponse(token);
-			this.storeTokenResponse(token);
+			await this.storeTokenResponse(token);
 			return this.accessToken;
 		} catch (err) {
 			this.handleRefreshError(err);

--- a/src/fs/googledrive/provider-base.ts
+++ b/src/fs/googledrive/provider-base.ts
@@ -16,11 +16,10 @@ import { classifyGoogleDriveError } from "./errors";
 import { FOLDER_MIME } from "./types";
 import type { GoogleDriveFile } from "./types";
 import type { GoogleDriveBackendData } from "./provider";
-import { hasBackendSecret, clearBackendSecrets } from "../token-store";
+import { hasBackendSecret, clearBackendSecrets, setBackendSecret } from "../token-store";
 import {
 	GoogleDriveAuthProviderBase,
 	readGoogleDriveTokens,
-	storeGoogleDriveTokens,
 	GOOGLE_DRIVE_SECRET_NAMES,
 } from "./auth-provider-base";
 
@@ -101,13 +100,12 @@ export abstract class GoogleDriveProviderBase implements IBackendProvider {
 
 		// The delta cursor is no longer persisted in settings — it commits atomically
 		// with the file map in the metadata store (ADR 0001, via the FS's
-		// commitCheckpoint). Here we only persist the non-secret token expiry; the
-		// tokens themselves go to SecretStorage. (Token state is saved on every cycle,
-		// clean or not: a refresh that already succeeded should not be discarded just
-		// because a later file op failed.)
+		// commitCheckpoint). Required refresh publication already completed at token
+		// acquisition; this late snapshot retains only the optional access-token cache
+		// and non-secret expiry.
 		const tokens = this.auth.getTokenState();
-		if (tokens && tokens.refreshToken) {
-			storeGoogleDriveTokens(this.secretStore, this.type, tokens);
+		if (tokens && (tokens.refreshToken || tokens.accessToken)) {
+			setBackendSecret(this.secretStore, this.type, "access", tokens.accessToken);
 			result.accessTokenExpiry = tokens.accessTokenExpiry;
 		}
 

--- a/src/fs/oauth-callback-error.test.ts
+++ b/src/fs/oauth-callback-error.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	correlateOAuthCallbackError,
+	handleOAuthProtocolCallback,
+	projectOAuthCallbackError,
+} from "./oauth-callback-error";
+
+describe("OAuth callback error projection", () => {
+	it("uses the fixed access-denied message", () => {
+		expect(projectOAuthCallbackError("access_denied")).toEqual({
+			code: "access_denied",
+			message: "Authorization was denied.",
+		});
+	});
+
+	it("preserves a bounded safe error code without provider descriptions", () => {
+		expect(projectOAuthCallbackError("temporarily_unavailable")).toEqual({
+			code: "temporarily_unavailable",
+			message: "Authorization failed (temporarily_unavailable).",
+		});
+		expect(projectOAuthCallbackError("<secret-sentinel>"))
+			.toEqual({ code: "invalid_error", message: "Authorization failed (invalid_error)." });
+	});
+
+	it("correlates only an exact nonempty active pending state", () => {
+		const params = { error: "access_denied", state: "current", code: "must-not-win" };
+		expect(correlateOAuthCallbackError(params, "current")?.message).toBe("Authorization was denied.");
+		expect(correlateOAuthCallbackError(params, "other")).toBeNull();
+		expect(correlateOAuthCallbackError(params, "")).toBeNull();
+	});
+
+	it("lets a denial win over success fields without dispatching", () => {
+		const notices: string[] = [];
+		let dispatches = 0;
+		handleOAuthProtocolCallback(
+			{
+				error: "access_denied",
+				error_description: "secret sentinel",
+				state: "current",
+				code: "must-not-win",
+				access_token: "must-not-win",
+				picked_file_ids: "must-not-win",
+			},
+			"current",
+			{
+				notify: (message) => notices.push(message),
+				completeConnect: () => { dispatches += 1; },
+				completeFolderPick: () => { dispatches += 1; },
+			},
+		);
+		expect(notices).toEqual(["Authorization was denied."]);
+		expect(dispatches).toBe(0);
+		expect(notices.join(" ")).not.toContain("sentinel");
+	});
+
+	it("has no denial side effect when the active state is unavailable or changed", () => {
+		for (const pending of [undefined, "", "other"]) {
+			let effects = 0;
+			handleOAuthProtocolCallback(
+				{ error: "access_denied", state: "current", code: "must-not-win" },
+				pending,
+				{
+					notify: () => { effects += 1; },
+					completeConnect: () => { effects += 1; },
+					completeFolderPick: () => { effects += 1; },
+				},
+			);
+			expect(effects).toBe(0);
+		}
+	});
+});

--- a/src/fs/oauth-callback-error.ts
+++ b/src/fs/oauth-callback-error.ts
@@ -1,0 +1,73 @@
+/** Bounded, channel-neutral OAuth denial projected from an untrusted callback. */
+export interface OAuthCallbackError {
+	code: string;
+	message: string;
+}
+
+const SAFE_ERROR_CODE = /^[A-Za-z0-9._~-]{1,64}$/;
+
+/**
+ * Project only the OAuth error code. Provider descriptions and URIs are never
+ * accepted as diagnostic input because they can contain arbitrary text.
+ */
+export function projectOAuthCallbackError(error: unknown): OAuthCallbackError | null {
+	if (typeof error !== "string" || !error) return null;
+	if (error === "access_denied") {
+		return { code: error, message: "Authorization was denied." };
+	}
+	const code = SAFE_ERROR_CODE.test(error) ? error : "invalid_error";
+	return { code, message: `Authorization failed (${code}).` };
+}
+
+/** Correlate a projected denial to the one active authorization attempt. */
+export function correlateOAuthCallbackError(
+	params: Record<string, unknown>,
+	pendingState: unknown,
+): OAuthCallbackError | null {
+	const projected = projectOAuthCallbackError(params.error);
+	if (!projected) return null;
+	if (typeof pendingState !== "string" || !pendingState || params.state !== pendingState) return null;
+	return projected;
+}
+
+export interface OAuthProtocolEffects {
+	notify(message: string): void;
+	completeConnect(url: string): void;
+	completeFolderPick(url: string, params: Record<string, string | undefined>): void;
+}
+
+function protocolParamsEntries(params: Record<string, string | undefined>): Array<[string, string]> {
+	const entries: Array<[string, string]> = [];
+	for (const key of Object.keys(params)) {
+		const value = params[key];
+		if (typeof value === "string") entries.push([key, value]);
+	}
+	return entries;
+}
+
+/** Apply the complete OAuth protocol-ingress policy before dispatching a callback. */
+export function handleOAuthProtocolCallback(
+	params: Record<string, string | undefined>,
+	pendingState: unknown,
+	effects: OAuthProtocolEffects,
+): void {
+	const callbackError = projectOAuthCallbackError(params.error);
+	if (callbackError) {
+		const correlated = correlateOAuthCallbackError(params, pendingState);
+		if (correlated) effects.notify(correlated.message);
+		return;
+	}
+	if (!params.access_token && !params.code) {
+		effects.notify("Authorization failed: no token or code received");
+		return;
+	}
+	const url = new URL("https://callback");
+	for (const [key, value] of protocolParamsEntries(params)) {
+		url.searchParams.set(key, value);
+	}
+	if (params.picked_file_ids) {
+		effects.completeFolderPick(url.toString(), params);
+	} else {
+		effects.completeConnect(url.toString());
+	}
+}

--- a/src/fs/oauth-pkce.test.ts
+++ b/src/fs/oauth-pkce.test.ts
@@ -70,7 +70,7 @@ class TestTokenManager extends BaseOAuthTokenManager {
 		this.refreshCount++;
 		await Promise.resolve();
 		if (this.error) this.handleRefreshError(this.error);
-		this.storeTokenResponse(this.response);
+		await this.storeTokenResponse(this.response);
 		return this.accessToken;
 	}
 }
@@ -152,7 +152,7 @@ describe("BaseOAuthTokenManager", () => {
 	it("fires the rotation hook only when the refresh token actually changes", async () => {
 		const rotated: string[] = [];
 		const m = new TestTokenManager();
-		m.setRefreshTokenRotatedHook((rt) => rotated.push(rt));
+		m.setRefreshTokenRotatedHook((rt) => { rotated.push(rt); });
 		m.setTokens("RT", "", 0);
 
 		// Same refresh token returned → no rotation.

--- a/src/fs/oauth-pkce.ts
+++ b/src/fs/oauth-pkce.ts
@@ -135,7 +135,7 @@ export abstract class BaseOAuthTokenManager {
 	private refreshPromise: Promise<string> | null = null;
 	protected authFailedAt = 0;
 	protected logger?: Logger;
-	private onRefreshTokenRotated?: (refreshToken: string) => void;
+	private onRefreshTokenRotated?: (refreshToken: string) => void | Promise<void>;
 
 	setTokens(refreshToken: string, accessToken: string, expiry: number): void {
 		this.refreshToken = refreshToken;
@@ -144,7 +144,7 @@ export abstract class BaseOAuthTokenManager {
 		this.authFailedAt = 0;
 	}
 
-	setRefreshTokenRotatedHook(cb: (refreshToken: string) => void): void {
+	setRefreshTokenRotatedHook(cb: (refreshToken: string) => void | Promise<void>): void {
 		this.onRefreshTokenRotated = cb;
 	}
 
@@ -212,18 +212,17 @@ export abstract class BaseOAuthTokenManager {
 		throw err as Error;
 	}
 
-	/** Store tokens from a validated token response, notifying on rotation. */
-	protected storeTokenResponse(token: OAuthTokenResponse): void {
+	/** Store a validated response, publishing rotation before installing any field. */
+	protected async storeTokenResponse(token: OAuthTokenResponse): Promise<void> {
+		if (token.refresh_token) {
+			// Detect rotation before mutating the manager. The owning provider wires the
+			// same publication hook for shared and detached managers.
+			const rotated = !!this.refreshToken && token.refresh_token !== this.refreshToken;
+			if (rotated) await this.onRefreshTokenRotated?.(token.refresh_token);
+		}
 		this.accessToken = token.access_token;
 		this.accessTokenExpiry = Date.now() + token.expires_in * 1000;
-		if (token.refresh_token) {
-			// Detect rotation: the provider returned a refresh token different from the
-			// one we held. Fire the hook so a detached auth can persist it (a shared
-			// auth leaves the hook unset and persists via its own checkpoint path).
-			const rotated = !!this.refreshToken && token.refresh_token !== this.refreshToken;
-			this.refreshToken = token.refresh_token;
-			if (rotated) this.onRefreshTokenRotated?.(token.refresh_token);
-		}
+		if (token.refresh_token) this.refreshToken = token.refresh_token;
 		this.authFailedAt = 0;
 	}
 }

--- a/src/fs/onedrive/auth-completion-audit.test.ts
+++ b/src/fs/onedrive/auth-completion-audit.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMockSecretStore, mockRes, spyRequestUrl } from "./test-helpers";
+import { DEFAULT_ONEDRIVE_AUTHORITY, OneDriveAuthProvider } from "./auth";
+import { OneDriveCustomAuthProvider } from "./provider-custom";
+import { ONEDRIVE_AUTH } from "../auth-config";
+
+vi.mock("obsidian");
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+const pending = {
+	pendingAuthState: "audit-state",
+	pendingCodeVerifier: "audit-verifier",
+	customClientId: "audit-client",
+	customClientSecret: "audit-secret",
+	customAuthority: "consumers",
+};
+const callback = "obsidian://air-sync-auth?code=audit-code&state=audit-state";
+
+describe.each([["onedrive", OneDriveAuthProvider], ["onedrive-custom", OneDriveCustomAuthProvider]] as const)("%s durable completion audit", (type, Provider) => {
+	const attempt = {
+		...pending,
+		pendingAuthIdentity: {
+			backendType: type,
+			clientId: type === "onedrive" ? ONEDRIVE_AUTH.clientId : pending.customClientId,
+			authority: type === "onedrive" ? DEFAULT_ONEDRIVE_AUTHORITY : pending.customAuthority,
+		},
+	};
+	function setup(existing = "") {
+		const store = createMockSecretStore({
+			"audit-client": "client-value",
+			"audit-secret": "secret-value",
+			...(existing ? { [`air-sync-${type}-refresh-token`]: existing } : {}),
+		});
+		return { store, auth: new Provider(store) };
+	}
+
+	it("rejects initial completion when the response omits a durable refresh credential", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({ access_token: "new-access", expires_in: 3600 }));
+		const { auth } = setup();
+		await expect(auth.completeAuth(callback, attempt)).rejects.toThrow();
+		expect(auth.isAuthenticated(attempt)).toBe(false);
+	});
+
+	it("rejects completion when the fresh refresh write cannot be read back", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({
+			access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600,
+		}));
+		const { auth, store } = setup();
+		const original = store.setSecret.bind(store);
+		vi.spyOn(store, "setSecret").mockImplementation((key, value) => {
+			if (key !== `air-sync-${type}-refresh-token`) original(key, value);
+		});
+		await expect(auth.completeAuth(callback, attempt)).rejects.toThrow();
+		expect(auth.isAuthenticated(attempt)).toBe(false);
+	});
+
+	it("preserves a stored refresh credential when the response omits its replacement", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({ access_token: "new-access", expires_in: 3600 }));
+		const { auth, store } = setup("existing-refresh");
+		await auth.completeAuth(callback, attempt);
+		expect(store.getSecret(`air-sync-${type}-refresh-token`)).toBe("existing-refresh");
+		expect(auth.isAuthenticated(attempt)).toBe(true);
+	});
+
+	it("completes normally when a fresh refresh credential is readable", async () => {
+		(await spyRequestUrl()).mockResolvedValue(mockRes({
+			access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600,
+		}));
+		const { auth, store } = setup();
+		const result = await auth.completeAuth(callback, attempt);
+		expect(store.getSecret(`air-sync-${type}-refresh-token`)).toBe("new-refresh");
+		expect(auth.isAuthenticated(attempt)).toBe(true);
+		expect(result.pendingAuthState).toBe("");
+	});
+});
+
+describe("OneDrive custom cached-manager identity audit", () => {
+	const customPending = {
+		...pending,
+		pendingAuthIdentity: {
+			backendType: "onedrive-custom",
+			clientId: pending.customClientId,
+			authority: pending.customAuthority,
+		},
+	};
+	it("uses edited identity when the prior failure happened before manager creation", async () => {
+		const request = (await spyRequestUrl()).mockResolvedValue(
+			mockRes({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }),
+		);
+		const auth = new OneDriveCustomAuthProvider(createMockSecretStore());
+		await expect(auth.completeAuth(
+			"obsidian://air-sync-auth?code=audit-code&state=wrong-state",
+			customPending,
+		)).rejects.toThrow(/state mismatch/i);
+
+		vi.stubGlobal("window", { open: vi.fn(), location: { href: "" } });
+		const edited = { ...customPending, customClientId: "edited-client", customAuthority: "organizations" };
+		const next = await auth.startAuth(edited);
+		await auth.completeAuth(
+			`obsidian://air-sync-auth?code=retry-code&state=${String(next.pendingAuthState)}`,
+			{ ...edited, ...next },
+		);
+
+		const exchange = request.mock.calls[0]![0] as { url: string; body?: string };
+		expect(exchange.url).toContain("/organizations/");
+		expect(new URLSearchParams(exchange.body).get("client_id")).toBe("edited-client");
+	});
+
+	it("uses the edited client id and authority when retrying after a failed exchange created the manager", async () => {
+		const request = await spyRequestUrl();
+		request
+			.mockResolvedValueOnce(mockRes({ error: "invalid_grant" }, { status: 400 }))
+			.mockResolvedValueOnce(mockRes({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }));
+		const store = createMockSecretStore();
+		const auth = new OneDriveCustomAuthProvider(store);
+		await expect(auth.completeAuth(callback, customPending)).rejects.toThrow();
+
+		vi.stubGlobal("window", { open: vi.fn(), location: { href: "" } });
+		const edited = { ...customPending, customClientId: "edited-client", customAuthority: "organizations" };
+		const next = await auth.startAuth(edited);
+		await auth.completeAuth(
+			`obsidian://air-sync-auth?code=retry-code&state=${String(next.pendingAuthState)}`,
+			{ ...edited, ...next },
+		);
+
+		const second = request.mock.calls[1]![0] as { url: string; body?: string };
+		expect(second.url).toContain("/organizations/");
+		expect(new URLSearchParams(second.body).get("client_id")).toBe("edited-client");
+	});
+
+	it("keeps the start-time client id and authority when settings change before callback", async () => {
+		const request = (await spyRequestUrl()).mockResolvedValue(
+			mockRes({ access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }),
+		);
+		vi.stubGlobal("window", { open: vi.fn(), location: { href: "" } });
+		const auth = new OneDriveCustomAuthProvider(createMockSecretStore());
+		const started = await auth.startAuth({ customClientId: "started-client", customAuthority: "common" });
+
+		await auth.completeAuth(
+			`obsidian://air-sync-auth?code=code&state=${String(started.pendingAuthState)}`,
+			{ ...started, customClientId: "edited-client", customAuthority: "organizations" },
+		);
+
+		const exchange = request.mock.calls[0]![0] as { url: string; body?: string };
+		expect(exchange.url).toContain("/common/");
+		expect(new URLSearchParams(exchange.body).get("client_id")).toBe("started-client");
+	});
+
+	it("rejects a missing attempt identity before token exchange", async () => {
+		const request = await spyRequestUrl();
+		const auth = new OneDriveCustomAuthProvider(createMockSecretStore());
+		await expect(auth.completeAuth(callback, pending)).rejects.toThrow(/attempt identity/i);
+		expect(request).not.toHaveBeenCalled();
+	});
+});

--- a/src/fs/onedrive/auth.test.ts
+++ b/src/fs/onedrive/auth.test.ts
@@ -17,6 +17,11 @@ async function makeProvider(secrets: Record<string, string> = {}) {
 }
 
 const TOKEN_URL = "https://login.microsoftonline.com/consumers/oauth2/v2.0/token";
+const ATTEMPT_IDENTITY = {
+	backendType: "onedrive",
+	clientId: "test-client-id",
+	authority: "consumers",
+};
 
 describe("OneDriveAuthProvider.isAuthenticated", () => {
 	it("is true only when a refresh secret is stored", async () => {
@@ -47,6 +52,7 @@ describe("OneDriveAuthProvider.startAuth", () => {
 
 		expect((out.pendingCodeVerifier as string).length).toBe(64);
 		expect(url.searchParams.get("state")).toBe(out.pendingAuthState);
+		expect(out.pendingAuthIdentity).toEqual(ATTEMPT_IDENTITY);
 	});
 
 	it("derives a code_challenge that is the base64url SHA-256 of the verifier", async () => {
@@ -73,6 +79,7 @@ describe("OneDriveAuthProvider.completeAuth", () => {
 		const out = await auth.completeAuth("obsidian://air-sync-auth?code=THECODE&state=abc", {
 			pendingAuthState: "abc",
 			pendingCodeVerifier: "verifier-xyz",
+			pendingAuthIdentity: ATTEMPT_IDENTITY,
 		});
 
 		const opts = spy.mock.calls[0]![0] as RequestUrlParam;
@@ -119,6 +126,7 @@ describe("OneDriveAuthProvider.completeAuth", () => {
 			auth.completeAuth("obsidian://air-sync-auth?code=THECODE&state=abc", {
 				pendingAuthState: "abc",
 				pendingCodeVerifier: "verifier-xyz",
+				pendingAuthIdentity: ATTEMPT_IDENTITY,
 			}),
 		).rejects.toThrow(/Invalid Microsoft token response/);
 	});

--- a/src/fs/onedrive/auth.ts
+++ b/src/fs/onedrive/auth.ts
@@ -105,7 +105,7 @@ export class OneDriveAuth extends BaseOAuthTokenManager {
 			throw new Error(`Token exchange failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertMicrosoftTokenResponse(res.json);
-		this.storeTokenResponse(res.json);
+		await this.storeTokenResponse(res.json);
 	}
 
 	protected async performRefresh(): Promise<string> {
@@ -138,7 +138,7 @@ export class OneDriveAuth extends BaseOAuthTokenManager {
 			throw new Error(`Token refresh failed: ${res.status} ${extractTokenErrorDetail(res)}`);
 		}
 		assertMicrosoftTokenResponse(res.json);
-		this.storeTokenResponse(res.json);
+		await this.storeTokenResponse(res.json);
 		return this.accessToken;
 	}
 }
@@ -159,6 +159,14 @@ export class OneDriveAuthProvider extends PkceAuthProvider<OneDriveAuth> {
 
 	protected createAuth(clientId: string, _backendData: Record<string, unknown>, logger?: Logger): OneDriveAuth {
 		return new OneDriveAuth(clientId, DEFAULT_ONEDRIVE_AUTHORITY, logger);
+	}
+
+	protected resolveAttemptAuthority(_backendData: Record<string, unknown>): string | undefined {
+		return DEFAULT_ONEDRIVE_AUTHORITY;
+	}
+
+	protected requiresAttemptAuthority(): boolean {
+		return true;
 	}
 
 	protected buildAuthorizeUrl(

--- a/src/fs/onedrive/provider-base.ts
+++ b/src/fs/onedrive/provider-base.ts
@@ -37,6 +37,7 @@ export const DEFAULT_ONEDRIVE_DATA: OneDriveBackendData = {
 	accessTokenExpiry: 0,
 	pendingCodeVerifier: "",
 	pendingAuthState: "",
+	pendingAuthIdentity: null,
 	pendingPickedFolderPath: "",
 };
 

--- a/src/fs/onedrive/provider-custom.test.ts
+++ b/src/fs/onedrive/provider-custom.test.ts
@@ -94,6 +94,11 @@ describe("OneDriveCustomAuthProvider.completeAuth", () => {
 			customAuthority: "organizations",
 			pendingAuthState: "abc",
 			pendingCodeVerifier: "verifier-xyz",
+			pendingAuthIdentity: {
+				backendType: "onedrive-custom",
+				clientId: "user-cid",
+				authority: "organizations",
+			},
 		});
 
 		const opts = spy.mock.calls[0]![0] as RequestUrlParam;

--- a/src/fs/onedrive/provider-custom.ts
+++ b/src/fs/onedrive/provider-custom.ts
@@ -29,6 +29,7 @@ const DEFAULT_ONEDRIVE_CUSTOM_DATA: OneDriveCustomData = {
 	accessTokenExpiry: 0,
 	pendingCodeVerifier: "",
 	pendingAuthState: "",
+	pendingAuthIdentity: null,
 	pendingPickedFolderPath: "",
 	customClientId: "",
 	customAuthority: DEFAULT_ONEDRIVE_AUTHORITY,
@@ -66,6 +67,14 @@ export class OneDriveCustomAuthProvider extends PkceAuthProvider<OneDriveAuth> {
 
 	protected resolveClientId(backendData: Record<string, unknown>): string {
 		return (backendData.customClientId as string | undefined) ?? "";
+	}
+
+	protected resolveAttemptAuthority(backendData: Record<string, unknown>): string | undefined {
+		return resolveAuthority(backendData);
+	}
+
+	protected requiresAttemptAuthority(): boolean {
+		return true;
 	}
 
 	protected hasCredentials(backendData: Record<string, unknown>): boolean {

--- a/src/fs/pkce-app-folder-provider.ts
+++ b/src/fs/pkce-app-folder-provider.ts
@@ -9,7 +9,7 @@ import type { Logger } from "../logging/logger";
 import type { RemoteVaultResolution } from "./remote-vault-contract";
 import { METADATA_CACHE_VERSION, MetadataStore } from "../store/metadata-store";
 import { getBackendSecret, setBackendSecret, hasBackendSecret, clearBackendSecrets } from "./token-store";
-import type { PkceAuthProvider, PkceTokenManager } from "./pkce-auth-provider";
+import type { PendingPkceAuthIdentity, PkceAuthProvider, PkceTokenManager } from "./pkce-auth-provider";
 
 /**
  * The `backendData` shape every in-plugin PKCE App-Folder backend stores: the bound
@@ -21,6 +21,7 @@ export interface PkceAppFolderData {
 	accessTokenExpiry: number;
 	pendingCodeVerifier: string;
 	pendingAuthState: string;
+	pendingAuthIdentity: PendingPkceAuthIdentity | null;
 	pendingPickedFolderPath: string;
 }
 
@@ -145,13 +146,11 @@ export abstract class PkceAppFolderProvider<
 	readBackendState(): Record<string, unknown> {
 		const result: Record<string, unknown> = {};
 		// The delta cursor commits atomically with the file map in the metadata store
-		// (ADR 0001). Here we only persist refreshed tokens (access may have rotated) and
-		// the non-secret expiry; the tokens go to SecretStorage. Saved every cycle, clean
-		// or not: a refresh that already succeeded should not be discarded if a later file
-		// op failed.
+		// (ADR 0001). Required refresh publication already completed at token acquisition;
+		// this late snapshot retains only the optional access-token cache and non-secret
+		// expiry.
 		const tokens = this.auth.getTokenState();
 		if (tokens && (tokens.refreshToken || tokens.accessToken)) {
-			setBackendSecret(this.secretStore, this.type, "refresh", tokens.refreshToken);
 			setBackendSecret(this.secretStore, this.type, "access", tokens.accessToken);
 			result.accessTokenExpiry = tokens.accessTokenExpiry;
 		}

--- a/src/fs/pkce-auth-provider.ts
+++ b/src/fs/pkce-auth-provider.ts
@@ -2,7 +2,7 @@ import { Notice, Platform } from "../platform/obsidian";
 import type { IAuthProvider } from "./auth";
 import type { ISecretStore } from "./secret-store";
 import type { Logger } from "../logging/logger";
-import { setBackendSecret, hasBackendSecret } from "./token-store";
+import { getBackendSecret, hasBackendSecret, publishBackendSecret, setBackendSecret } from "./token-store";
 import {
 	BaseOAuthTokenManager,
 	buildOAuthState,
@@ -17,6 +17,13 @@ export interface PkceTokenManager extends BaseOAuthTokenManager {
 	exchangeCode(code: string, codeVerifier: string, redirectUri?: string): Promise<void>;
 	/** Revoke the active token, if the provider supports it (Microsoft does not). */
 	revokeToken?(): Promise<void>;
+}
+
+/** Nonsecret identity bound to one pending PKCE authorization attempt. */
+export interface PendingPkceAuthIdentity {
+	backendType: string;
+	clientId: string;
+	authority?: string;
 }
 
 /**
@@ -69,10 +76,64 @@ export abstract class PkceAuthProvider<TAuth extends PkceTokenManager> implement
 	/** Notify the user on the start path when credentials are missing (custom variants override). */
 	protected onMissingCredentials(): void {}
 
+	/** Optional provider identity segment (OneDrive custom authority). */
+	protected resolveAttemptAuthority(_backendData: Record<string, unknown>): string | undefined {
+		return undefined;
+	}
+
+	/** Whether this provider requires a nonempty authority in the pending snapshot. */
+	protected requiresAttemptAuthority(): boolean {
+		return false;
+	}
+
+	private createAttemptIdentity(backendData: Record<string, unknown>): PendingPkceAuthIdentity {
+		const authority = this.resolveAttemptAuthority(backendData);
+		return {
+			backendType: this.backendType,
+			clientId: this.resolveClientId(backendData),
+			...(authority === undefined ? {} : { authority }),
+		};
+	}
+
+	private readAttemptIdentity(value: unknown): PendingPkceAuthIdentity {
+		if (!value || typeof value !== "object" || Array.isArray(value)) {
+			throw new Error("OAuth attempt identity is missing. Please restart the authorization flow.");
+		}
+		const identity = value as Record<string, unknown>;
+		if (
+			identity.backendType !== this.backendType ||
+			typeof identity.clientId !== "string" ||
+			!identity.clientId ||
+			(this.clientId !== "" && identity.clientId !== this.clientId) ||
+			(this.requiresAttemptAuthority() && (typeof identity.authority !== "string" || !identity.authority)) ||
+			(identity.authority !== undefined && typeof identity.authority !== "string")
+		) {
+			throw new Error("OAuth attempt identity is invalid. Please restart the authorization flow.");
+		}
+		return {
+			backendType: identity.backendType,
+			clientId: identity.clientId,
+			...(typeof identity.authority === "string" ? { authority: identity.authority } : {}),
+		};
+	}
+
+	private applyAttemptIdentity(
+		backendData: Record<string, unknown>,
+		identity: PendingPkceAuthIdentity,
+	): Record<string, unknown> {
+		return {
+			...backendData,
+			customClientId: identity.clientId,
+			...(identity.authority === undefined ? {} : { customAuthority: identity.authority }),
+		};
+	}
+
 	/** Get or lazily create the shared token manager (so refreshed tokens are persistable). */
 	getOrCreateAuth(backendData: Record<string, unknown>, logger?: Logger): TAuth {
 		if (!this.tokenAuth) {
-			this.tokenAuth = this.createAuth(this.resolveClientId(backendData), backendData, logger ?? this.logger);
+			this.tokenAuth = this.wireRefreshPersistence(
+				this.createAuth(this.resolveClientId(backendData), backendData, logger ?? this.logger),
+			);
 		}
 		return this.tokenAuth;
 	}
@@ -85,8 +146,15 @@ export abstract class PkceAuthProvider<TAuth extends PkceTokenManager> implement
 	 * would be discarded with this instance, leaving the stored token stale.
 	 */
 	createDetachedAuth(backendData: Record<string, unknown>, logger?: Logger): TAuth {
-		const auth = this.createAuth(this.resolveClientId(backendData), backendData, logger ?? this.logger);
-		auth.setRefreshTokenRotatedHook((rt) => setBackendSecret(this.secretStore, this.backendType, "refresh", rt));
+		return this.wireRefreshPersistence(
+			this.createAuth(this.resolveClientId(backendData), backendData, logger ?? this.logger),
+		);
+	}
+
+	private wireRefreshPersistence(auth: TAuth): TAuth {
+		auth.setRefreshTokenRotatedHook((refreshToken) => {
+			publishBackendSecret(this.secretStore, this.backendType, "refresh", refreshToken);
+		});
 		return auth;
 	}
 
@@ -109,19 +177,22 @@ export abstract class PkceAuthProvider<TAuth extends PkceTokenManager> implement
 			this.onMissingCredentials();
 			return {};
 		}
+		const identity = this.createAttemptIdentity(backendData);
+		const attemptData = this.applyAttemptIdentity(backendData, identity);
 		const codeVerifier = generateRandomString(64);
 		const codeChallenge = await computeS256Challenge(codeVerifier);
 		// base64url state (URL-transit safe); it returns through the
 		// obsidian://air-sync-auth deep link and is validated in completeAuth.
 		const state = buildOAuthState();
-		const url = this.buildAuthorizeUrl({ clientId: this.resolveClientId(backendData), codeChallenge, state }, backendData);
+		this.tokenAuth = null;
+		const url = this.buildAuthorizeUrl({ clientId: identity.clientId, codeChallenge, state }, attemptData);
 		if (Platform.isMobile) {
 			window.location.href = url;
 		} else {
 			window.open(url);
 		}
 		new Notice("Complete authorization in your browser");
-		return { pendingAuthState: state, pendingCodeVerifier: codeVerifier };
+		return { pendingAuthState: state, pendingCodeVerifier: codeVerifier, pendingAuthIdentity: identity };
 	}
 
 	async completeAuth(input: string, backendData: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -134,13 +205,27 @@ export abstract class PkceAuthProvider<TAuth extends PkceTokenManager> implement
 		if (typeof codeVerifier !== "string" || !codeVerifier) {
 			throw new Error("PKCE code verifier is missing. Please restart the authorization flow.");
 		}
+		const identity = this.readAttemptIdentity(backendData.pendingAuthIdentity);
+		const attemptData = this.applyAttemptIdentity(backendData, identity);
 
-		const auth = this.getOrCreateAuth(backendData);
+		const auth = this.wireRefreshPersistence(
+			this.createAuth(identity.clientId, attemptData, this.logger),
+		);
 		await auth.exchangeCode(params.code, codeVerifier);
 		const tokens = auth.getTokenState();
-		setBackendSecret(this.secretStore, this.backendType, "refresh", tokens.refreshToken);
+		const requiredRefresh = tokens.refreshToken || getBackendSecret(this.secretStore, this.backendType, "refresh");
+		publishBackendSecret(this.secretStore, this.backendType, "refresh", requiredRefresh);
 		setBackendSecret(this.secretStore, this.backendType, "access", tokens.accessToken);
+		if (!tokens.refreshToken) {
+			auth.setTokens(requiredRefresh, tokens.accessToken, tokens.accessTokenExpiry);
+		}
+		this.tokenAuth = auth;
 
-		return { accessTokenExpiry: tokens.accessTokenExpiry, pendingAuthState: "", pendingCodeVerifier: "" };
+		return {
+			accessTokenExpiry: tokens.accessTokenExpiry,
+			pendingAuthState: "",
+			pendingCodeVerifier: "",
+			pendingAuthIdentity: null,
+		};
 	}
 }

--- a/src/fs/token-store.test.ts
+++ b/src/fs/token-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { createMockSecretStore } from "./googledrive/test-helpers.test";
 import {
 	setBackendSecret,
+	publishBackendSecret,
 	getBackendSecret,
 	hasBackendSecret,
 	clearBackendSecrets,
@@ -46,5 +47,31 @@ describe("backend secret store", () => {
 		const store = createMockSecretStore({ "air-sync-googledrive-refresh-token": "legacy" });
 		expect(getBackendSecret(store, "googledrive", "refresh")).toBe("legacy");
 		expect(hasBackendSecret(store, "googledrive", "refresh")).toBe(true);
+	});
+
+	it("publishes a required secret only after exact immediate readback", () => {
+		const store = createMockSecretStore();
+		publishBackendSecret(store, "dropbox", "refresh", "candidate");
+		expect(getBackendSecret(store, "dropbox", "refresh")).toBe("candidate");
+	});
+
+	it.each(["", "stale"])("fails when required publication reads back %j", (readback) => {
+		const store = createMockSecretStore();
+		store.getSecret = () => readback || null;
+		expect(() => publishBackendSecret(store, "dropbox", "refresh", "candidate"))
+			.toThrow("Secret credential could not be saved securely");
+	});
+
+	it("fails with bounded text when SecretStorage throws", () => {
+		const store = createMockSecretStore();
+		store.setSecret = () => { throw new Error("secret sentinel"); };
+		expect(() => publishBackendSecret(store, "dropbox", "refresh", "candidate"))
+			.toThrow("Secret credential could not be saved securely. Please try connecting again.");
+	});
+
+	it("rejects an empty required candidate", () => {
+		const store = createMockSecretStore();
+		expect(() => publishBackendSecret(store, "dropbox", "refresh", ""))
+			.toThrow("Required refresh token is missing");
 	});
 });

--- a/src/fs/token-store.ts
+++ b/src/fs/token-store.ts
@@ -23,6 +23,33 @@ export function setBackendSecret(store: ISecretStore, backendType: string, name:
 	}
 }
 
+/**
+ * Publish a required non-empty backend secret and prove the synchronous
+ * SecretStorage postcondition before the caller exposes dependent state.
+ *
+ * Obsidian's API is synchronous but does not promise OS-level flush semantics.
+ * This check therefore proves only the boundary the API exposes: immediate,
+ * exact readback of the candidate under the stable backend key.
+ */
+export function publishBackendSecret(
+	store: ISecretStore,
+	backendType: string,
+	name: string,
+	candidate: string,
+): void {
+	if (!candidate) {
+		throw new Error("Required refresh token is missing");
+	}
+	try {
+		store.setSecret(secretKey(backendType, name), candidate);
+		if (store.getSecret(secretKey(backendType, name)) !== candidate) {
+			throw new Error("readback mismatch");
+		}
+	} catch {
+		throw new Error("Secret credential could not be saved securely. Please try connecting again.");
+	}
+}
+
 /** Read an opaque backend secret, or `""` if absent. */
 export function getBackendSecret(store: ISecretStore, backendType: string, name: string): string {
 	return store.getSecret(secretKey(backendType, name)) ?? "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,16 +14,7 @@ import { ScreenWakeLockManager } from "./sync/wake-lock";
 import { LocalChangeTracker } from "./sync/local-tracker";
 import { Logger, getDeviceName } from "./logging/logger";
 import { ConflictHistory } from "./sync/conflict-history";
-
-function protocolParamsEntries(params: unknown): Array<[string, string]> {
-	if (!params || typeof params !== "object") return [];
-	const entries: Array<[string, string]> = [];
-	for (const key of Object.keys(params)) {
-		const value = (params as Record<string, unknown>)[key];
-		if (typeof value === "string") entries.push([key, value]);
-	}
-	return entries;
-}
+import { handleOAuthProtocolCallback } from "./fs/oauth-callback-error";
 
 export default class AirSyncPlugin extends Plugin {
 	settings!: AirSyncSettings;
@@ -159,20 +150,14 @@ export default class AirSyncPlugin extends Plugin {
 		// OAuth callback via obsidian://air-sync-auth?access_token=...&state=... or ?code=...&state=...
 		// Google's top-level Picker also returns picked_file_ids on this callback.
 		this.registerObsidianProtocolHandler("air-sync-auth", (params) => {
-			if (!params.access_token && !params.code) {
-				new Notice("Authorization failed: no token or code received");
-				return;
-			}
-			// Synthetic URL to pass tokens/code to completeAuth(), which parses callback URL params
-			const url = new URL("https://callback");
-			for (const [key, value] of protocolParamsEntries(params)) {
-				url.searchParams.set(key, value);
-			}
-			if (params.picked_file_ids) {
-				void this.backendManager.completeBackendAuthFolderPick(url.toString(), params);
-			} else {
-				void this.backendManager.completeBackendConnect(url.toString());
-			}
+			const pendingState = this.settings.backendData.pendingAuthState;
+			handleOAuthProtocolCallback(params, pendingState, {
+				notify: (message) => { new Notice(message); },
+				completeConnect: (url) => { void this.backendManager.completeBackendConnect(url); },
+				completeFolderPick: (url, callbackParams) => {
+					void this.backendManager.completeBackendAuthFolderPick(url, callbackParams);
+				},
+			});
 		});
 
 		// Web folder-picker result via obsidian://air-sync-folder. Backend-agnostic:


### PR DESCRIPTION
## Summary

- make OAuth completion succeed only after refresh-token publication is immediately readable from Obsidian SecretStorage
- persist refresh-token rotation before exposing refreshed credentials to Google Drive, Dropbox, and OneDrive callers
- keep custom-provider callback exchanges bound to the identity snapshot that initiated authentication
- reject malformed callbacks and preserve OAuth denial errors without dispatching invalid state
- add cross-provider completion audits, regression tests, architecture notes, and native restart verification guidance

## Verification

- `npm run lint`
- `npm run lint:bot-repro`
- `npm run build`
- `npm run test:coverage` (94 files, 1923 tests)
- `npm run test:e2e` (Google Drive, Dropbox, and OneDrive: 163/163 live tests)
- `git diff --check`

OS-level durability after a full Obsidian or device restart remains a manual native verification because SecretStorage exposes no flush/durability acknowledgement beyond synchronous readback.

Fixes #52
